### PR TITLE
derive mtu from docker0

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -199,8 +199,13 @@ func (c *CLab) initMgmtNetwork() error {
 	}
 	// init docker network mtu
 	if c.Config.Mgmt.MTU == "" {
-		c.Config.Mgmt.MTU = dockerNetMTU
+		m, err := getDefaultDockerMTU()
+		if err != nil {
+			log.Warnf("Error occurred during getting the default docker MTU: %v", err)
+		}
+		c.Config.Mgmt.MTU = m
 	}
+
 	return nil
 }
 

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -36,7 +36,8 @@ func (c *CLab) CreateDockerNet(ctx context.Context) (err error) {
 	switch {
 	case client.IsErrNetworkNotFound(err):
 		log.Debugf("Network '%s' does not exist", c.Config.Mgmt.Network)
-		log.Infof("Creating docker network: Name='%s', IPv4Subnet='%s', IPv6Subnet='%s'", c.Config.Mgmt.Network, c.Config.Mgmt.IPv4Subnet, c.Config.Mgmt.IPv6Subnet)
+		log.Infof("Creating docker network: Name='%s', IPv4Subnet='%s', IPv6Subnet='%s', MTU='%s'",
+			c.Config.Mgmt.Network, c.Config.Mgmt.IPv4Subnet, c.Config.Mgmt.IPv6Subnet, c.Config.Mgmt.MTU)
 
 		enableIPv6 := false
 		var ipamConfig []network.IPAMConfig
@@ -403,4 +404,14 @@ func linkContainerNS(nspath string, containerName string) error {
 // setSysctl writes sysctl data by writing to a specific file
 func setSysctl(sysctl string, newVal int) error {
 	return ioutil.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
+}
+
+// getDefaultDockerMTU gets the MTU of a docker0 bridge interface
+// if fails to get the MTU of docker0, returns "1500"
+func getDefaultDockerMTU() (string, error) {
+	b, err := bridgeByName("docker0")
+	if err != nil {
+		return "1500", err
+	}
+	return fmt.Sprint(b.MTU), nil
 }

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -52,7 +52,7 @@ The addressing information that containerlab will use on this network:
 * IPv4: subnet 172.20.20.0/24, gateway 172.20.20.1
 * IPv6: subnet 2001:172:20:20::/80, gateway 2001:172:20:20::1
 
-This management network will be configured with `1500` MTU. This option is configurable.
+This management network will be configured with MTU value matching the value of a `docker0` host interface to match docker configuration on the system. This option is [configurable](#mtu).
 
 With these defaults in place, the two containers from this lab will get connected to that management network and will be able to communicate using the IP addresses allocated by docker daemon. The addresses that docker carves out for each container are presented to a user once the lab deployment finishes or can be queried any time after:
 
@@ -147,7 +147,7 @@ Users can specify either IPv4 or IPv6 or both addresses, if one of the addresses
     2. IPv4/6 addresses set on a node level must be from the management network range.
 
 #### MTU
-The MTU of the management network can be set to user defined value:
+The MTU of the management network defaults to an MTU value of `docker0` interface, but it can be set to a user defined value:
 
 ```yaml
 mgmt:


### PR DESCRIPTION
make clab network to inherit the mtu from the docker0 interface when creating the network.