### PR TITLE
fix cases with dash in lab names

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -438,6 +438,7 @@ func (c *CLab) publishInit(nodeCfg *NodeConfig, kind string) []string {
 func (c *CLab) labelsInit(nodeCfg *NodeConfig, kind string, node *Node) map[string]string {
 	defaultLabels := map[string]string{
 		"containerlab":      c.Config.Name,
+		"clab-node-name":    node.ShortName,
 		"clab-node-kind":    kind,
 		"clab-node-type":    node.NodeType,
 		"clab-node-group":   node.Group,

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -307,6 +307,7 @@ func TestLablesInit(t *testing.T) {
 			node: "node1",
 			want: map[string]string{
 				"containerlab":      "topo1",
+				"clab-node-name":    "node1",
 				"clab-node-kind":    "srl",
 				"clab-node-type":    "ixr6",
 				"clab-node-group":   "",
@@ -319,6 +320,7 @@ func TestLablesInit(t *testing.T) {
 			node: "node2",
 			want: map[string]string{
 				"containerlab":      "topo1",
+				"clab-node-name":    "node2",
 				"clab-node-kind":    "srl",
 				"clab-node-type":    "ixr6",
 				"clab-node-group":   "",
@@ -332,6 +334,7 @@ func TestLablesInit(t *testing.T) {
 			node: "node1",
 			want: map[string]string{
 				"containerlab":      "topo2",
+				"clab-node-name":    "node1",
 				"clab-node-kind":    "srl",
 				"clab-node-type":    "ixrd2",
 				"clab-node-group":   "",
@@ -345,6 +348,7 @@ func TestLablesInit(t *testing.T) {
 			node: "node2",
 			want: map[string]string{
 				"containerlab":      "topo3",
+				"clab-node-name":    "node2",
 				"clab-node-kind":    "srl",
 				"clab-node-type":    "ixrd2",
 				"clab-node-group":   "",

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -253,7 +253,7 @@ func hostsEntries(containers []types.Container, bridgeName string) []byte {
 
 func enrichNodes(containers []types.Container, nodes map[string]*clab.Node, mgmtNet string) {
 	for _, c := range containers {
-		name = strings.Split(c.Names[0], "-")[2]
+		name = c.Labels["clab-node-name"]
 		if node, ok := nodes[name]; ok {
 			// add network information
 			// skipping host networking nodes as they don't have separate addresses


### PR DESCRIPTION
as reported in #358 there was an issue with lab' name that contain `-`.

This PR adds a node name to container labels, so that any code that relied on parsing out the node name out of container' full name (`clab-$lab-$node`) will be able to just get the right label