### PR TITLE
Update ceos.cfg.tpl

### DIFF
--- a/templates/arista/ceos.cfg.tpl
+++ b/templates/arista/ceos.cfg.tpl
@@ -1,6 +1,8 @@
 hostname {{ .ShortName }}
 username admin privilege 15 secret admin
 !
+service routing protocols model multi-agent
+!
 interface Management0
 {{ if .MgmtIPv4Address }}ip address {{ .MgmtIPv4Address }}/{{.MgmtIPv4PrefixLength}}{{end}}
 {{ if .MgmtIPv6Address }}ipv6 address {{ .MgmtIPv6Address }}/{{.MgmtIPv6PrefixLength}}{{end}}


### PR DESCRIPTION
cEOS-Lab requires Multimode Agent running for BGP instead of default RibD
Switching agents requires reboot
Hence requesting this be default as most of the work we do on cEOS-lab will be on EVPN/VxLAN
```
leaf1#conf
leaf1(config)#service routing protocols model ?
  multi-agent  Configure protocols model as multi-agent
  ribd         Configure protocols model as ribd (single agent)

leaf1(config)#service routing protocols model multi-agent
! Change will take effect only after switch reboot
leaf1(config)#
```

https://eos.arista.com/evpn-configuration-layer-2-evpn-design-with-type-2-routes/