### PR TITLE
gitlab-ci tests via private runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,5 +28,5 @@ smoke-tests:
   tags:
     - containerlab
   script:
-    - source venvs/rf/bin/activate
+    - source ~/venvs/rf/bin/activate
     - bash ./tests/rf-run.sh ./tests/01-smoke

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,9 @@ stages:
   - build
   - integration-tests
 
+variables:
+  CGO_ENABLED: 0
+
 go-tests:
   stage: code-tests
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,3 +30,21 @@ smoke-tests:
   script:
     - source ~/venvs/rf/bin/activate
     - bash ./tests/rf-run.sh ./tests/01-smoke
+  artifacts:
+    when: always
+    paths:
+      - "./tests/out/*.html"
+
+srl-tests:
+  stage: integration-tests
+  needs:
+    - smoke-tests
+  tags:
+    - containerlab
+  script:
+    - source ~/venvs/rf/bin/activate
+    - bash ./tests/rf-run.sh ./tests/02-basic-srl
+  artifacts:
+    when: always
+    paths:
+      - "./tests/out/*.html"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,10 +8,6 @@ stages:
 variables:
   CGO_ENABLED: 0
 
-before_script:
-  # clean up state from previous builds
-  - sudo rm -rf builds/*/0/rdodin/containerlab
-
 go-tests:
   stage: code-tests
   tags:
@@ -44,8 +40,6 @@ srl-tests:
   stage: integration-tests
   tags:
     - containerlab
-  before_script:
-    - sudo rm -rf builds/*/0/rdodin/containerlab
   script:
     - source ~/venvs/rf/bin/activate
     - bash ./tests/rf-run.sh ./tests/02-basic-srl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,8 @@ go-tests:
   tags:
     - containerlab
   script:
+    # create empty files to make clab happy
+    - sudo mkdir -p /etc/containerlab/templates/srl && sudo touch /etc/containerlab/templates/srl/srlconfig.tpl
     - CGO_ENABLED=1 go test -cover -race ./...
 
 build-containerlab:
@@ -19,4 +21,12 @@ build-containerlab:
   tags:
     - containerlab
   script:
-    - go build
+    - sudo go build -o /usr/bin/containerlab
+
+smoke-tests:
+  stage: integration-tests
+  tags:
+    - containerlab
+  script:
+    - source venvs/rf/bin/activate
+    - bash ./tests/rf-run.sh ./tests/01-smoke

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,8 @@ srl-tests:
   stage: integration-tests
   tags:
     - containerlab
+  before_script:
+    - sudo rm -rf builds/*/0/rdodin/containerlab
   script:
     - source ~/venvs/rf/bin/activate
     - bash ./tests/rf-run.sh ./tests/02-basic-srl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,3 +10,10 @@ go-tests:
     - containerlab
   script:
     - go test -cover -race ./...
+
+build-containerlab:
+  stage: build
+  tags:
+    - containerlab
+  script:
+    - go build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,5 +6,7 @@ stages:
 
 go-tests:
   stage: code-tests
+  tags:
+    - containerlab
   script:
     - go test -cover -race ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,10 @@ stages:
 variables:
   CGO_ENABLED: 0
 
+before_script:
+  # clean up state from previous builds
+  - sudo rm -rf builds/*/0/rdodin/containerlab
+
 go-tests:
   stage: code-tests
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 stages:
   - code-tests
   - build
+  - smoke-tests
   - integration-tests
 
 variables:
@@ -24,7 +25,7 @@ build-containerlab:
     - sudo go build -o /usr/bin/containerlab
 
 smoke-tests:
-  stage: integration-tests
+  stage: smoke-tests
   tags:
     - containerlab
   script:
@@ -37,8 +38,6 @@ smoke-tests:
 
 srl-tests:
   stage: integration-tests
-  needs:
-    - smoke-tests
   tags:
     - containerlab
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+---
+stages:
+  - code-tests
+  - build
+  - integration-tests
+
+go-tests:
+  stage: code-tests
+  script:
+    - go test -cover -race ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,10 @@
 ---
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      when: never # Prevent pipeline run for push event
+    - when: always # Run pipeline for all other cases
+
 stages:
   - code-tests
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ go-tests:
   tags:
     - containerlab
   script:
-    - go test -cover -race ./...
+    - CGO_ENABLED=1 go test -cover -race ./...
 
 build-containerlab:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ workflow:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
       when: never # Prevent pipeline run for push event
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event"'
+      when: never # Prevent pipeline run for PRs from github mirror
     - when: always # Run pipeline for all other cases
 
 stages:

--- a/clab/cert.go
+++ b/clab/cert.go
@@ -55,6 +55,46 @@ type CaRootInput struct {
 	NamePrefix string
 }
 
+var rootCACSRTempl string = `{
+    "CN": "{{.Prefix}} Root CA",
+    "key": {
+       "algo": "rsa",
+       "size": 2048
+    },
+    "names": [{
+       "C": "BE",
+       "L": "Antwerp",
+       "O": "Nokia",
+       "OU": "Container lab"
+    }],
+    "ca": {
+       "expiry": "262800h"
+    }
+}
+`
+
+var nodeCSRTempl string = `{
+    "CN": "{{.Name}}.{{.Prefix}}.io",
+    "key": {
+      "algo": "rsa",
+      "size": 2048
+    },
+    "names": [{
+      "C": "BE",
+      "L": "Antwerp",
+      "O": "Nokia",
+      "OU": "Container lab"
+    }],
+    "hosts": [
+      "{{.Name}}",
+      "{{.LongName}}",
+      "{{.Fqdn}}"
+    ]
+}
+
+
+`
+
 // GenerateRootCa function
 func (c *CLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInput) (*Certificates, error) {
 	log.Info("Creating root CA")
@@ -227,9 +267,9 @@ func (c *CLab) CreateRootCA() error {
 		return nil
 	}
 
-	tpl, err := template.ParseFiles(rootCaCsrTemplate)
+	tpl, err := template.New("ca-csr").Parse(rootCACSRTempl)
 	if err != nil {
-		return fmt.Errorf("failed to parse rootCACsrTemplate: %v", err)
+		return fmt.Errorf("failed to parse Root CA CSR Template: %v", err)
 	}
 	rootCerts, err := c.GenerateRootCa(tpl, CaRootInput{
 		Prefix:     c.Config.Name,

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -15,13 +15,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	rootCaCsrTemplate = "/etc/containerlab/templates/ca/csr-root-ca.json"
-	certCsrTemplate   = "/etc/containerlab/templates/ca/csr.json"
-)
-
-// var debug bool
-
 type CLab struct {
 	Config       *Config
 	TopoFile     *TopoFile
@@ -200,9 +193,9 @@ func (c *CLab) CreateNodes(ctx context.Context, workers uint) {
 						// if not available on disk, create cert in next step
 						if err != nil {
 							// create CERT
-							certTpl, err = template.ParseFiles(certCsrTemplate)
+							certTpl, err = template.New("node-cert").Parse(nodeCSRTempl)
 							if err != nil {
-								log.Errorf("failed to parse certCsrTemplate: %v", err)
+								log.Errorf("failed to parse Node CSR Template: %v", err)
 							}
 							certInput := CertInput{
 								Name:     node.ShortName,

--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -15,6 +15,10 @@ func (c *CLab) GenerateInventories() error {
 	if err != nil {
 		return err
 	}
+	err = os.Chmod(ansibleInvFPath, 0777)
+	if err != nil {
+		return err
+	}
 	if err := c.generateAnsibleInventory(f); err != nil {
 		return err
 	}

--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -15,10 +15,6 @@ func (c *CLab) GenerateInventories() error {
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(ansibleInvFPath, 0777)
-	if err != nil {
-		return err
-	}
 	if err := c.generateAnsibleInventory(f); err != nil {
 		return err
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -171,6 +171,15 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 	if err != nil {
 		return fmt.Errorf("could not list containers: %v", err)
 	}
+	if len(containers) == 0 {
+		return nil
+	}
+
+	// get lab directory used by this lab to remove it later if cleanup is used
+	var labDir string
+	if cleanup {
+		labDir = filepath.Dir(containers[0].Labels["clab-node-lab-dir"])
+	}
 
 	log.Infof("Destroying container lab: %s", c.Config.Name)
 	wg := new(sync.WaitGroup)
@@ -192,7 +201,7 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 
 	// remove the lab directories
 	if cleanup {
-		err = os.RemoveAll(c.Dir.Lab)
+		err = os.RemoveAll(labDir)
 		if err != nil {
 			log.Errorf("error deleting lab directory: %v", err)
 		}

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
+Suite Teardown    Run Keyword    sudo containerlab destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
 
 *** Variables ***
 ${lab-name}       2-linux-nodes

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
-Suite Teardown    Run Keyword    sudo containerlab destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
+Suite Teardown    Run    sudo containerlab destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
 
 *** Variables ***
 ${lab-name}       2-linux-nodes

--- a/tests/01-smoke/02-destroy-all.robot
+++ b/tests/01-smoke/02-destroy-all.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
+Suite Teardown    Run Keyword    sudo containerlab destroy --all
 
 *** Test Cases ***
 Deploy first lab

--- a/tests/01-smoke/02-destroy-all.robot
+++ b/tests/01-smoke/02-destroy-all.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
-Suite Teardown    Run    sudo containerlab destroy --all
+Suite Teardown    Run    sudo containerlab destroy --all --cleanup
 
 *** Test Cases ***
 Deploy first lab

--- a/tests/01-smoke/02-destroy-all.robot
+++ b/tests/01-smoke/02-destroy-all.robot
@@ -17,7 +17,7 @@ Deploy second lab
 
 Destroy all labs
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab destroy --all
+    ...    sudo containerlab destroy --all --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 

--- a/tests/01-smoke/02-destroy-all.robot
+++ b/tests/01-smoke/02-destroy-all.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
-Suite Teardown    Run Keyword    sudo containerlab destroy --all
+Suite Teardown    Run    sudo containerlab destroy --all
 
 *** Test Cases ***
 Deploy first lab

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -9,7 +9,7 @@ ${lab-name}       02-01-two-srls
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab deploy -t ${CURDIR}/02-srl02.clab.yml.yml
+    ...    sudo containerlab deploy -t ${CURDIR}/02-srl02.clab.yml
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
-Suite Teardown    Run Keyword    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
+Suite Teardown    Run    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
 
 *** Variables ***
 ${lab-name}       02-01-two-srls

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library           OperatingSystem
-Suite Teardown    Run    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
+Suite Teardown    Run Keyword    Cleanup
 
 *** Variables ***
 ${lab-name}       02-01-two-srls
@@ -29,3 +29,8 @@ Verify links in node srl2
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
+
+*** Keywords ***
+Cleanup
+    Run    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
+    Run    rm -rf ${CURDIR}/${lab-name}

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Library           OperatingSystem
+Suite Teardown    Run Keyword    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
+
+*** Variables ***
+${lab-name}       02-01-two-srls
+
+*** Test Cases ***
+Deploy ${lab-name} lab
+    Log    ${CURDIR}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab deploy -t ${CURDIR}/02-srl02.clab.yml.yml
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Wait 5 seconds
+    Sleep    5s
+
+Verify links in node srl1
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo docker exec clab-${lab-name}-srl1 ip link show e1-1
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    state UP
+
+Verify links in node srl2
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo docker exec clab-${lab-name}-srl2 ip link show e1-1
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    state UP

--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -1,0 +1,14 @@
+name: 02-01-two-srls
+
+topology:
+  kinds:
+    srl:
+      image: srlinux:21.3.1-410
+  nodes:
+    srl1:
+      kind: srl
+    srl2:
+      kind: srl
+
+  links:
+    - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -4,6 +4,7 @@ topology:
   kinds:
     srl:
       image: srlinux:21.3.1-410
+      license: /home/gitlab-runner/srl-lic.key
   nodes:
     srl1:
       kind: srl

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-robotframework==3.2.2
+robotframework==4.0.1
 robotframework-sshlibrary


### PR DESCRIPTION
this PR adds gitlab ci pipeline configuration that is to be run on internal runner to do extensive testing on various labs and containerlab features.

Pipeline trigger is manual via hellt/containerlab gitlab web ui.

apart from that change, the following was changed to support this testing:

- the dir to remove when `cleanup` flag is provided is now fetched from a container label. Previous way of deducing the labdir was not working correctly when used with sudo
- node CSR and root CA CSR template files were embedded in the code instead of separate files