### PR TITLE
Unique rootns ifaces

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -660,6 +660,9 @@ func (c *CLab) CheckTopologyDefinition(ctx context.Context) error {
 	if err := c.verifyLinks(); err != nil {
 		return err
 	}
+	if err := c.verifyRootNetnsInterfaceUniqueness(); err != nil {
+		return err
+	}
 	if err := c.VerifyContainersUniqueness(ctx); err != nil {
 		return err
 	}
@@ -670,9 +673,6 @@ func (c *CLab) CheckTopologyDefinition(ctx context.Context) error {
 		return err
 	}
 	if err := c.VerifyImages(ctx); err != nil {
-		return err
-	}
-	if err := c.VerifyInterfaceUniqueness(); err != nil {
 		return err
 	}
 	return nil
@@ -793,33 +793,20 @@ func (c *CLab) verifyHostIfaces() error {
 	return nil
 }
 
-func (c *CLab) VerifyInterfaceUniqueness() error {
-	hostInterfaces := make([]string, 0)
-	nodeInterfaces := make(map[string][]string)
-
+// verifyRootNetnsInterfaceUniqueness ensures that interafaces that appear in the root ns (bridge, ovs-bridge and host)
+// are uniquely defined in the topology file
+func (c *CLab) verifyRootNetnsInterfaceUniqueness() error {
+	rootNsIfaces := map[string]struct{}{}
 	for _, l := range c.Links {
 		endpoints := [2]*Endpoint{l.A, l.B}
 		for _, e := range endpoints {
-			// Iterate over the two endpoints of the link
-			if e.Node.Kind == "bridge" {
-				// if the interface is a bridge interface check in the hostInterfaces array
-				for _, x := range hostInterfaces {
-					// if the actual endpoint name is already part of the array throw an error
-					if x == e.EndpointName {
-						return fmt.Errorf("duplicate endpoint detected for %s:%s. This is a bridge endpoint end therefore meant to be unique amongst all bridges", e.Node.ShortName, e.EndpointName)
-					}
+			if e.Node.Kind == "bridge" || e.Node.Kind == "ovs-bridge" || e.Node.Kind == "host" {
+				if _, ok := rootNsIfaces[e.EndpointName]; ok {
+					return fmt.Errorf(`interface %s defined for node %s has already been used in other bridges, ovs-bridges or host interfaces. 
+					Make sure that nodes of these kinds use unique interface names`, e.EndpointName, e.Node.ShortName)
+				} else {
+					rootNsIfaces[e.EndpointName] = struct{}{}
 				}
-				// append to known interfaces for the host node
-				hostInterfaces = append(hostInterfaces, e.EndpointName)
-			} else {
-				// Must be a container interface, so we need to make sure interface names are unique per container
-				for _, x := range nodeInterfaces[e.Node.ShortName] {
-					if x == e.EndpointName {
-						return fmt.Errorf("duplicate endpoint %s detected for node %s", e.EndpointName, e.Node.ShortName)
-					}
-				}
-				// append to known interfaces for the specific node
-				nodeInterfaces[e.Node.ShortName] = append(nodeInterfaces[e.Node.ShortName], e.EndpointName)
 			}
 		}
 	}

--- a/clab/config.go
+++ b/clab/config.go
@@ -608,7 +608,7 @@ func (c *CLab) NewEndpoint(e string) *Endpoint {
 	// split the string to get node name and endpoint name
 	split := strings.Split(e, ":")
 	if len(split) != 2 {
-		log.Fatalf("endpoint %s has wrong syntax", e)
+		log.Fatalf("endpoint %s has wrong syntax", e) // skipcq: GO-S0904
 	}
 	nName := split[0]  // node name
 	epName := split[1] // endpoint name
@@ -641,7 +641,7 @@ func (c *CLab) NewEndpoint(e string) *Endpoint {
 	// stop the deployment if the matching node element was not found
 	// "host" node name is an exception, it may exist without a matching node
 	if endpoint.Node == nil {
-		log.Fatalf("Not all nodes are specified in the 'topology.nodes' section or the names don't match in the 'links.endpoints' section: %s", nName)
+		log.Fatalf("Not all nodes are specified in the 'topology.nodes' section or the names don't match in the 'links.endpoints' section: %s", nName) // skipcq: GO-S0904
 	}
 
 	// initialize the endpoint name based on the split function

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -380,3 +380,22 @@ func TestLablesInit(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyRootNetnsInterfaceUniqueness(t *testing.T) {
+
+	opts := []ClabOption{
+		WithTopoFile("test_data/topo7-dup-rootnetns.yml"),
+	}
+	c := NewContainerLab(opts...)
+
+	if err := c.ParseTopology(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := c.verifyRootNetnsInterfaceUniqueness()
+	if err == nil {
+		t.Fatalf("expected duplicate rootns links error")
+	}
+	t.Logf("error: %v", err)
+
+}

--- a/clab/test_data/topo7-dup-rootnetns.yml
+++ b/clab/test_data/topo7-dup-rootnetns.yml
@@ -1,0 +1,11 @@
+name: topo7
+
+topology:
+  nodes:
+    br1:
+      kind: bridge
+    br2:
+      kind: bridge
+
+  links:
+    - endpoints: ["br1:eth1", "br2:eth1"]


### PR DESCRIPTION
ref #400 

close #387 

Hi @steiler 
I had a look at #400 and I propose we change it as per this PR.

There are two small issues that I noticed in your PR

1. we need to account for all kinds which interfaces appear in root netns: `bridge`, `ovs-bridge` and `host` kinds.
2. we don't need to check for uniqueness of container interfaces, as it has already been checked [here](https://github.com/srl-labs/containerlab/blob/cb400ef37f867e13d0132e5cd83041f147455ef1/clab/config.go#L690)

So I cut out the pieces that I don't think are needed here.
Can you check this PR and see if I missed something imoportant? 