### PR TITLE
added $nodeDir as a variable parameter when binding files or dirs via *.clab.yml

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -480,7 +480,7 @@ func (c *CLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 
 	// initialize bind mounts
 	binds := c.bindsInit(&nodeCfg)
-	err := resolveBindPaths(binds)
+	err := resolveBindPaths(binds, node.LabDir)
 	if err != nil {
 		return err
 	}
@@ -883,14 +883,19 @@ func resolvePath(p string) (string, error) {
 // resolveBindPaths resolves the host paths in a bind string, such as /hostpath:/remotepath(:options) string
 // it allows host path to have `~` and returns absolute path for a relative path
 // if the host path doesn't exist, the error will be returned
-func resolveBindPaths(binds []string) error {
+func resolveBindPaths(binds []string, nodedir string) error {
 	for i := range binds {
 		// host path is a first element in a /hostpath:/remotepath(:options) string
 		elems := strings.Split(binds[i], ":")
-		hp, err := resolvePath(elems[0])
+
+		r := strings.NewReplacer("$nodeDir", nodedir)
+		hp := r.Replace(elems[0])
+
+		hp, err := resolvePath(hp)
 		if err != nil {
 			return err
 		}
+
 		_, err = os.Stat(hp)
 		if err != nil {
 			return fmt.Errorf("failed to verify bind path: %v", err)

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -2,6 +2,7 @@ package clab
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -111,14 +112,18 @@ func TestBindsInitNodeDir(t *testing.T) {
 		want    string
 	}{
 		"node_binds_nodeDir": {
-			bind:    "$nodeDir/nodex/conf:/dst",
-			nodeDir: os.TempDir() + "/clab_test",
-			want:    os.TempDir() + "/clab_test/nodex/conf:/dst",
+			bind:    "$nodeDir/conf:/dst",
+			nodeDir: os.TempDir() + "/clab-nodeDirTest/nodeX",
+			want:    os.TempDir() + "/clab-nodeDirTest/nodeX/conf:/dst",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			defer func() {
+				os.RemoveAll(path.Dir(tc.nodeDir))
+			}()
+
 			// extract host filesystem path
 			bind_part := strings.Split(tc.want, ":")
 			// create folder from filesystem path
@@ -129,7 +134,7 @@ func TestBindsInitNodeDir(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(binds[0], tc.want) {
+			if !cmp.Equal(binds[0], tc.want) {
 				t.Fatalf("wanted %q got %q", tc.want, binds[0])
 			}
 		})

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -78,6 +78,69 @@ binds:
   - /root/files:/root/files:ro
 ```
 
+???info "Bind variables"
+    By default binds are either provided as an absolute, or a relative (to the current working dir) path. Although the majority of cases can be very well covered with this, there are situations in which it is desirable to use a path that is relative to the node-specific example.
+
+    Consider a two-node lab `mylab.clab.yml` that has node-specific files, such as state information or some additional configuration artifacts. A user could create a directory for such files similar to that:
+
+    ```
+    .
+    ├── cfgs
+    │   ├── n1
+    │   │   └── conf
+    │   └── n2
+    │       └── conf
+    └── mylab.clab.yml
+
+    3 directories, 3 files
+    ```
+
+    Then to mount those files to the nodes, the nodes would have been configured with binds like that:
+
+    ```yaml
+    name: mylab
+    topology:
+      nodes:
+        n1:
+          binds:
+            - cfgs/n1/conf:/conf
+        n2:
+          binds:
+            - cfgs/n2/conf:/conf
+    ```
+
+    while this configuration is perfectly fine, it might be considered verbose as the number of nodes grow. To remove this verbosity, the users can leverage a special variable `$nodeDir` in their bind paths. This variable will expand to the node specific directory that containerlab creates for each node.
+
+    What this means is that you can create a directory structure that containerlab will create anyhow and put the needed files over there. With the lab named `mylab` and the nodes named `n1` and `n2` the structure containerlab uses is as follows:
+
+    ```
+    .
+    ├── clab-mylab
+    │   ├── n1
+    │   │   └── conf
+    │   └── n2
+    │       └── conf
+    └── mylab.clab.yml
+
+    3 directories, 3 files
+    ```
+
+    With this structure in place, the clab file can leverage the `$nodeDir` variable:
+
+    ```yaml
+    name: mylab
+    topology:
+      nodes:
+        n1:
+          binds:
+            - $nodeDir/conf:/conf
+        n2:
+          binds:
+            - $nodeDir/conf:/conf
+    ```
+
+    Notice how `$nodeDir` hides the directory structure and node names and removes the verbosity of the previous approach.
+
 ### ports
 To bind the ports between the lab host and the containers the users can populate the `ports` object inside the node:
 


### PR DESCRIPTION
Proposed Implementation for #398.

Are we file with using `node.LabDir` or should this be a different directory, maybe even a sub-directory, anything?

close #398