### PR TITLE
adjust ceos-lab interface type and import topology defined environment variables into container

### DIFF
--- a/clab/ceos.go
+++ b/clab/ceos.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+        "strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -62,7 +63,6 @@ func initCeosNode(c *CLab, nodeCfg NodeConfig, node *Node, user string, envs map
 	node.Position = c.positionInitialization(&nodeCfg, node.Kind)
 
 	// initialize specific container information
-	node.Cmd = "/sbin/init systemd.setenv=INTFTYPE=et systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0"
 
 	// defined env vars for the ceos
 	kindEnv := map[string]string{
@@ -71,10 +71,19 @@ func initCeosNode(c *CLab, nodeCfg NodeConfig, node *Node, user string, envs map
 		"container":                           "docker",
 		"ETBA":                                "4",
 		"SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT": "1",
-		"INTFTYPE":                            "et",
+		"INTFTYPE":                            "eth",
 		"MAPETH0":                             "1",
 		"MGMT_INTF":                           "eth0"}
 	node.Env = mergeStringMaps(kindEnv, envs)
+
+        // the node.Cmd should be aligned with the environment. 
+        var env_sb strings.Builder
+        env_sb.WriteString("/sbin/init ")
+        for k, v := range node.Env {
+                env_sb.WriteString("systemd.setenv=" + k + "=" + v + " ")
+
+        }
+        node.Cmd = env_sb.String()
 
 	node.User = user
 	node.Group = c.groupInitialization(&nodeCfg, node.Kind)

--- a/clab/ceos.go
+++ b/clab/ceos.go
@@ -62,7 +62,7 @@ func initCeosNode(c *CLab, nodeCfg NodeConfig, node *Node, user string, envs map
 	node.Position = c.positionInitialization(&nodeCfg, node.Kind)
 
 	// initialize specific container information
-	node.Cmd = "/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0"
+	node.Cmd = "/sbin/init systemd.setenv=INTFTYPE=et systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0"
 
 	// defined env vars for the ceos
 	kindEnv := map[string]string{
@@ -71,7 +71,7 @@ func initCeosNode(c *CLab, nodeCfg NodeConfig, node *Node, user string, envs map
 		"container":                           "docker",
 		"ETBA":                                "4",
 		"SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT": "1",
-		"INTFTYPE":                            "eth",
+		"INTFTYPE":                            "et",
 		"MAPETH0":                             "1",
 		"MGMT_INTF":                           "eth0"}
 	node.Env = mergeStringMaps(kindEnv, envs)

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -56,7 +56,7 @@ ceos container uses the following mapping for its linux interfaces:
 * `eth0` - management interface connected to the containerlab management network
 * `et1` - first data interface
 
-When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `et0` interface and ceos node will boot with that addresses configure. Data interfaces `et1+` need to be configured with IP addressing manually.
+When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configured. Data interfaces `et1+` need to be configured with IP addressing manually.
 
 ???note "ceos interfaces output"
     This output demonstrates the IP addressing of the linux interfaces of ceos node.

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -39,13 +39,24 @@ Arista cEOS node launched with containerlab can be managed via the following int
 !!!info
     Default user credentials: `admin:admin`
 
+## Interface naming and link definition
+
+When defining links in the topology, ceos container interfaces should be named `et` as opposed to `eth`.  This provides consistency with the underlying interface mappings and the interactions with some features internally to ceos.  This naming requirement does not apply to the `eth0` interface created by containerlab only to links that are used for interconnection with other elements in a topology.
+
+example:
+```yml
+  links:
+    - endpoints: ["ceos_rtr1:et1", "ceos_rtr2:et1"]
+    - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
+```
+
 ## Interfaces mapping
 ceos container uses the following mapping for its linux interfaces:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface
+* `et1` - first data interface
 
-When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configure. Data interfaces `eth1+` need to be configured with IP addressing manually.
+When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `et0` interface and ceos node will boot with that addresses configure. Data interfaces `et1+` need to be configured with IP addressing manually.
 
 ???note "ceos interfaces output"
     This output demonstrates the IP addressing of the linux interfaces of ceos node.
@@ -146,16 +157,16 @@ In addition to cli commands such as `write memory` user can take advantage of th
 To start an Arista cEOS node containerlab uses the configuration instructions described in Arista Forums[^1]. The exact parameters are outlined below.
 
 === "Startup command"
-    `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
+    `/sbin/init systemd.setenv=INTFTYPE=et systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
 === "Environment variables"
     `CEOS:1`  
     `EOS_PLATFORM":ceoslab`  
     `container:docker`  
     `ETBA:4`  
     `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
-    `INTFTYPE:eth`  
+    `INTFTYPE:et`  
     `MAPETH0:1`  
-    `MGMT_INTF:eth0`
+    `MGMT_INTF:et0`
 
 ### File mounts
 When a user starts a lab, containerlab creates a node directory for storing [configuration artifacts](../conf-artifacts.md). For `ceos` kind containerlab creates `flash` directory for each ceos node and mounts these folders by `/mnt/flash` paths.

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -166,7 +166,7 @@ To start an Arista cEOS node containerlab uses the configuration instructions de
     `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
     `INTFTYPE:et`  
     `MAPETH0:1`  
-    `MGMT_INTF:et0`
+    `MGMT_INTF:eth0`
 
 ### File mounts
 When a user starts a lab, containerlab creates a node directory for storing [configuration artifacts](../conf-artifacts.md). For `ceos` kind containerlab creates `flash` directory for each ceos node and mounts these folders by `/mnt/flash` paths.

--- a/docs/manual/kinds/kinds.md
+++ b/docs/manual/kinds/kinds.md
@@ -21,7 +21,7 @@ topology:
       image: ceos:4.25F
 
   links:
-    - endpoints: ["node1:e1-1", "node2:eth1"]
+    - endpoints: ["node1:e1-1", "node2:et1"]
 ```
 
 Containerlab supports a fixed number of kinds. Within each predefined kind we store the necessary information that is used to launch the container successfully. The following kinds are supported or in the roadmap of containerlab:

--- a/docs/manual/kinds/ovs-bridge.md
+++ b/docs/manual/kinds/ovs-bridge.md
@@ -17,7 +17,7 @@ topology:
       kind: ceos
       image: ceos:latest
   links:
-    - endpoints: ["myovs:ovsp1", "srl:eth1"]
+    - endpoints: ["myovs:ovsp1", "ceos:et1"]
 
 ```
 

--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -22,7 +22,7 @@ topology:
       image: ceos:4.25.0F
 
   links:
-    - endpoints: ["srl:e1-1", "ceos:eth1"]
+    - endpoints: ["srl:e1-1", "ceos:et1"]
 ```
 
 This topology results in the two nodes being started up and interconnected with each other using a single point-po-point interface:
@@ -91,8 +91,8 @@ topology:
     ceos:
 
   links:
-    - endpoints: ["srl:e1-1", "ceos:eth1"]
-    - endpoints: ["srl:e1-2", "ceos:eth2"]
+    - endpoints: ["srl:e1-1", "ceos:et1"]
+    - endpoints: ["srl:e1-2", "ceos:et2"]
 ```
 
 As you see, the `topology.links` element is a list of individual links. The link itself is expressed as pair of `endpoints`. This might sound complicated, lets use a graphical explanation:
@@ -102,10 +102,10 @@ As you see, the `topology.links` element is a list of individual links. The link
 As demonstrated on a diagram above, the links between the containers are the point-to-point links which are defined by a pair of interfaces. The link defined as:
 
 ```yaml
-endpoints: ["srl:e1-1", "ceos:eth1"]
+endpoints: ["srl:e1-1", "ceos:et1"]
 ```
 
-will result in a creation of a p2p link between the node named `srl` and its `e1-1` interface and the node named `ceos` and its `eth1` interface. The p2p link is realized with a veth pair.
+will result in a creation of a p2p link between the node named `srl` and its `e1-1` interface and the node named `ceos` and its `et1` interface. The p2p link is realized with a veth pair.
 
 #### Kinds
 Kinds define the behavior and the nature of a node, it says if the node is a specific containerized Network OS, virtualized router or something else. We go into details of kinds in its own [document section](kinds/kinds.md), so here we will discuss what happens when `kinds` section appears in the topology definition:

--- a/docs/manual/wireshark.md
+++ b/docs/manual/wireshark.md
@@ -97,7 +97,7 @@ In the examples below the wireshark will be used as a sniffing tool and the foll
 === "cEOS [2]"
     Similarly to SR Linux example, to capture the data interface of cEOS is no different. Just pick the right interface:
     ```bash
-    ssh $clab_host "ip netns exec $clab-pcap-ceos tcpdump -U -nni eth1 -w -" | wireshark -k -i -
+    ssh $clab_host "ip netns exec $clab-pcap-ceos tcpdump -U -nni et1 -w -" | wireshark -k -i -
     ```
 === "Linux container [3]"
     A bare linux container is no different, its interfaces are named `ethX` where `eth0` is the interface connected to the containerlab management network.  

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,7 +42,7 @@ topology:
       image: ceos:4.25.0F
 
   links:
-    - endpoints: ["srl:e1-1", "ceos:eth1"]
+    - endpoints: ["srl:e1-1", "ceos:et1"]
 ```
 
 

--- a/lab-examples/srlceos01/srlceos01.clab.yml
+++ b/lab-examples/srlceos01/srlceos01.clab.yml
@@ -12,4 +12,4 @@ topology:
       image: ceos:4.25.0F
 
   links:
-    - endpoints: ["srl:e1-1", "ceos:eth1"]
+    - endpoints: ["srl:e1-1", "ceos:et1"]

--- a/tests/03-basic-ceos/03-ceos01-clab.yml
+++ b/tests/03-basic-ceos/03-ceos01-clab.yml
@@ -12,4 +12,4 @@ topology:
       mgmt_ipv4: 172.20.20.22
 
   links:
-    - endpoints: ["n1:eth1", "n2:eth1"]
+    - endpoints: ["n1:et1", "n2:et1"]


### PR DESCRIPTION
currently, to provide better alignment with some features internal to ceos-lab, interfaces should be named `et` and not `eth`.    
this PR modifies the default ceos-lab invocations to provide this consistency. 

- updates relevant elements of clab/ceos.go
- updates manual/kinds/ceos.md to align with the env changes and outlines the use in topologies.