### PR TITLE
import ceos environment variables into container for run time application

### DIFF
--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -39,13 +39,24 @@ Arista cEOS node launched with containerlab can be managed via the following int
 !!!info
     Default user credentials: `admin:admin`
 
+## Interface naming and link definition
+
+When defining links in the topology, ceos container interfaces should be named `et` as opposed to `eth`.  This provides consistency with the underlying interface mappings and the interactions with some features internally to ceos.  This naming requirement does not apply to the `eth0` interface created by containerlab only to links that are used for interconnection with other elements in a topology.
+
+example:
+```yml
+  links:
+    - endpoints: ["ceos_rtr1:et1", "ceos_rtr2:et1"]
+    - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
+```
+
 ## Interfaces mapping
 ceos container uses the following mapping for its linux interfaces:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface
+* `et1` - first data interface
 
-When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configure. Data interfaces `eth1+` need to be configured with IP addressing manually.
+When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configured. Data interfaces `et1+` need to be configured with IP addressing manually.
 
 ???note "ceos interfaces output"
     This output demonstrates the IP addressing of the linux interfaces of ceos node.
@@ -146,14 +157,14 @@ In addition to cli commands such as `write memory` user can take advantage of th
 To start an Arista cEOS node containerlab uses the configuration instructions described in Arista Forums[^1]. The exact parameters are outlined below.
 
 === "Startup command"
-    `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
+    `/sbin/init systemd.setenv=INTFTYPE=et systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
 === "Environment variables"
     `CEOS:1`  
     `EOS_PLATFORM":ceoslab`  
     `container:docker`  
     `ETBA:4`  
     `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
-    `INTFTYPE:eth`  
+    `INTFTYPE:et`  
     `MAPETH0:1`  
     `MGMT_INTF:eth0`
 

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -166,14 +166,14 @@ In addition to cli commands such as `write memory` user can take advantage of th
 To start an Arista cEOS node containerlab uses the configuration instructions described in Arista Forums[^1]. The exact parameters are outlined below.
 
 === "Startup command"
-    `/sbin/init systemd.setenv=INTFTYPE=et systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
+    `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
 === "Environment variables"
     `CEOS:1`  
     `EOS_PLATFORM":ceoslab`  
     `container:docker`  
     `ETBA:4`  
     `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
-    `INTFTYPE:et`  
+    `INTFTYPE:eth`  
     `MAPETH0:1`  
     `MGMT_INTF:eth0`
 

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -84,11 +84,11 @@ When containerlab launches ceos node, it will set IPv4/6 addresses as assigned b
     As you see, the management interface `Ma0` inherits the IP address that docker assigned to ceos container management interface.
 
 
-## Additional Interface naming considerations
+## Additional interface naming considerations
 
 While many users will be fine with the default ceos naming of `eth`, some ceos users may find that they need to name their interfaces `et`. Interfaces named `et` provide consistency with the underlying interface mappings within ceos. This enables the correct operation of commands/features which depend on `et` format interface naming.
 
-In order to align interfaces in this manner, the `INTFTYPE` environment variable must be set to `et` in the topology definition file and the links which are defined must be named `et`, as opposed to `eth`. This naming requirement does not apply to the `eth0 interface automatically created by containerlab. This is only required for links that are used for interconnection with other elements in a topology.
+In order to align interfaces in this manner, the `INTFTYPE` environment variable must be set to `et` in the topology definition file and the links which are defined must be named `et`, as opposed to `eth`. This naming requirement does not apply to the `eth0` interface automatically created by containerlab. This is only required for links that are used for interconnection with other elements in a topology.
 
 example:
 ```yml

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -39,24 +39,13 @@ Arista cEOS node launched with containerlab can be managed via the following int
 !!!info
     Default user credentials: `admin:admin`
 
-## Interface naming and link definition
-
-When defining links in the topology, ceos container interfaces should be named `et` as opposed to `eth`.  This provides consistency with the underlying interface mappings and the interactions with some features internally to ceos.  This naming requirement does not apply to the `eth0` interface created by containerlab only to links that are used for interconnection with other elements in a topology.
-
-example:
-```yml
-  links:
-    - endpoints: ["ceos_rtr1:et1", "ceos_rtr2:et1"]
-    - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
-```
-
 ## Interfaces mapping
 ceos container uses the following mapping for its linux interfaces:
 
 * `eth0` - management interface connected to the containerlab management network
-* `et1` - first data interface
+* `eth1` - first data interface
 
-When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configured. Data interfaces `et1+` need to be configured with IP addressing manually.
+When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and ceos node will boot with that addresses configured. Data interfaces `eth1+` need to be configured with IP addressing manually.
 
 ???note "ceos interfaces output"
     This output demonstrates the IP addressing of the linux interfaces of ceos node.
@@ -93,6 +82,26 @@ When containerlab launches ceos node, it will set IPv4/6 addresses as assigned b
                                             2001:172:20:20::2/80             up            config
     ```
     As you see, the management interface `Ma0` inherits the IP address that docker assigned to ceos container management interface.
+
+
+## Additional Interface naming considerations
+
+While many users will be fine with the default ceos naming of `eth`, some ceos users may find that they need to name their interfaces `et`. Interfaces named `et` provide consistency with the underlying interface mappings within ceos. This enables the correct operation of commands/features which depend on `et` format interface naming.
+
+In order to align interfaces in this manner, the `INTFTYPE` environment variable must be set to `et` in the topology definition file and the links which are defined must be named `et`, as opposed to `eth`. This naming requirement does not apply to the `eth0 interface automatically created by containerlab. This is only required for links that are used for interconnection with other elements in a topology.
+
+example:
+```yml
+topology:
+  defaults:
+    env:
+      INTFTYPE: et
+  nodes:
+  { ... snipped misc. node definition for brevity ... }
+  links:
+    - endpoints: ["ceos_rtr1:et1", "ceos_rtr2:et1"]
+    - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
+```
 
 ## Features and options
 ### Node configuration


### PR DESCRIPTION
## overview

this PR builds the node.Cmd string to import the merged environment variables from the into the container execution environment.  this allows the correct application and import of the topology/node-specific overrides.  notably, this allows for setting the `INTFTYPE` to provide alignment with the interfaces that ceos uses internally for various features.  

this also updates `docs/manual/kinds/ceos.md` to include text outlining the potential need for some users to adopt the `et` naming and provides an example for application in the topology file. 