### PR TITLE
hard stop when topo file is not present in `WithTopoFile`

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -61,7 +61,7 @@ func WithRuntime(name string, d bool, dur time.Duration, gracefulShutdown bool) 
 func WithTopoFile(file string) ClabOption {
 	return func(c *CLab) {
 		if file == "" {
-			return
+			log.Fatal("provide a path to the clab toplogy file")
 		}
 		if err := c.GetTopology(file); err != nil {
 			log.Fatalf("failed to read topology file: %v", err)
@@ -69,7 +69,7 @@ func WithTopoFile(file string) ClabOption {
 
 		err := c.initMgmtNetwork()
 		if err != nil {
-			log.Fatalf("initMgmtNetwork: %s", err)
+			log.Fatalf("failed to init the management network: %s", err)
 		}
 
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -49,8 +49,10 @@ var inspectCmd = &cobra.Command{
 		opts := []clab.ClabOption{
 			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
-			clab.WithTopoFile(topo),
 			clab.WithRuntime(rt, debug, timeout, graceful),
+		}
+		if topo != "" {
+			opts = append(opts, clab.WithTopoFile(topo))
 		}
 		c := clab.NewContainerLab(opts...)
 		if name == "" {

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -80,7 +80,7 @@ If `--offline` flag was not provided and no containers were found matching the l
 
 #### topology
 
-With the global `--topo | -t` flag a user sets the path to the topology file that will be used to get the .
+With the global `--topo | -t` flag a user sets the path to the topology file that will be used to get the nodes of a lab.
 
 #### srv
 

--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -3,6 +3,7 @@
 DirectoryPath: ./site
 IgnoreURLs:
   - fonts.gstatic.com
+  - img.shields.io
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true


### PR DESCRIPTION
supersedes #413
close #412

stops execution of WithTopoFile if the topo file is not present/empty