### PR TITLE
added docs for vrnetlab 0.3.1 with sros improvements

### DIFF
--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -66,6 +66,23 @@ When containerlab launches vr-sros node, it will assign IPv4/6 address to the `e
 
 Data interfaces `eth1+` needs to be configured with IP addressing manually using CLI/management protocols.
 
+???warning "at least one data interface (`eth1`) needs to be defined"
+    If a user wants to launch a single SR OS node without actually connecting it to anything, they may use [host link](../network.md#host-links) interface:
+
+    ```yaml
+    topology:
+      nodes:
+        sr1:
+          kind: vr-sros
+          image: vrnetlab/vr-sros:20.10.R3
+          license: license-sros20.txt
+      links:
+        - endpoints:
+            - "sr1:eth1"
+            - "host:sr1_eth1"
+    ```
+
+    This links definition will launch the SR OS node with its first port connected to the host OS.
 
 ## Features and options
 ### Variants

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -33,6 +33,7 @@ The following table provides a link between the version combinations that were v
 | --               | [`0.2.2`](https://github.com/hellt/vrnetlab/tree/v0.2.2)       | fixed serial (telnet) access to SR OS nodes                                                                                                              |
 | --               | [`0.2.3`](https://github.com/hellt/vrnetlab/tree/v0.2.3)       | set default cpu/ram for SR OS images                                                                                                                     |
 | `0.13.0`         | [`0.3.0`](https://github.com/hellt/vrnetlab/tree/v0.3.0)       | added support for Cisco CSR1000v via [`vr-csr`](kinds/vr-csr.md) and MikroTik routeros via [`vr-ros`](kinds/vr-ros.md) kind                              |
+|                  | [`0.3.1`](https://github.com/hellt/vrnetlab/tree/v0.3.1)       | enhanced SR OS boot sequence                                                                                                                             |
 
 ### Building vrnetlab images
 To build a vrnetlab image compatible with containerlab users first need to ensure that the versions of both projects follow [compatibility matrix](#compatibility-matrix).


### PR DESCRIPTION
vrnetlab 0.3.1 adds an indefinite wait timer for `eth1` interface to appear in the container namespace.

Before that, a 5sec timer was used which was not enough in situations where many sros nodes boot up simultaneously. 