### PR TITLE
Pseudo-random MACs & Node.Endpoints

### DIFF
--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -118,7 +118,7 @@ func (c *CLab) CreateVirtualWiring(l *types.Link) (err error) {
 
 // createVethIface takes two veth endpoint structs and create a veth pair and return
 // veth interface links.
-func createVethIface(ifName, peerName string, mtu int, aMAC, bMAC net.HardwareAddr) (linkA netlink.Link, linkB netlink.Link, err error) {
+func createVethIface(ifName, peerName string, mtu int, aMAC, bMAC net.HardwareAddr) (linkA, linkB netlink.Link, err error) {
 	linkA = &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:         ifName,

--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -246,8 +246,8 @@ func deleteNetnsSymlink(n string) error {
 	return nil
 }
 
-// GetLiknsByNamePrefix returns a list of links whose name matches a prefix
-func GetLiknsByNamePrefix(prefix string) ([]netlink.Link, error) {
+// GetLinksByNamePrefix returns a list of links whose name matches a prefix
+func GetLinksByNamePrefix(prefix string) ([]netlink.Link, error) {
 	// filtered list of interfaces
 	if prefix == "" {
 		return nil, fmt.Errorf("prefix is not specified")

--- a/cmd/vxlan.go
+++ b/cmd/vxlan.go
@@ -92,7 +92,7 @@ var vxlanDeleteCmd = &cobra.Command{
 		var ls []netlink.Link
 		var err error
 
-		ls, err = clab.GetLiknsByNamePrefix(delPrefix)
+		ls, err = clab.GetLinksByNamePrefix(delPrefix)
 
 		if err != nil {
 			return err

--- a/types/types.go
+++ b/types/types.go
@@ -24,6 +24,8 @@ type Endpoint struct {
 	Node *Node
 	// e1-x, eth, etc
 	EndpointName string
+	// mac address
+	MAC string
 }
 
 // mgmtNet struct defines the management network options
@@ -77,6 +79,8 @@ type Node struct {
 	Publish              []string //list of ports to publish with mysocketctl
 	// container labels
 	Labels map[string]string
+	// Slice of pointers to local endpoints
+	Endpoints []*Endpoint
 }
 
 // GenerateConfig generates configuration for the nodes


### PR DESCRIPTION
This is a PR to address #420 . It's slightly broader in scope and adds the following:

1. Each endpoint of the link now gets a random MAC with `clabOUI` prefix. This is needed to have a pre-determined MAC addresses at the point when container is created. In case of vr-xxx and other VM-based images, this information can be used to build a udev rules file to change the interface naming inside the VM to match the one in the container.
2. `types.Node` now stores all of its local Endpoints (pointers) in a slice. This way its easy to see not only how many extra links Node has, but what are their names and MACs.
3. Delete action now accepts `max-workers` argument, which acts the same way as for the `deploy` action.