### PR TITLE
Refactored deleteLab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+BIN_DIR = $(shell pwd)/bin
+BINARY = $(shell pwd)/bin/containerlab
+
+all: build
+
+build:
+	mkdir -p $(BIN_DIR)
+	go build -o $(BINARY) main.go 
+
+test:
+	go test -race ./... -v
+
+lint:
+	golangci-lint run
+

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -132,7 +132,7 @@ func TestBindsInitNodeDir(t *testing.T) {
 			// extract host filesystem path
 			bind_part := strings.Split(tc.want, ":")
 			// create folder from filesystem path
-			os.MkdirAll(bind_part[0], os.ModePerm)
+			_ = os.MkdirAll(bind_part[0], os.ModePerm)
 
 			binds := []string{tc.bind}
 			err := resolveBindPaths(binds, tc.nodeDir)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -191,41 +190,7 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 	}
 
 	log.Infof("Destroying lab: %s", c.Config.Name)
-	ctrChan := make(chan *types.GenericContainer)
-	wg := new(sync.WaitGroup)
-	wg.Add(int(maxWorkers))
-	for i := uint(0); i < maxWorkers; i++ {
-
-		go func(i uint) {
-			defer wg.Done()
-			for {
-				select {
-				case cont := <-ctrChan:
-					if cont == nil {
-						log.Debugf("Worker %d terminating...", i)
-						return
-					}
-					name := cont.ID
-					if len(cont.Names) > 0 {
-						name = strings.TrimLeft(cont.Names[0], "/")
-					}
-					err := c.Runtime.DeleteContainer(ctx, name)
-					if err != nil {
-						log.Errorf("could not remove container '%s': %v", name, err)
-					}
-				case <-ctx.Done():
-					return
-				}
-			}
-		}(i)
-	}
-	for _, ctr := range containers {
-		ctr := ctr
-		ctrChan <- &ctr
-	}
-	close(ctrChan)
-
-	wg.Wait()
+	c.DeleteNodes(ctx, maxWorkers, containers)
 
 	// remove the lab directories
 	if cleanup {


### PR DESCRIPTION
This change will make nodes deletion code path similar to nodes creation. 
In the future, this will give Clab ability to override maxworkers based on specific node's requirements.