### PR TITLE
fixing #456

### DIFF
--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -46,7 +46,7 @@ func init() {
 
 func (c *ContainerdRuntime) Init(opts ...runtime.RuntimeOption) error {
 	var err error
-	log.Info("Runtime: containerd")
+	log.Debug("Runtime: containerd")
 	c.client, err = containerd.New("/run/containerd/containerd.sock")
 	if err != nil {
 		return err

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -52,7 +52,7 @@ type DockerRuntime struct {
 
 func (c *DockerRuntime) Init(opts ...runtime.RuntimeOption) error {
 	var err error
-	log.Info("Runtime: Docker")
+	log.Debug("Runtime: Docker")
 	c.Client, err = dockerC.NewClientWithOpts(dockerC.FromEnv, dockerC.WithAPIVersionNegotiation())
 	if err != nil {
 		return err

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -360,14 +360,10 @@ func (c *DockerRuntime) ListContainers(ctx context.Context, gfilters []*types.Ge
 	}
 	var nr []dockerTypes.NetworkResource
 	if c.Mgmt.Network == "" {
-		netFilter := filters.NewArgs()
-		netFilter.Add("label", "containerlab")
 		nctx, cancel := context.WithTimeout(ctx, c.timeout)
 		defer cancel()
 
-		nr, err = c.Client.NetworkList(nctx, dockerTypes.NetworkListOptions{
-			Filters: netFilter,
-		})
+		nr, err = c.Client.NetworkList(nctx, dockerTypes.NetworkListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/tests/01-smoke/05-docker-bridge.clab.yml
+++ b/tests/01-smoke/05-docker-bridge.clab.yml
@@ -1,0 +1,15 @@
+# Copyright 2020 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: 05-docker-bridge
+# use the default docker network named "bridge"
+mgmt:
+  network: bridge
+
+topology:
+  nodes:
+    l1:
+      kind: linux
+      image: alpine:3
+      cmd: ash -c "sleep 9999"

--- a/tests/01-smoke/05-docker-bridge.robot
+++ b/tests/01-smoke/05-docker-bridge.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Library           OperatingSystem
+Library           String
+Suite Teardown    Cleanup
+
+*** Variables ***
+${lab-name}       05-docker-bridge
+${lab-file}       05-docker-bridge.clab.yml
+${runtime}        docker
+
+*** Test Cases ***
+Deploy ${lab-name} lab
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Ensure inspect outputs IP addresses
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab --runtime ${runtime} inspect -n ${lab-name}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    ${line} =    String.Get Line    ${output}    -2
+    Log    ${line}
+    @{data} =    Split String    ${line}    |
+    Log    ${data}
+    # verify ipv4 address
+    ${ipv4} =    String.Strip String    ${data}[8]
+    Should Match Regexp    ${ipv4}    ^[\\d\\.]+/\\d{1,2}$
+
+*** Keywords ***
+Cleanup
+    ${rc}    ${output} =    Run And Return Rc And Output    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    Log    ${output}


### PR DESCRIPTION
The filter caused the default bridge to be excluded from the network listing. 
Hence the container IP wasn't found.
I'm not sure why the filter was introduced in #433 for issue #432. Topology mentioned in #456 works fine. #433 has no topo attached to test.