### PR TITLE
Deduplicating destroy -t vs destroy --all

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -44,9 +44,6 @@ var deployCmd = &cobra.Command{
 	PreRunE:      sudoCheck,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		if err = topoSet(); err != nil {
-			return err
-		}
 		opts := []clab.ClabOption{
 			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -45,30 +45,20 @@ var destroyCmd = &cobra.Command{
 
 		switch {
 		case !all:
-			{
-				// stop if not topo file provided and not all labs are requested
-				// to be deleted
-				if err = topoSet(); err != nil {
-					return err
-				}
-				topos[topo] = struct{}{}
-			}
+			topos[topo] = struct{}{}
 		case all:
-			{
-				c := clab.NewContainerLab(opts...)
-				// list all containerlab containers
-				containers, err := c.Runtime.ListContainers(ctx, []*types.GenericFilter{{FilterType: "label", Field: "containerlab", Operator: "exists"}})
-				if err != nil {
-					return fmt.Errorf("could not list containers: %v", err)
-				}
-				if len(containers) == 0 {
-					return fmt.Errorf("no containerlab labs were found")
-				}
-				// get unique topo files from all labs
-				for _, cont := range containers {
-					topos[cont.Labels["clab-topo-file"]] = struct{}{}
-				}
-
+			c := clab.NewContainerLab(opts...)
+			// list all containerlab containers
+			containers, err := c.Runtime.ListContainers(ctx, []*types.GenericFilter{{FilterType: "label", Field: "containerlab", Operator: "exists"}})
+			if err != nil {
+				return fmt.Errorf("could not list containers: %v", err)
+			}
+			if len(containers) == 0 {
+				return fmt.Errorf("no containerlab labs were found")
+			}
+			// get unique topo files from all labs
+			for _, cont := range containers {
+				topos[cont.Labels["clab-topo-file"]] = struct{}{}
 			}
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,14 +54,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rt, "runtime", "r", "", "container runtime")
 }
 
-// returns an error if topo path is not provided
-func topoSet() error {
-	if topo == "" {
-		return errors.New("path to the topology definition file must be provided with --topo/-t flag")
-	}
-	return nil
-}
-
 func sudoCheck(cmd *cobra.Command, args []string) error {
 	id := os.Geteuid()
 	if id != 0 {


### PR DESCRIPTION
The destroy action did carry a lot of duplicated code for the --all and the -t option.
This pull request is to streamline that process.