### PR TITLE
update kind/ceos.md doc re: cgroup v1 requirement

### DIFF
--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -103,6 +103,10 @@ topology:
     - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
 ```
 
+## cgroup requirements
+
+As of this writing (22-June, 2021), ceos-lab images require a cgroup v1 environment.  For many users this should not require any changes to the runtime environment.  However, some users (ref: [#467](https://github.com/srl-labs/containerlab/issues/467)) will potentially need to configure their container runtime environment to utilize a cgroup v1 environment.  Other cgroup v1-based software (e.g.: Kubernetes) requires a cgroup v1-based runtiem environment as well.  Consult your distribution's documentation for details regarding configuring cgroup v1 operation. 
+
 ## Features and options
 ### Node configuration
 cEOS nodes have a dedicated [`config`](../conf-artifacts.md#identifying-a-lab-directory) directory that is used to persist the configuration of the node. It is possible to launch nodes of `ceos` kind with a basic config or to provide a custom config file that will be 

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -103,10 +103,6 @@ topology:
     - endpoints: ["ceos_rtr1:et2", "ceos_rtr3:et1"]
 ```
 
-## cgroup requirements
-
-As of this writing (22-June, 2021), ceos-lab images require a cgroup v1 environment.  For many users this should not require any changes to the runtime environment.  However, some users (ref: [#467](https://github.com/srl-labs/containerlab/issues/467)) will potentially need to configure their container runtime environment to utilize a cgroup v1 environment.  Other cgroup v1-based software (e.g.: Kubernetes) requires a cgroup v1-based runtiem environment as well.  Consult your distribution's documentation for details regarding configuring cgroup v1 operation. 
-
 ## Features and options
 ### Node configuration
 cEOS nodes have a dedicated [`config`](../conf-artifacts.md#identifying-a-lab-directory) directory that is used to persist the configuration of the node. It is possible to launch nodes of `ceos` kind with a basic config or to provide a custom config file that will be 
@@ -216,5 +212,12 @@ clab-srlceos01/ceos
 The following labs feature cEOS node:
 
 - [SR Linux and cEOS](../../lab-examples/srl-ceos.md)
+
+## Known issues or limitations
+### cgroups v1
+
+As of this writing (22-June, 2021), ceos-lab image requires a cgroups v1 environment.  For many users this should not require any changes to the runtime environment.  However, some linux distributions (ref: [#467](https://github.com/srl-labs/containerlab/issues/467)) may be configured to use cgroups v2 out-of-the-box, which will prevent ceos-lab image from booting. In such cases, the users will need to configure their system to utilize a cgroups v1 environment.  
+
+Consult your distribution's documentation for details regarding configuring cgroups v1 in case you see similar startup issues as indicated in [#467](https://github.com/srl-labs/containerlab/issues/467). 
 
 [^1]: https://eos.arista.com/ceos-lab-topo/


### PR DESCRIPTION
reference issue: #467,  ceos-lab only supports cgroup v1 operation. this documentation update advises users that they may need to revert their runtime environment to accommodate this requirement.