### PR TITLE
renamed config to startup-config and fixed startup-config usage

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -166,7 +166,7 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 	log.Debugf("node config: %+v", nodeCfg)
 	var err error
 	// initialize config
-	nodeCfg.Config, err = c.Config.Topology.GetNodeConfig(nodeCfg.ShortName)
+	nodeCfg.StartupConfig, err = c.Config.Topology.GetNodeConfig(nodeCfg.ShortName)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -127,7 +127,7 @@ The generated config will be saved by the path `clab-<lab_name>/<node-name>/flas
 cEOS Ma0 interface will be configured with a random MAC address with `00:1c:73` OUI part. Containerlab will also create a `system_mac_address` file in the node's lab directory with the value of a System MAC address. The System MAC address value is calculated as `Ma0-MAC-addr + 1`.
 
 #### User defined config
-It is possible to make ceos nodes to boot up with a user-defined config instead of a built-in one. With a [`config`](../nodes.md#config) property a user sets the path to the config file that will be mounted to a container and used as a startup config:
+It is possible to make ceos nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property a user sets the path to the config file that will be mounted to a container and used as a startup config:
 
 ```yaml
 name: ceos_lab

--- a/docs/manual/kinds/crpd.md
+++ b/docs/manual/kinds/crpd.md
@@ -112,7 +112,7 @@ topology:
 The generated config will be saved by the path `clab-<lab_name>/<node-name>/config/juniper.conf`. Using the example topology presented above, the exact path to the config will be `clab-crpd/crpd/config/juniper.conf`.
 
 #### User defined config
-It is possible to make cRPD nodes to boot up with a user-defined config instead of a built-in one. With a [`config`](../nodes.md#config) property of the node/kind a user sets the path to the config file that will be mounted to a container:
+It is possible to make cRPD nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind a user sets the path to the config file that will be mounted to a container:
 
 ```yaml
 name: crpd_lab

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -57,8 +57,8 @@ topology:
 
 The generated config will be saved by the path `clab-<lab_name>/<node-name>/config/config.json`. Using the example topology presented above, the exact path to the config will be `clab-srl_lab/srl1/config/config.json`.
 
-#### User defined config
-It is possible to make SR Linux nodes to boot up with a user-defined config instead of a built-in one. With a [`config`](../nodes.md#config) property of the node/kind a user sets the path to the config file that will be mounted to a container:
+#### User defined startup config
+It is possible to make SR Linux nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind a user sets the path to the config file that will be mounted to a container:
 
 ```yaml
 name: srl_lab

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -121,7 +121,7 @@ type: "cpu=2 ram=4 slot=A chassis=ixr-r6 card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-2
 vr-sros nodes come up with a basic "blank" configuration where only the card/mda are provisioned, as well as the management interfaces such as Netconf, SNMP, gNMI.
 
 #### User defined config
-It is possible to make SR OS nodes to boot up with a user-defined config instead of a built-in one. With a [`config`](../nodes.md#config) property of the node/kind a user sets the path to the config file that will be mounted to a container and used as a startup config:
+It is possible to make SR OS nodes to boot up with a user-defined startup config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind a user sets the path to the config file that will be mounted to a container and used as a startup config:
 
 ```yaml
 name: sros_lab

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -58,8 +58,8 @@ docker tag srlinux:20.6.1-286 srlinux:latest
 ### license
 Some containerized NOSes require a license to operate. With `license` property a user sets a path to a license file that a node will use. The license file will then be mounted to the container by the path that is defined by the `kind/type` of the node.
 
-### config
-For some kinds its possible to pass a path to a config file that a node will use on start instead of a bare config. Check documentation for a specific kind to see if `config` element is supported.
+### startup-config
+For some kinds it's possible to pass a path to a config file that a node will use on start instead of a bare config. Check documentation for a specific kind to see if `startup-config` element is supported.
 
 ### binds
 In order to expose host files to the containerized nodes a user can leverage the bind mount capability.

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -43,8 +43,8 @@ func (s *crpd) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	for _, o := range opts {
 		o(s)
 	}
-	if s.cfg.Config == "" {
-		s.cfg.Config = nodes.DefaultConfigTemplates[s.cfg.Kind]
+	if s.cfg.StartupConfig == "" {
+		s.cfg.StartupConfig = nodes.DefaultConfigTemplates[s.cfg.Kind]
 	}
 
 	// mount config and log dirs

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -73,8 +73,8 @@ func (s *srl) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	for _, o := range opts {
 		o(s)
 	}
-	if s.cfg.Config == "" {
-		s.cfg.Config = nodes.DefaultConfigTemplates[s.cfg.Kind]
+	if s.cfg.StartupConfig == "" {
+		s.cfg.StartupConfig = nodes.DefaultConfigTemplates[s.cfg.Kind]
 	}
 	if s.cfg.License == "" {
 		return fmt.Errorf("no license found for node '%s' of kind '%s'", s.cfg.ShortName, s.cfg.Kind)
@@ -211,11 +211,18 @@ func createSRLFiles(nodeCfg *types.NodeConfig) error {
 		return err
 	}
 
-	// generate a config file
-	// if the node has a `config:` statement, the file specified in that section
-	// will be used as a template in nodeGenerateConfig()
+	// generate a startup config file
+	// if the node has a `startup-config:` statement, the file specified in that section
+	// will be used as a template in GenerateConfig()
 	utils.CreateDirectory(path.Join(nodeCfg.LabDir, "config"), 0777)
 	dst = path.Join(nodeCfg.LabDir, "config", "config.json")
+	if nodeCfg.StartupConfig != "" {
+		c, err := os.ReadFile(nodeCfg.StartupConfig)
+		if err != nil {
+			return err
+		}
+		cfgTemplate = string(c)
+	}
 	err = nodeCfg.GenerateConfig(dst, cfgTemplate)
 	if err != nil {
 		log.Errorf("node=%s, failed to generate config: %v", nodeCfg.ShortName, err)

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -41,10 +41,10 @@
                     "description": "path to a license file",
                     "markdownDescription": "path to a [license](https://containerlab.srlinux.dev/manual/nodes/#license) file"
                 },
-                "config": {
+                "startup-config": {
                     "type": "string",
-                    "description": "path to a config file (if supported by kind)",
-                    "markdownDescription": "path to a [config file](https://containerlab.srlinux.dev/manual/nodes/#config) (if supported by kind)"
+                    "description": "path to a startup config file (if supported by kind)",
+                    "markdownDescription": "path to a [config file](https://containerlab.srlinux.dev/manual/nodes/#startup-config) (if supported by kind)"
                 },
                 "binds": {
                     "type": "array",

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -2,14 +2,14 @@ package types
 
 // NodeDefinition represents a configuration a given node can have in the lab definition file
 type NodeDefinition struct {
-	Kind     string `yaml:"kind,omitempty"`
-	Group    string `yaml:"group,omitempty"`
-	Type     string `yaml:"type,omitempty"`
-	Config   string `yaml:"config,omitempty"`
-	Image    string `yaml:"image,omitempty"`
-	License  string `yaml:"license,omitempty"`
-	Position string `yaml:"position,omitempty"`
-	Cmd      string `yaml:"cmd,omitempty"`
+	Kind          string `yaml:"kind,omitempty"`
+	Group         string `yaml:"group,omitempty"`
+	Type          string `yaml:"type,omitempty"`
+	StartupConfig string `yaml:"startup-config,omitempty"`
+	Image         string `yaml:"image,omitempty"`
+	License       string `yaml:"license,omitempty"`
+	Position      string `yaml:"position,omitempty"`
+	Cmd           string `yaml:"cmd,omitempty"`
 	// list of bind mount compatible strings
 	Binds []string `yaml:"binds,omitempty"`
 	// list of port bindings
@@ -51,11 +51,11 @@ func (n *NodeDefinition) GetType() string {
 	return n.Type
 }
 
-func (n *NodeDefinition) GetConfig() string {
+func (n *NodeDefinition) GetStartupConfig() string {
 	if n == nil {
 		return ""
 	}
-	return n.Config
+	return n.StartupConfig
 }
 
 func (n *NodeDefinition) GetImage() string {

--- a/types/topology.go
+++ b/types/topology.go
@@ -138,12 +138,12 @@ func (t *Topology) GetNodeConfig(name string) (string, error) {
 	var cfg string
 	if ndef, ok := t.Nodes[name]; ok {
 		var err error
-		cfg = ndef.GetConfig()
-		if t.GetKind(t.GetNodeKind(name)).GetConfig() != "" && cfg == "" {
-			cfg = t.GetKind(t.GetNodeKind(name)).GetConfig()
+		cfg = ndef.GetStartupConfig()
+		if t.GetKind(t.GetNodeKind(name)).GetStartupConfig() != "" && cfg == "" {
+			cfg = t.GetKind(t.GetNodeKind(name)).GetStartupConfig()
 		}
 		if cfg == "" {
-			cfg = t.GetDefaults().GetConfig()
+			cfg = t.GetDefaults().GetStartupConfig()
 		}
 		if cfg != "" {
 			cfg, err = resolvePath(cfg)

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -28,14 +28,14 @@ var topologyTestSet = map[string]struct {
 		input: &Topology{
 			Kinds: map[string]*NodeDefinition{
 				"srl": {
-					Group:    "grp1",
-					Type:     "type1",
-					Config:   "test_data/config.cfg",
-					Image:    "image:latest",
-					License:  "test_data/lic1.key",
-					Position: "pos1",
-					Cmd:      "runit",
-					User:     "user1",
+					Group:         "grp1",
+					Type:          "type1",
+					StartupConfig: "test_data/config.cfg",
+					Image:         "image:latest",
+					License:       "test_data/lic1.key",
+					Position:      "pos1",
+					Cmd:           "runit",
+					User:          "user1",
 					Binds: []string{
 						"a:b",
 						"c:d",
@@ -67,15 +67,15 @@ var topologyTestSet = map[string]struct {
 		},
 		want: map[string]*NodeDefinition{
 			"node1": {
-				Kind:     "srl",
-				Group:    "grp1",
-				Type:     "type1",
-				Config:   "test_data/config.cfg",
-				Image:    "image:latest",
-				License:  "test_data/lic1.key",
-				Position: "pos1",
-				Cmd:      "runit",
-				User:     "user1",
+				Kind:          "srl",
+				Group:         "grp1",
+				Type:          "type1",
+				StartupConfig: "test_data/config.cfg",
+				Image:         "image:latest",
+				License:       "test_data/lic1.key",
+				Position:      "pos1",
+				Cmd:           "runit",
+				User:          "user1",
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -102,13 +102,13 @@ var topologyTestSet = map[string]struct {
 			},
 			Kinds: map[string]*NodeDefinition{
 				"srl": {
-					Group:    "grp1",
-					Type:     "type1",
-					Config:   "test_data/config.cfg",
-					Image:    "image:latest",
-					License:  "test_data/lic1.key",
-					Position: "pos1",
-					Cmd:      "runit",
+					Group:         "grp1",
+					Type:          "type1",
+					StartupConfig: "test_data/config.cfg",
+					Image:         "image:latest",
+					License:       "test_data/lic1.key",
+					Position:      "pos1",
+					Cmd:           "runit",
 					Binds: []string{
 						"a:b",
 						"c:d",
@@ -132,15 +132,15 @@ var topologyTestSet = map[string]struct {
 		},
 		want: map[string]*NodeDefinition{
 			"node1": {
-				Kind:     "srl",
-				Group:    "grp1",
-				Type:     "type1",
-				Config:   "test_data/config.cfg",
-				Image:    "image:latest",
-				License:  "test_data/lic1.key",
-				Position: "pos1",
-				Cmd:      "runit",
-				User:     "user1",
+				Kind:          "srl",
+				Group:         "grp1",
+				Type:          "type1",
+				StartupConfig: "test_data/config.cfg",
+				Image:         "image:latest",
+				License:       "test_data/lic1.key",
+				Position:      "pos1",
+				Cmd:           "runit",
+				User:          "user1",
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -162,14 +162,14 @@ var topologyTestSet = map[string]struct {
 	"node_default": {
 		input: &Topology{
 			Defaults: &NodeDefinition{
-				Kind:     "srl",
-				Group:    "grp1",
-				Type:     "type1",
-				Config:   "test_data/config.cfg",
-				Image:    "image:latest",
-				License:  "test_data/lic1.key",
-				Position: "pos1",
-				Cmd:      "runit",
+				Kind:          "srl",
+				Group:         "grp1",
+				Type:          "type1",
+				StartupConfig: "test_data/config.cfg",
+				Image:         "image:latest",
+				License:       "test_data/lic1.key",
+				Position:      "pos1",
+				Cmd:           "runit",
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -192,14 +192,14 @@ var topologyTestSet = map[string]struct {
 		},
 		want: map[string]*NodeDefinition{
 			"node1": {
-				Kind:     "srl",
-				Group:    "grp1",
-				Type:     "type1",
-				Config:   "test_data/config.cfg",
-				Image:    "image:latest",
-				License:  "test_data/lic1.key",
-				Position: "pos1",
-				Cmd:      "runit",
+				Kind:          "srl",
+				Group:         "grp1",
+				Type:          "type1",
+				StartupConfig: "test_data/config.cfg",
+				Image:         "image:latest",
+				License:       "test_data/lic1.key",
+				Position:      "pos1",
+				Cmd:           "runit",
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -268,7 +268,7 @@ func TestGetNodeConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantedConfig, err := resolvePath(item.want["node1"].Config)
+		wantedConfig, err := resolvePath(item.want["node1"].StartupConfig)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -46,27 +46,27 @@ type MgmtNet struct {
 
 // NodeConfig is a struct that contains the information of a container element
 type NodeConfig struct {
-	ShortName    string
-	LongName     string
-	Fqdn         string
-	LabDir       string // LabDir is a directory related to the node, it contains config items and/or other persistent state
-	Index        int
-	Group        string
-	Kind         string
-	Config       string // path to config template file that is used for config generation
-	ResConfig    string // path to config file that is actually mounted to the container and is a result of templation
-	NodeType     string
-	Position     string
-	License      string
-	Image        string
-	Sysctls      map[string]string
-	User         string
-	Entrypoint   string
-	Cmd          string
-	Env          map[string]string
-	Binds        []string    // Bind mounts strings (src:dest:options)
-	PortBindings nat.PortMap // PortBindings define the bindings between the container ports and host ports
-	PortSet      nat.PortSet // PortSet define the ports that should be exposed on a container
+	ShortName        string
+	LongName         string
+	Fqdn             string
+	LabDir           string // LabDir is a directory related to the node, it contains config items and/or other persistent state
+	Index            int
+	Group            string
+	Kind             string
+	StartupConfig    string // path to config template file that is used for startup config generation
+	ResStartupConfig string // path to config file that is actually mounted to the container and is a result of templation
+	NodeType         string
+	Position         string
+	License          string
+	Image            string
+	Sysctls          map[string]string
+	User             string
+	Entrypoint       string
+	Cmd              string
+	Env              map[string]string
+	Binds            []string    // Bind mounts strings (src:dest:options)
+	PortBindings     nat.PortMap // PortBindings define the bindings between the container ports and host ports
+	PortSet          nat.PortSet // PortSet define the ports that should be exposed on a container
 	// container networking mode. if set to `host` the host networking will be used for this node, else bridged network
 	NetworkMode          string
 	MgmtNet              string // name of the docker network this node is connected to with its first interface
@@ -88,14 +88,17 @@ type NodeConfig struct {
 }
 
 // GenerateConfig generates configuration for the nodes
-// out of the templ based on the node configuration
+// out of the templ based on the node configuration and saves the result to dst
 func (node *NodeConfig) GenerateConfig(dst, templ string) error {
-	if utils.FileExists(dst) && (node.Config != "") {
+	// if startup config is not set, and the config file is already present in the node dir
+	// we do not regenerate the config, since we will take what was saved from the previous run
+	// in other words, the startup config set by a user takes preference and will trigger config generation
+	if utils.FileExists(dst) && (node.StartupConfig == "") {
 		log.Debugf("config file '%s' for node '%s' already exists and will not be generated", dst, node.ShortName)
 		return nil
 	}
-	log.Debugf("generating config for node %s from file %s", node.ShortName, node.Config)
-	tpl, err := template.New(filepath.Base(node.Config)).Parse(templ)
+	log.Debugf("generating config for node %s from file %s", node.ShortName, node.StartupConfig)
+	tpl, err := template.New(filepath.Base(node.StartupConfig)).Parse(templ)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this PR introduces a **breaking change**: renaming of `config` element of a node to `startup-config`
This is to better indicate its purpose and at the same time to release the `config` name for #383 