### PR TITLE
config: No text/template wrapper

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -84,7 +84,7 @@ func RenderAll(nodes map[string]nodes.Node, links map[int]*types.Link) (map[stri
 			}
 
 			var buf strings.Builder
-			err := tmpl.Lookup(tmplN).Execute(&buf, vars)
+			err := tmpl.ExecutTemplate(&buf, tmplN, vars)
 			if err != nil {
 				return nil, err
 			}

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -87,8 +87,8 @@ func RenderAll(nodes map[string]nodes.Node, links map[int]*types.Link) (map[stri
 				return nil, err
 			}
 
-			data1 := strings.ReplaceAll(strings.Trim(buf.String(), "\n \t"), "\n\n\n", "\n\n")
-			res[nodeName].Data = append(res[nodeName].Data, data1)
+			data := strings.ReplaceAll(strings.Trim(buf.String(), "\n \t"), "\n\n\n", "\n\n")
+			res[nodeName].Data = append(res[nodeName].Data, data)
 			res[nodeName].Info = append(res[nodeName].Info, tmplN)
 		}
 	}

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -84,7 +84,7 @@ func RenderAll(nodes map[string]nodes.Node, links map[int]*types.Link) (map[stri
 			}
 
 			var buf strings.Builder
-			err := tmpl.ExecutTemplate(&buf, tmplN, vars)
+			err := tmpl.ExecuteTemplate(&buf, tmplN, vars)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Nr 1 from #487 

Implementation similar to the existing logic from https://github.com/kellerza/template/blob/main/template.go#L59

@karimra mentioned there is a built in method to search the paths, but did not find it.