### PR TITLE
remove duration timeout from stopcontainer

### DIFF
--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
@@ -152,9 +151,8 @@ func ceosPostDeploy(ctx context.Context, r runtime.ContainerRuntime, nodeCfg *ty
 	if err != nil {
 		return err
 	}
-	// force stopping and start is faster than ContainerRestart
-	var timeout time.Duration = 1
-	err = r.StopContainer(ctx, nodeCfg.ContainerID, &timeout)
+
+	err = r.StopContainer(ctx, nodeCfg.ContainerID)
 	if err != nil {
 		return err
 	}

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -404,7 +404,7 @@ func (c *ContainerdRuntime) StartContainer(ctx context.Context, containername st
 	}
 	return nil
 }
-func (c *ContainerdRuntime) StopContainer(ctx context.Context, containername string, dur *time.Duration) error {
+func (c *ContainerdRuntime) StopContainer(ctx context.Context, containername string) error {
 	ctask, err := c.getContainerTask(ctx, containername)
 	if err != nil {
 		log.Debugf("container %s: %v", containername, err)
@@ -729,7 +729,7 @@ func (c *ContainerdRuntime) DeleteContainer(ctx context.Context, containerID str
 	log.Debugf("deleting container %s", containerID)
 	ctx = namespaces.WithNamespace(ctx, containerdNamespace)
 
-	err := c.StopContainer(ctx, containerID, nil)
+	err := c.StopContainer(ctx, containerID)
 	if err != nil {
 		return err
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -571,7 +571,7 @@ func setSysctl(sysctl string, newVal int) error {
 	return ioutil.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
 }
 
-func (c *DockerRuntime) StopContainer(ctx context.Context, name string, dur *time.Duration) error {
+func (c *DockerRuntime) StopContainer(ctx context.Context, name string) error {
 	log.Printf("Stopping container %q", name)
 	return c.Client.ContainerKill(ctx, name, "kill")
 }

--- a/runtime/ignite/iginite.go
+++ b/runtime/ignite/iginite.go
@@ -252,7 +252,7 @@ func (c *IgniteRuntime) StartContainer(ctx context.Context, _ string) error {
 	// this is a no-op
 	return nil
 }
-func (c *IgniteRuntime) StopContainer(ctx context.Context, name string, timeout *time.Duration) error {
+func (c *IgniteRuntime) StopContainer(ctx context.Context, name string) error {
 	// this is a no-op, only used by ceos at this stage
 	return nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -36,7 +36,7 @@ type ContainerRuntime interface {
 	// Start pre-created container by its name
 	StartContainer(context.Context, string) error
 	// Stop running container by its name
-	StopContainer(context.Context, string, *time.Duration) error
+	StopContainer(context.Context, string) error
 	// List all containers matching labels
 	ListContainers(context.Context, []*types.GenericFilter) ([]types.GenericContainer, error)
 	// Get a netns path using the pid of a container


### PR DESCRIPTION
duration timeout was initially used to stop the container without waiting for it to stop gracefully
it was implemented to stop ceos containers before running them again.

Now the newer docker api allowed us to use ContainerKill, so that the artificial timeout is not needed anymore

close #483 