### PR TITLE
cleanup unused variables and change Clab.WithRuntime(...) to use *runtime.RuntimeConfig

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -30,9 +30,7 @@ type CLab struct {
 	globalRuntime string
 	Dir           *Directory
 
-	debug            bool
-	timeout          time.Duration
-	gracefulShutdown bool
+	timeout time.Duration
 }
 
 type Directory struct {
@@ -44,19 +42,13 @@ type Directory struct {
 
 type ClabOption func(c *CLab)
 
-func WithDebug(d bool) ClabOption {
-	return func(c *CLab) {
-		c.debug = d
-	}
-}
-
 func WithTimeout(dur time.Duration) ClabOption {
 	return func(c *CLab) {
 		c.timeout = dur
 	}
 }
 
-func WithRuntime(name string, d bool, dur time.Duration, gracefulShutdown bool) ClabOption {
+func WithRuntime(name string, rtconfig *runtime.RuntimeConfig) ClabOption {
 	return func(c *CLab) {
 		// define runtime name.
 		// order of preference: cli flag -> env var -> default value of docker
@@ -73,10 +65,7 @@ func WithRuntime(name string, d bool, dur time.Duration, gracefulShutdown bool) 
 		if rInit, ok := runtime.ContainerRuntimes[name]; ok {
 			r := rInit()
 			err := r.Init(
-				runtime.WithConfig(&runtime.RuntimeConfig{
-					Timeout: dur,
-					Debug:   d,
-				}),
+				runtime.WithConfig(rtconfig),
 				runtime.WithMgmtNet(c.Config.Mgmt),
 			)
 			if err != nil {
@@ -105,12 +94,6 @@ func WithTopoFile(file string) ClabOption {
 			log.Fatalf("failed to init the management network: %s", err)
 		}
 
-	}
-}
-
-func WithGracefulShutdown(gracefulShutdown bool) ClabOption {
-	return func(c *CLab) {
-		c.gracefulShutdown = gracefulShutdown
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,7 +27,6 @@ var configCmd = &cobra.Command{
 		transport.DebugCount = debugCount
 
 		c, err := clab.NewContainerLab(
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo),
 		)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,10 +48,15 @@ var deployCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -37,9 +37,14 @@ var destroyCmd = &cobra.Command{
 		defer cancel()
 
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 
 		topos := map[string]struct{}{}
@@ -71,7 +76,6 @@ var destroyCmd = &cobra.Command{
 		for topo := range topos {
 			opts := append(opts,
 				clab.WithTopoFile(topo),
-				clab.WithGracefulShutdown(graceful),
 			)
 			c, err := clab.NewContainerLab(opts...)
 			if err != nil {

--- a/cmd/disableTxOffload.go
+++ b/cmd/disableTxOffload.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/utils"
 )
 
@@ -23,9 +24,14 @@ var disableTxOffloadCmd = &cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 )
 
@@ -47,10 +48,15 @@ var execCmd = &cobra.Command{
 			log.Error("format is expected to be either json or plain")
 		}
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 )
 
@@ -56,10 +57,15 @@ var graphCmd = &cobra.Command{
 		var err error
 
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 )
 
@@ -51,9 +52,14 @@ var inspectCmd = &cobra.Command{
 			return
 		}
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		if topo != "" {
 			opts = append(opts, clab.WithTopoFile(topo))

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/runtime"
 )
 
 // saveCmd represents the save command
@@ -27,10 +28,15 @@ Refer to the https://containerlab.srlinux.dev/cmd/save/ documentation to see the
 			return fmt.Errorf("provide topology file path  with --topo flag")
 		}
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/cmd/tools_cert.go
+++ b/cmd/tools_cert.go
@@ -100,7 +100,6 @@ func createCA(cmd *cobra.Command, args []string) error {
 `
 	var err error
 	opts := []clab.ClabOption{
-		clab.WithDebug(debug),
 		clab.WithTimeout(timeout),
 	}
 	c, err := clab.NewContainerLab(opts...)

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -40,9 +41,14 @@ var vethCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		opts := []clab.ClabOption{
-			clab.WithDebug(debug),
 			clab.WithTimeout(timeout),
-			clab.WithRuntime(rt, debug, timeout, graceful),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		}
 		c, err := clab.NewContainerLab(opts...)
 		if err != nil {


### PR DESCRIPTION
the Clab bound options where not used any more. Hence I've deleted them.
changed Clab.WithRuntime from `(name string, d bool, dur time.Duration, gracefulShutdown bool)` to `(name string, rtconfig *runtime.RuntimeConfig)`.