### PR TITLE
embedding host file entries in signature

### DIFF
--- a/clab/general.go
+++ b/clab/general.go
@@ -1,0 +1,127 @@
+package clab
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/srl-labs/containerlab/types"
+)
+
+var (
+	CLAB_HOSTENTRY_PREFIX  = "###### CLAB-%s-START ######"
+	CLAB_HOSTENTRY_POSTFIX = "###### CLAB-%s-END ######"
+)
+
+func AppendHostsFileEntries(containers []types.GenericContainer, labname string) error {
+	if labname == "" {
+		return fmt.Errorf("missing lab name")
+	}
+	// lets make sure we do not have remaining of a non destroyed run in the hosts file
+	err := DeleteEntriesFromHostsFile(labname)
+	if err != nil {
+		return err
+	}
+	data := GenerateHostsEntries(containers, labname)
+	if len(data) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile("/etc/hosts", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString("\n")
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// hostEntries builds an /etc/hosts compliant text blob (as []byte]) for containers ipv4/6 address<->name pairs
+func GenerateHostsEntries(containers []types.GenericContainer, labname string) []byte {
+	buff := bytes.Buffer{}
+	v4buff := bytes.Buffer{}
+	v6buff := bytes.Buffer{}
+
+	for _, cont := range containers {
+		if len(cont.Names) == 0 {
+			continue
+		}
+		if cont.NetworkSettings.Set {
+			if cont.NetworkSettings.IPv4addr != "" {
+				v4buff.WriteString(cont.NetworkSettings.IPv4addr)
+				v4buff.WriteString("\t")
+				v4buff.WriteString(strings.TrimLeft(cont.Names[0], "/"))
+				v4buff.WriteString("\n")
+			}
+			if cont.NetworkSettings.IPv6addr != "" {
+				v6buff.WriteString(cont.NetworkSettings.IPv6addr)
+				v6buff.WriteString("\t")
+				v6buff.WriteString(strings.TrimLeft(cont.Names[0], "/"))
+				v6buff.WriteString("\n")
+			}
+		}
+	}
+	// combine stuff
+	buff.WriteString(fmt.Sprintf(CLAB_HOSTENTRY_PREFIX+"\n", labname))
+	buff.WriteString(v4buff.String())
+	buff.WriteString(v6buff.String())
+	buff.WriteString(fmt.Sprintf(CLAB_HOSTENTRY_POSTFIX+"\n", labname))
+	return buff.Bytes()
+}
+
+func DeleteEntriesFromHostsFile(labname string) error {
+	if labname == "" {
+		return fmt.Errorf("missing containerlab name")
+	}
+	f, err := os.OpenFile("/etc/hosts", os.O_RDWR, 0644) // skipcq: GSC-G302
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	reader := bufio.NewReader(f)
+	skiplines := false
+	output := bytes.Buffer{}
+	prefix := fmt.Sprintf(CLAB_HOSTENTRY_PREFIX, labname)
+	postfix := fmt.Sprintf(CLAB_HOSTENTRY_POSTFIX, labname)
+	for {
+		line, err := reader.ReadString(byte('\n'))
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(line) == postfix {
+			skiplines = false
+			continue
+		} else if strings.TrimSpace(line) == prefix || skiplines {
+			skiplines = true
+			continue
+		}
+		output.WriteString(line)
+	}
+	if skiplines {
+		// if skiplines is not false, we did not find the end
+		// so we should not mess with /etc/hosts
+		return fmt.Errorf("issue cleaning up /etc/hosts file. Please do so manually")
+	}
+	err = f.Truncate(0)
+	if err != nil {
+		return err
+	}
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(output.Bytes())
+	return err
+}

--- a/clab/general.go
+++ b/clab/general.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	ClabHostEntryPrefix  = "###### CLAB-%s-START ######"
-	ClabHostEntryPostfix = "###### CLAB-%s-END ######"
+	clabHostEntryPrefix  = "###### CLAB-%s-START ######"
+	clabHostEntryPostfix = "###### CLAB-%s-END ######"
 )
 
 func AppendHostsFileEntries(containers []types.GenericContainer, labname string) error {
@@ -53,7 +53,8 @@ func generateHostsEntries(containers []types.GenericContainer, labname string) [
 	entries := bytes.Buffer{}
 	v6entries := bytes.Buffer{}
 
-	fmt.Fprintf(&entries, ClabHostEntryPrefix+"\n", labname)
+	fmt.Fprintf(&entries, clabHostEntryPrefix, labname)
+	entries.WriteByte('\n')
 
 	for _, cont := range containers {
 		if len(cont.Names) == 0 {
@@ -70,7 +71,8 @@ func generateHostsEntries(containers []types.GenericContainer, labname string) [
 	}
 
 	entries.Write(v6entries.Bytes())
-	fmt.Fprintf(&entries, ClabHostEntryPostfix+"\n", labname)
+	fmt.Fprintf(&entries, clabHostEntryPostfix, labname)
+	entries.WriteByte('\n')
 	return entries.Bytes()
 }
 
@@ -91,8 +93,8 @@ func DeleteEntriesFromHostsFile(labname string) error {
 	reader := bufio.NewReader(f)
 	skiplines := false
 	output := bytes.Buffer{}
-	prefix := fmt.Sprintf(ClabHostEntryPrefix, labname)
-	postfix := fmt.Sprintf(ClabHostEntryPostfix, labname)
+	prefix := fmt.Sprintf(clabHostEntryPrefix, labname)
+	postfix := fmt.Sprintf(clabHostEntryPostfix, labname)
 	for {
 		line, err := reader.ReadString(byte('\n'))
 		if err == io.EOF {

--- a/clab/general.go
+++ b/clab/general.go
@@ -13,9 +13,9 @@ import (
 	"github.com/srl-labs/containerlab/types"
 )
 
-var (
-	CLAB_HOSTENTRY_PREFIX  = "###### CLAB-%s-START ######"
-	CLAB_HOSTENTRY_POSTFIX = "###### CLAB-%s-END ######"
+const (
+	ClabHostEntryPrefix  = "###### CLAB-%s-START ######"
+	ClabHostEntryPostfix = "###### CLAB-%s-END ######"
 )
 
 func AppendHostsFileEntries(containers []types.GenericContainer, labname string) error {
@@ -27,7 +27,7 @@ func AppendHostsFileEntries(containers []types.GenericContainer, labname string)
 	if err != nil {
 		return err
 	}
-	data := GenerateHostsEntries(containers, labname)
+	data := generateHostsEntries(containers, labname)
 	if len(data) == 0 {
 		return nil
 	}
@@ -48,11 +48,12 @@ func AppendHostsFileEntries(containers []types.GenericContainer, labname string)
 }
 
 // hostEntries builds an /etc/hosts compliant text blob (as []byte]) for containers ipv4/6 address<->name pairs
-func GenerateHostsEntries(containers []types.GenericContainer, labname string) []byte {
-	entries := strings.Builder{}
-	v6entries := strings.Builder{}
+func generateHostsEntries(containers []types.GenericContainer, labname string) []byte {
 
-	entries.WriteString(fmt.Sprintf(CLAB_HOSTENTRY_PREFIX+"\n", labname))
+	entries := bytes.Buffer{}
+	v6entries := bytes.Buffer{}
+
+	fmt.Fprintf(&entries, ClabHostEntryPrefix+"\n", labname)
 
 	for _, cont := range containers {
 		if len(cont.Names) == 0 {
@@ -68,9 +69,9 @@ func GenerateHostsEntries(containers []types.GenericContainer, labname string) [
 		}
 	}
 
-	entries.WriteString(v6entries.String())
-	entries.WriteString(fmt.Sprintf(CLAB_HOSTENTRY_POSTFIX+"\n", labname))
-	return []byte(entries.String())
+	entries.Write(v6entries.Bytes())
+	fmt.Fprintf(&entries, ClabHostEntryPostfix+"\n", labname)
+	return entries.Bytes()
 }
 
 func DeleteEntriesFromHostsFile(labname string) error {
@@ -90,8 +91,8 @@ func DeleteEntriesFromHostsFile(labname string) error {
 	reader := bufio.NewReader(f)
 	skiplines := false
 	output := bytes.Buffer{}
-	prefix := fmt.Sprintf(CLAB_HOSTENTRY_PREFIX, labname)
-	postfix := fmt.Sprintf(CLAB_HOSTENTRY_POSTFIX, labname)
+	prefix := fmt.Sprintf(ClabHostEntryPrefix, labname)
+	postfix := fmt.Sprintf(ClabHostEntryPostfix, labname)
 	for {
 		line, err := reader.ReadString(byte('\n'))
 		if err == io.EOF {

--- a/clab/general.go
+++ b/clab/general.go
@@ -36,10 +36,6 @@ func AppendHostsFileEntries(containers []types.GenericContainer, labname string)
 		return err
 	}
 	defer f.Close()
-	_, err = f.WriteString("\n")
-	if err != nil {
-		return err
-	}
 	_, err = f.Write(data)
 	if err != nil {
 		return err

--- a/clab/hostsfile.go
+++ b/clab/hostsfile.go
@@ -54,7 +54,7 @@ func AppendHostsFileEntries(containers []types.GenericContainer, labname string)
 	return nil
 }
 
-// generateHostsEntries hostEntries builds an /etc/hosts compliant text blob (as []byte]) for containers ipv4/6 address<->name pairs
+// generateHostsEntries builds an /etc/hosts compliant text blob (as []byte]) for containers ipv4/6 address<->name pairs
 func generateHostsEntries(containers []types.GenericContainer, labname string) []byte {
 
 	entries := bytes.Buffer{}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -175,7 +175,7 @@ var deployCmd = &cobra.Command{
 		// run links postdeploy creation (ceos links creation)
 		c.CreateLinks(ctx, linkWorkers, true)
 
-		log.Info("Writing /etc/hosts file")
+		log.Info("Adding containerlab host entries to /etc/hosts file")
 		err = clab.AppendHostsFileEntries(containers, c.Config.Name)
 		if err != nil {
 			log.Errorf("failed to create hosts file: %v", err)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -164,7 +164,7 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 		}
 	}
 
-	log.Info("Removing container entries from /etc/hosts file")
+	log.Info("Removing containerlab host entries from /etc/hosts file")
 	err = clab.DeleteEntriesFromHostsFile(c.Config.Name)
 	if err != nil {
 		return err

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -272,3 +272,19 @@ By specifying `mgmt-net` name of the node in the endpoint definition we tell con
 This is best illustrated with the following diagram:
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:14,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
+
+## DNS
+When containerlab finishes the nodes deployment, it also creates static DNS entries inside the `/etc/hosts` file so that users can access the nodes using their DNS names.
+
+The DNS entries are created for each node's IPv4/6 address, and follow the pattern - `clab-$labName-$nodeName`.
+
+For a lab named `demo` with two nodes named `l1` and `l2` containerlab will create the following section inside the `/etc/hosts` file.
+
+```
+###### CLAB-demo-START ######
+172.20.20.2     clab-demo-l1
+172.20.20.3     clab-demo-l2
+2001:172:20:20::2       clab-demo-l1
+2001:172:20:20::3       clab-demo-l2
+###### CLAB-demo-END ######
+```

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -15,6 +15,12 @@ ${n2-ipv4}        172.20.20.100/24
 ${n2-ipv6}        2001:172:20:20::100/64
 
 *** Test Cases ***
+Verify number of Hosts entries before deploy
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    cat /etc/hosts | wc -l
+    Log    ${output}
+    Set Suite Variable  ${HostsFileLines}   ${output}
+
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
@@ -110,7 +116,7 @@ Verify l1 environment has MYVAR variable set
 Verify Hosts entries exist
     [Documentation]     Verification that the expected /etc/hosts entries are created. We are also checking for the HEADER and FOOTER values here, which also contain the lab name.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    cat /etc/hosts | grep "2-linux-nodes" | wc -l
+    ...    cat /etc/hosts | grep "${lab-name}" | wc -l
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    6
@@ -124,10 +130,16 @@ Destroy ${lab-name} lab
 Verify Hosts entries are gone
     [Documentation]     Verification that the previously created /etc/hosts entries are properly removed. (Again including HEADER and FOOTER).
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    cat /etc/hosts | grep "2-linux-nodes" | wc -l
+    ...    cat /etc/hosts | grep "${lab-name}" | wc -l
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0
+   
+Verify Hosts file has same number of lines
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    cat /etc/hosts | wc -l
+    Log    ${output}
+    Should Be Equal As Integers    ${HostsFileLines}    ${output}
 
 *** Keywords ***
 Setup

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -107,11 +107,27 @@ Verify l1 environment has MYVAR variable set
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    MYVAR is SET
 
+Verify Hosts entries exist
+    [Documentation]     Verification that the expected /etc/hosts entries are created. We are also checking for the HEADER and FOOTER values here, which also contain the lab name.
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    cat /etc/hosts | grep "2-linux-nodes" | wc -l
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    6
+
 Destroy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
+
+Verify Hosts entries are gone
+    [Documentation]     Verification that the previously created /etc/hosts entries are properly removed. (Again including HEADER and FOOTER).
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    cat /etc/hosts | grep "2-linux-nodes" | wc -l
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    0
 
 *** Keywords ***
 Setup


### PR DESCRIPTION
As outlined in #236 /etc/hosts entries are now being embedded in a per Lab (comment based) signature.
This is then used to delete entries on lab destroy.
```
###### CLAB-<LABNAME>-START ######
[<ENTRIES>]
###### CLAB-<LABNAME>-END ######
```