### PR TITLE
Supress nodes in config debug output

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -21,6 +21,9 @@ var TemplateNames []string
 // path to additional templates
 var TemplatePaths []string
 
+// debug count
+var DebugCount int
+
 type NodeConfig struct {
 	TargetNode *types.NodeConfig
 	// All the variables used to render the template
@@ -116,10 +119,27 @@ func (c *NodeConfig) Print(printLines int, forceDebug ...bool) {
 
 	if log.IsLevelEnabled(log.DebugLevel) || len(forceDebug) > 0 {
 		s.WriteString(" vars = ")
+		var saved_nodes Dict
+		restore := false
+		if DebugCount < 3 {
+			saved_nodes, restore = c.Vars[vkNodes].(Dict)
+			if restore {
+				var n strings.Builder
+				n.WriteRune('{')
+				for k := range saved_nodes {
+					fmt.Fprintf(&n, "%s: {...}, ", k)
+				}
+				n.WriteRune('}')
+				c.Vars[vkNodes] = n.String()
+			}
+		}
 		vars, err := yaml.Marshal(c.Vars)
 		if err != nil {
 			log.Warnf("error printing vars for node %s: %s", c.TargetNode.ShortName, err)
 			s.WriteString(err.Error())
+		}
+		if restore {
+			c.Vars[vkNodes] = saved_nodes
 		}
 		if len(vars) > 0 {
 			s.Write(vars)

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -92,7 +92,7 @@ func RenderAll(nodes map[string]nodes.Node, links map[int]*types.Link) (map[stri
 			var buf strings.Builder
 			err := tmpl.ExecuteTemplate(&buf, tmplN, vars)
 			if err != nil {
-				res[nodeName].Print(0, true)
+				res[nodeName].Print(true, true)
 				return nil, err
 			}
 
@@ -106,18 +106,17 @@ func RenderAll(nodes map[string]nodes.Node, links map[int]*types.Link) (map[stri
 
 // Implement stringer for NodeConfig
 func (c *NodeConfig) String() string {
-
 	s := fmt.Sprintf("%s: %v", c.TargetNode.ShortName, c.Info)
 	return s
 }
 
 // Print the config
-func (c *NodeConfig) Print(printLines int, forceDebug ...bool) {
+func (c *NodeConfig) Print(vars, rendered bool) {
 	var s strings.Builder
 
 	s.WriteString(c.TargetNode.ShortName)
 
-	if log.IsLevelEnabled(log.DebugLevel) || len(forceDebug) > 0 {
+	if vars {
 		s.WriteString(" vars = ")
 		var saved_nodes Dict
 		restore := false
@@ -146,14 +145,11 @@ func (c *NodeConfig) Print(printLines int, forceDebug ...bool) {
 		}
 	}
 
-	if printLines > 0 {
+	if rendered {
 		for idx, conf := range c.Data {
 			fmt.Fprintf(&s, "\n  Template %s for %s = [[", c.Info[idx], c.TargetNode.ShortName)
 
-			cl := strings.SplitN(conf, "\n", printLines+1)
-			if len(cl) > printLines {
-				cl[printLines] = "..."
-			}
+			cl := strings.Split(conf, "\n")
 			for _, l := range cl {
 				s.WriteString("\n     ")
 				s.WriteString(l)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -25,6 +25,7 @@ var configCmd = &cobra.Command{
 		var err error
 
 		transport.DebugCount = debugCount
+		config.DebugCount = debugCount
 
 		c, err := clab.NewContainerLab(
 			clab.WithTimeout(timeout),
@@ -101,7 +102,7 @@ var configCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.Flags().StringSliceVarP(&config.TemplatePaths, "template-path", "p", []string{}, "comma separated list of paths to search for templates")
-	configCmd.MarkFlagDirname("template-path")
+	_ = configCmd.MarkFlagDirname("template-path")
 	configCmd.Flags().StringSliceVarP(&config.TemplateNames, "template-list", "l", []string{}, "comma separated list of template names to render")
 	configCmd.Flags().IntVarP(&printLines, "check", "c", 0, "render templates in dry-run mode & print N lines of rendered config")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ var configCmd = &cobra.Command{
 					c.Print(true, true)
 					return nil
 				}
-				log.Warnf("Invalid command line option for check. It needs to be either 'template'(default), 'vars', 'all' or a valid node name")
+				log.Warnf("Invalid command line option for check. Options: 'template'(default), 'vars', 'all' or a valid node name")
 				pt = true
 			}
 			for _, c := range allConfig {
@@ -116,6 +116,6 @@ func init() {
 	configCmd.Flags().StringSliceVarP(&config.TemplatePaths, "template-path", "p", []string{}, "comma separated list of paths to search for templates")
 	_ = configCmd.MarkFlagDirname("template-path")
 	configCmd.Flags().StringSliceVarP(&config.TemplateNames, "template-list", "l", []string{}, "comma separated list of template names to render")
-	configCmd.Flags().StringVarP(&check, "check", "c", "", "render templates in dry-run mode & print N lines of rendered config")
+	configCmd.Flags().StringVarP(&check, "check", "c", "", "render templates in dry-run mode & print either 'template', 'vars', 'all' or a specific node")
 	configCmd.Flags().Lookup("check").NoOptDefVal = "template"
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,8 +11,8 @@ import (
 	"github.com/srl-labs/containerlab/nodes"
 )
 
-// Only print config locally, don't send to the node
-var printLines int
+// Dryrun and print config
+var check string
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
@@ -41,9 +41,21 @@ var configCmd = &cobra.Command{
 			return err
 		}
 
-		if printLines > 0 {
+		if check != "" {
+
+			pv := check == "all" || check == "vars"
+			pt := check == "all" || check == "template"
+
+			if !(pv || pt) {
+				if c, ok := allConfig[check]; ok {
+					c.Print(true, true)
+					return nil
+				}
+				log.Warnf("Invalid command line option for check. It needs to be either 'template'(default), 'vars', 'all' or a valid node name")
+				pt = true
+			}
 			for _, c := range allConfig {
-				c.Print(printLines)
+				c.Print(pv, pt)
 			}
 			return nil
 		}
@@ -104,5 +116,6 @@ func init() {
 	configCmd.Flags().StringSliceVarP(&config.TemplatePaths, "template-path", "p", []string{}, "comma separated list of paths to search for templates")
 	_ = configCmd.MarkFlagDirname("template-path")
 	configCmd.Flags().StringSliceVarP(&config.TemplateNames, "template-list", "l", []string{}, "comma separated list of template names to render")
-	configCmd.Flags().IntVarP(&printLines, "check", "c", 0, "render templates in dry-run mode & print N lines of rendered config")
+	configCmd.Flags().StringVarP(&check, "check", "c", "", "render templates in dry-run mode & print N lines of rendered config")
+	configCmd.Flags().Lookup("check").NoOptDefVal = "template"
 }


### PR DESCRIPTION
Debug output of variables is currently very long due to the fact that all nodes variables are included under 'nodes'

This PR compresses other nodes:

The output becomes:

```
INFO[0000] p1 vars = {
      "links": [
            {
                  "far": {
                        "ip": "1.3.8.0/31",
                        "isis_iid": "0",
                        "name": "to_p1",
                        "node": "asbr1",
                        "port": "1/1/c2/1",
                        "sid_idx": "3"
                  },
                  "ip": "1.3.8.1/31",
                  "isis_iid": "0",
                  "name": "to_asbr1",
                  "port": "1/1/c1/1",
                  "sid_idx": "8"
            },
            {
                  "far": {
                        "ip": "1.2.8.0/31",
                        "isis_iid": "0",
                        "name": "to_p1",
                        "node": "abr1",
                        "port": "1/1/c1/1",
                        "sid_idx": "2"
                  },
                  "ip": "1.2.8.1/31",
                  "isis_iid": "0",
                  "name": "to_abr1",
                  "port": "1/1/c2/1",
                  "sid_idx": "8"
            }
      ],
      "node": "p1",
      "nodes": "{p1: {...}, pe1: {...}, pe2: {...}, abr1: {...}, asbr1: {...}, asbr2: {...}, }",
      "r20": "1",
      "role": "vr-sros",
      "systemip": "8.8.8.8/32"
  }
```

The important part here is 
```
      "nodes": "{p1: {...}, pe1: {...}, pe2: {...}, abr1: {...}, asbr1: {...}, asbr2: {...}, }",
```

which makes the total output about 1/7th of what it is today.

Note that with the debug flags `-d -c 1` you do see the other node individually as well

It is also possible to see the full output using a debug count of 3 or higher `-d 3`
