### PR TITLE
cvx02 lab fix - host will wait for 2 interfaces to be connected

### DIFF
--- a/lab-examples/cvx02/topo.clab.yml
+++ b/lab-examples/cvx02/topo.clab.yml
@@ -13,6 +13,7 @@ topology:
       image: networkop/host:ifreload
       binds:
         - h1/interfaces:/etc/network/interfaces
+      cmd: 2 # wait for 2 interfaces to be connected: eth0 + eth1
 
   links:
     - endpoints: ["sw1:swp12", "h1:eth1"]


### PR DESCRIPTION
There is [an issue](https://github.com/networkop/cx/issues/1) with host configuration being applied before all links are connected by containerlab. This should fix it.