### PR TITLE
cvx-bump-ram

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -211,6 +211,8 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		Sandbox:         c.Config.Topology.GetNodeSandbox(nodeName),
 		Kernel:          c.Config.Topology.GetNodeKernel(nodeName),
 		Runtime:         c.Config.Topology.GetNodeRuntime(nodeName),
+		CPU:             c.Config.Topology.GetNodeCPU(nodeName),
+		RAM:             c.Config.Topology.GetNodeRAM(nodeName),
 	}
 
 	log.Debugf("node config: %+v", nodeCfg)

--- a/nodes/cvx/cvx.go
+++ b/nodes/cvx/cvx.go
@@ -53,12 +53,15 @@ func (c *cvx) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 		return fmt.Errorf("failed to parse OCI image ref %q: %s", cfg.Image, err)
 	}
 
-	ram, ok := memoryReqs[ociRef.Ref().Tag()]
-	cfg.RAM = ram
+	// if RAM is not statically set, apply the defaults
+	if cfg.RAM == "" {
+		ram, ok := memoryReqs[ociRef.Ref().Tag()]
+		cfg.RAM = ram
 
-	// by default setting the limit to 768MB
-	if !ok {
-		cfg.RAM = "768MB"
+		// by default setting the limit to 768MB
+		if !ok {
+			cfg.RAM = "768MB"
+		}
 	}
 
 	return nil

--- a/runtime/ignite/iginite.go
+++ b/runtime/ignite/iginite.go
@@ -154,6 +154,14 @@ func (c *IgniteRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 
 	vm := c.baseVM.DeepCopy()
 
+	// CL 4.4.0 requires a slight memory bump
+	newMemoryStr := "768MB"
+	cvxMem, err := meta.NewSizeFromString(newMemoryStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q as memory value: %s", newMemoryStr, err)
+	}
+	vm.Spec.Memory = cvxMem
+
 	ociRef, err := meta.NewOCIImageRef(node.Sandbox)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse OCI image ref %q: %s", node.Sandbox, err)

--- a/runtime/ignite/iginite.go
+++ b/runtime/ignite/iginite.go
@@ -154,13 +154,14 @@ func (c *IgniteRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 
 	vm := c.baseVM.DeepCopy()
 
-	// CL 4.4.0 requires a slight memory bump
-	newMemoryStr := "768MB"
-	cvxMem, err := meta.NewSizeFromString(newMemoryStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse %q as memory value: %s", newMemoryStr, err)
+	// updating the node RAM if it's set
+	if node.RAM != "" {
+		ram, err := meta.NewSizeFromString(node.RAM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q as memory value: %s", node.RAM, err)
+		}
+		vm.Spec.Memory = ram
 	}
-	vm.Spec.Memory = cvxMem
 
 	ociRef, err := meta.NewOCIImageRef(node.Sandbox)
 	if err != nil {

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -34,6 +34,10 @@ type NodeDefinition struct {
 	Kernel  string `yaml:"kernel,omitempty"`
 	// Override container runtime
 	Runtime string `yaml:"runtime,omitempty"`
+	// Set node CPU (cgroup or hypervisor)
+	CPU string `yaml:"cpu,omitempty"`
+	// Set node RAM (cgroup or hypervisor)
+	RAM string `yaml:"ram,omitempty"`
 }
 
 func (n *NodeDefinition) GetKind() string {
@@ -181,4 +185,18 @@ func (n *NodeDefinition) GetNodeRuntime() string {
 		return ""
 	}
 	return n.Runtime
+}
+
+func (n *NodeDefinition) GetNodeCPU() string {
+	if n == nil {
+		return ""
+	}
+	return n.CPU
+}
+
+func (n *NodeDefinition) GetNodeRAM() string {
+	if n == nil {
+		return ""
+	}
+	return n.RAM
 }

--- a/types/topology.go
+++ b/types/topology.go
@@ -324,6 +324,32 @@ func (t *Topology) GetNodeRuntime(name string) string {
 	return ""
 }
 
+func (t *Topology) GetNodeCPU(name string) string {
+	if ndef, ok := t.Nodes[name]; ok {
+		if ndef.GetNodeCPU() != "" {
+			return ndef.GetNodeCPU()
+		}
+		if t.GetKind(t.GetNodeKind(name)).GetNodeCPU() != "" {
+			return t.GetKind(t.GetNodeKind(name)).GetNodeCPU()
+		}
+		return t.GetDefaults().GetNodeCPU()
+	}
+	return ""
+}
+
+func (t *Topology) GetNodeRAM(name string) string {
+	if ndef, ok := t.Nodes[name]; ok {
+		if ndef.GetNodeRAM() != "" {
+			return ndef.GetNodeRAM()
+		}
+		if t.GetKind(t.GetNodeKind(name)).GetNodeRAM() != "" {
+			return t.GetKind(t.GetNodeKind(name)).GetNodeRAM()
+		}
+		return t.GetDefaults().GetNodeRAM()
+	}
+	return ""
+}
+
 //resolvePath resolves a string path by expanding `~` to home dir or getting Abs path for the given path
 func resolvePath(p string) (string, error) {
 	if p == "" {

--- a/types/types.go
+++ b/types/types.go
@@ -98,6 +98,8 @@ type NodeConfig struct {
 	Sandbox, Kernel string
 	// Configured container runtime
 	Runtime string
+	// Resource requirements
+	CPU, RAM string
 }
 
 // GenerateConfig generates configuration for the nodes


### PR DESCRIPTION
Slight memory bump for for the latest cvx image. Doing this globally for the entire ignite runtime since a) it's only used by cvx ATM b) `type NodeConfig struct` doesn't have a memory field. 