### PR TITLE
fix frr01 example lab file and container names

### DIFF
--- a/lab-examples/frr01/PC-interfaces.sh
+++ b/lab-examples/frr01/PC-interfaces.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
-sudo docker exec -d clab-frrlab-PC1 ip link set eth1 up
-sudo docker exec -d clab-frrlab-PC1 ip addr add 192.168.11.2/24 dev eth1
-sudo docker exec -d clab-frrlab-PC1 ip route add 192.168.0.0/16 via 192.168.11.1 dev eth1
-sudo docker exec -d clab-frrlab-PC1 ip route add 10.10.10.0/24 via 192.168.11.1 dev eth1
+sudo docker exec -d clab-frr01-PC1 ip link set eth1 up
+sudo docker exec -d clab-frr01-PC1 ip addr add 192.168.11.2/24 dev eth1
+sudo docker exec -d clab-frr01-PC1 ip route add 192.168.0.0/16 via 192.168.11.1 dev eth1
+sudo docker exec -d clab-frr01-PC1 ip route add 10.10.10.0/24 via 192.168.11.1 dev eth1
 
-sudo docker exec -d clab-frrlab-PC2 ip link set eth1 up
-sudo docker exec -d clab-frrlab-PC2 ip addr add 192.168.12.2/24 dev eth1
-sudo docker exec -d clab-frrlab-PC2 ip route add 192.168.0.0/16 via 192.168.12.1 dev eth1
-sudo docker exec -d clab-frrlab-PC2 ip route add 10.10.10.0/24 via 192.168.12.1 dev eth1
+sudo docker exec -d clab-frr01-PC2 ip link set eth1 up
+sudo docker exec -d clab-frr01-PC2 ip addr add 192.168.12.2/24 dev eth1
+sudo docker exec -d clab-frr01-PC2 ip route add 192.168.0.0/16 via 192.168.12.1 dev eth1
+sudo docker exec -d clab-frr01-PC2 ip route add 10.10.10.0/24 via 192.168.12.1 dev eth1
 
-sudo docker exec -d clab-frrlab-PC3 ip link set eth1 up
-sudo docker exec -d clab-frrlab-PC3 ip addr add 192.168.13.2/24 dev eth1
-sudo docker exec -d clab-frrlab-PC3 ip route add 192.168.0.0/16 via 192.168.13.1 dev eth1
-sudo docker exec -d clab-frrlab-PC3 ip route add 10.10.10.0/24 via 192.168.13.1 dev eth1
+sudo docker exec -d clab-frr01-PC3 ip link set eth1 up
+sudo docker exec -d clab-frr01-PC3 ip addr add 192.168.13.2/24 dev eth1
+sudo docker exec -d clab-frr01-PC3 ip route add 192.168.0.0/16 via 192.168.13.1 dev eth1
+sudo docker exec -d clab-frr01-PC3 ip route add 10.10.10.0/24 via 192.168.13.1 dev eth1

--- a/lab-examples/frr01/run.sh
+++ b/lab-examples/frr01/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-clab deploy --topo frrlab.yml
+clab deploy --topo frr01.clab.yml
 ./PC-interfaces.sh


### PR DESCRIPTION
Updates lab-example/frr01 such that _run.sh_ uses the correct topology file, and _PC-interfaces.sh_ uses the correct container names.