### PR TITLE
changed default srl type to ixrd2

### DIFF
--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -159,7 +159,7 @@ func TestTypeInit(t *testing.T) {
 		"undefined_type_returns_default": {
 			got:  "test_data/topo1.yml",
 			node: "node2",
-			want: "ixr6",
+			want: "ixrd2",
 		},
 		"node_type_override_kind_type": {
 			got:  "test_data/topo2.yml",
@@ -369,7 +369,7 @@ func TestLabelsInit(t *testing.T) {
 				"containerlab":      "topo1",
 				"clab-node-name":    "node2",
 				"clab-node-kind":    "srl",
-				"clab-node-type":    "ixr6",
+				"clab-node-type":    "ixrd2",
 				"clab-node-group":   "",
 				"clab-node-lab-dir": "./clab-topo1/node2",
 				"clab-topo-file":    "./test_data/topo1.yml",

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -34,7 +34,7 @@ var interfaceFormat = map[string]string{
 var supportedKinds = []string{"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros", "vr-vmx", "vr-xrv9k"}
 
 const (
-	defaultSRLType     = "ixr6"
+	defaultSRLType     = "ixrd2"
 	defaultNodePrefix  = "node"
 	defaultGroupPrefix = "tier"
 )

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -127,9 +127,9 @@ var nodesTestSet = map[string]struct {
 		},
 		out: nodesOutput{
 			out: []nodesDef{
-				{numNodes: 1, kind: "srl", typ: "ixr6"},
-				{numNodes: 2, kind: "srl", typ: "ixr6"},
-				{numNodes: 3, kind: "srl", typ: "ixr6"},
+				{numNodes: 1, kind: "srl", typ: "ixrd2"},
+				{numNodes: 2, kind: "srl", typ: "ixrd2"},
+				{numNodes: 3, kind: "srl", typ: "ixrd2"},
 			},
 			err: nil,
 		},
@@ -142,7 +142,7 @@ var nodesTestSet = map[string]struct {
 		out: nodesOutput{
 			out: []nodesDef{
 				{numNodes: 1, kind: "linux", typ: ""},
-				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 2, kind: "srl", typ: "ixrd2"},
 				{numNodes: 3, kind: "ceos", typ: ""},
 			},
 			err: nil,
@@ -156,7 +156,7 @@ var nodesTestSet = map[string]struct {
 		out: nodesOutput{
 			out: []nodesDef{
 				{numNodes: 1, kind: "srl", typ: "ixrd"},
-				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 2, kind: "srl", typ: "ixrd2"},
 				{numNodes: 3, kind: "ceos", typ: ""},
 			},
 			err: nil,
@@ -169,7 +169,7 @@ var nodesTestSet = map[string]struct {
 		},
 		out: nodesOutput{
 			out: []nodesDef{
-				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 2, kind: "srl", typ: "ixrd2"},
 			},
 			err: nil,
 		},

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -38,7 +38,7 @@ For SR Linux nodes [`type`](../nodes.md#type) defines the hardware variant that 
 
 The available type values are: `ixr6`, `ixr10`, `ixrd1`, `ixrd2`, `ixrd3` which correspond to a hardware variant of Nokia 7250/7220 IXR chassis.
 
-By default, `ixr6` type will be used by containerlab.
+By default, `ixrd2` type will be used by containerlab.
 
 Based on the provided type, containerlab will generate the topology file that will be mounted to SR Linux container and make it boot in a chosen HW variant.
 ### Node configuration

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	srlDefaultType = "ixr6"
+	srlDefaultType = "ixrd2"
 )
 
 var (


### PR DESCRIPTION
prev. default srl type - ixr6 - is a spine hw variant which doesn't support services
the idea behind changing that to ixrd2 is to minimize the number of lines in the config, since leafs outnumber spines