### PR TITLE
Replacing usage of config in examples by startup-config

### DIFF
--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -135,7 +135,7 @@ topology:
   nodes:
     ceos:
       kind: ceos
-      config: myconfig.conf
+      startup-config: myconfig.conf
 ```
 
 When a config file is passed via `config` parameter, it will override any configuration that may have left upon lab destroy.

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -138,7 +138,7 @@ topology:
       startup-config: myconfig.conf
 ```
 
-When a config file is passed via `config` parameter, it will override any configuration that may have left upon lab destroy.
+When a config file is passed via `startup-config` parameter, it will override any configuration that may have left upon lab destroy.
 
 With such topology file containerlab is instructed to take a file `myconfig.conf` from the current working directory, copy it to the lab directory for that specific node under the `/flash/startup-config` name and mount that dir to the container. This will result in this config to act as a startup config for the node.
 

--- a/docs/manual/kinds/crpd.md
+++ b/docs/manual/kinds/crpd.md
@@ -120,7 +120,7 @@ topology:
   nodes:
     crpd:
       kind: crpd
-      config: myconfig.conf
+      startup-config: myconfig.conf
 ```
 
 With such topology file containerlab is instructed to take a file `myconfig.conf` from the current working directory, copy it to the lab directory for that specific node under the `/config/juniper.conf` name and mount that dir to the container. This will result in this config to act as a startup config for the node.

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -129,7 +129,7 @@ topology:
   nodes:
     sros:
       kind: vr-sros
-      config: myconfig.txt
+      startup-config: myconfig.txt
 ```
 
 With such topology file containerlab is instructed to take a file `myconfig.txt` from the current working directory, copy it to the lab directory for that specific node under the `/tftpboot/config.txt` name and mount that dir to the container. This will result in this config to act as a startup config for the node.

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -230,7 +230,7 @@ topology:
     srl:
       kind: srl
       image: ghcr.io/nokia/srlinux
-      config: test-srl-config.json
+      startup-config: test-srl-config.json
   links:
     - endpoints: ["srl:e1-1", "host:srl_e1-1"]
 ```

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -10,7 +10,7 @@ topology:
       kind: srl
       type: ixrd2
       image: ghcr.io/nokia/srlinux
-      config: /root/mylab/node1.cfg
+      startup-config: /root/mylab/node1.cfg
       binds:
         - /usr/local/bin/gobgp:/root/gobgp
         - /root/files:/root/files:ro


### PR DESCRIPTION
I got some issues recently trying to use the `config` property to pass a startup config file as mentioned in #567.

The documentation was only partially updated and some examples where still using the `config` property.

This MR fixes this.