### PR TITLE
allow custom lab prefix

### DIFF
--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -42,6 +42,35 @@ The name is a free-formed string, though it is better not to use dashes (`-`) as
 
 When containerlab starts the containers, their names will be generated using the following pattern: `clab-{{lab-name}}-{{node-name}}`. The lab name here is used to make the container's names unique between two different labs even if the nodes are named the same.
 
+### Prefix
+It is possible to change the `clab` prefix that containerlab adds to node names and configuration directory by means of the `prefix` parameter. The `prefix` parameter follows the below mentioned logic:
+
+1. When `prefix` is not present in the topology file, the default `clab` prefix will apply.
+2. When set to some value, for example `cl`, this string value will be used as a prefix for container names and lab's configuration directory.
+3. When set to empty string the prefix will not be used at all, and nodes and lab directory will not have the prefix element.
+
+Example:
+
+```yaml
+name: mylab
+prefix: c
+nodes:
+  n1:
+   # <some config>
+```
+
+With a prefix set to `c`, the container name for node `n1` will be `c-mylab-n1`, and the lab directory will be named as `c-mylab`.
+
+```yaml
+name: mylab
+prefix: ""
+nodes:
+  n1:
+   # <some config>
+```
+
+When prefix is set to empty string like in the example above, the container name will be `mylab-n1` and the lab directory will be named simply `mylab`
+
 ### Topology
 The topology object inside the topology definition is the core element of the file. Under the `topology` element you will find all the main building blocks of a topology such as `nodes`, `kinds`, `defaults` and `links`.
 

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -227,6 +227,10 @@
             "description": "topology name",
             "type": "string"
         },
+        "prefix": {
+            "description": "lab prefix",
+            "type": "string"
+        },
         "mgmt": {
             "description": "configuration container for management network",
             "markdownDescription": "configuration container for [management network](https://containerlab.srlinux.dev/manual/network/#management-network)",


### PR DESCRIPTION
This PR allows setting a custom prefix for the lab, instead of `clab`.
The prefix is configured in the topology file using field `prefix`.
For e.g:
```yaml
name: lab1
prefix: custom-prefix
topology:
  nodes:
    node1:
```
- `node1` longName will be `custom-prefix-lab1-node1`
- the lab directory will be `custom-prefix-lab1`

If not set ( not present ) the default `clab` is used.
If present and set to `""`, the default does not apply. In this case, the `node` longName will be `lab1-node1` and the lab directory will be `lab1`

The prefix value impacts the nodes longName, the hosts entries, the lab directory name,.. but it does not impact the docker labels, those still have prefix `clab-`

