### PR TITLE
directory based srlinux mounts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,7 +96,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        runtime: ["docker", "containerd"]
+        runtime:
+          - "docker"
+          # - "containerd"
     needs:
       - unit-test
     steps:
@@ -139,7 +141,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        runtime: ["docker", "containerd"]
+        runtime:
+          - "docker"
+          # - "containerd"
     needs:
       - unit-test
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -135,6 +135,41 @@ jobs:
           name: 03-basic-ceos-log
           path: ./tests/out/*.html
 
+  srlinux-basic-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        runtime: ["docker", "containerd"]
+    needs:
+      - unit-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Build containerlab
+        run: go build && sudo mv ./containerlab /usr/bin/containerlab
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install robotframework
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+      - name: Run srlinux tests
+        run: |
+          bash ./tests/rf-run.sh ${{ matrix.runtime }} ./tests/02-basic-srl
+      # upload test reports as a zip file
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: 02-basic-srl-log
+          path: ./tests/out/*.html
+
   docs-test:
     runs-on: ubuntu-20.04
     needs: file-changes

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -105,9 +105,9 @@ func (s *srl) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 		s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(filepath.Join(s.cfg.LabDir, "license.key"), ":/opt/srlinux/etc/license.key:ro"))
 	}
 
-	// mount config file
-	cfgPath := filepath.Join(s.cfg.LabDir, "config.json")
-	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(cfgPath, ":/etc/opt/srlinux/config.json:rw"))
+	// mount config directory
+	cfgPath := filepath.Join(s.cfg.LabDir, "config")
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(cfgPath, ":/etc/opt/srlinux/:rw"))
 
 	// mount srlinux topology
 	topoPath := filepath.Join(s.cfg.LabDir, "topology.yml")
@@ -223,7 +223,8 @@ func createSRLFiles(nodeCfg *types.NodeConfig) error {
 	// generate a startup config file
 	// if the node has a `startup-config:` statement, the file specified in that section
 	// will be used as a template in GenerateConfig()
-	dst = path.Join(nodeCfg.LabDir, "config.json")
+	utils.CreateDirectory(path.Join(nodeCfg.LabDir, "config"), 0777)
+	dst = path.Join(nodeCfg.LabDir, "config", "config.json")
 	if nodeCfg.StartupConfig != "" {
 		c, err := os.ReadFile(nodeCfg.StartupConfig)
 		if err != nil {

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -4,33 +4,41 @@ Suite Teardown    Run Keyword    Cleanup
 
 *** Variables ***
 ${lab-name}       02-01-two-srls
+${lab-file-name}    02-srl02.clab.yml
+${runtime}        docker
 
 *** Test Cases ***
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab deploy -t ${CURDIR}/02-srl02.clab.yml
+    ...    sudo containerlab deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
-Wait 5 seconds
+Wait 5 seconds for srl to boot
     Sleep    5s
 
 Verify links in node srl1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo docker exec clab-${lab-name}-srl1 ip link show e1-1
+    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify links in node srl2
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo docker exec clab-${lab-name}-srl2 ip link show e1-1
+    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
+Verify saving config
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${output}    ERRO
+
 *** Keywords ***
 Cleanup
-    Run    sudo containerlab destroy -t ${CURDIR}/02-srl02.clab.yml --cleanup
-    Run    rm -rf ${CURDIR}/${lab-name}
+    Run    sudo containerlab destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -7,8 +7,7 @@ name: 02-01-two-srls
 topology:
   kinds:
     srl:
-      image: srlinux:21.3.1-410
-      license: /home/gitlab-runner/srl-lic.key
+      image: ghcr.io/nokia/srlinux
   nodes:
     srl1:
       kind: srl


### PR DESCRIPTION
Have to revert #562 because when mounting the config file  specifically the move/rename operations are not possible on the mounted config file

That prevents srlinux code to save configuration, as it apparently uses move/rename operation:

```
Error in /system:    Rename of temporary output '/etc/opt/srlinux/config.tmp' to '/etc/opt/srlinux/config.json' failed with error_code = 16 [Device or resource busy]
```

this is because the `/etc/opt/srlinux/config.json` is the mount itself.

By mounting the parent directory of config.json, namely `/etc/opt/srlinux/` we avoiding this block, because the renaming happens on the file, and not on the mount point

fix #578 