### PR TITLE
chore: Added a line about UUIDs

### DIFF
--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -98,6 +98,13 @@ type: "cp: cpu=2 ram=4 chassis=ixr-e slot=A card=cpm-ixr-e ___ lc: cpu=2 ram=4 m
 type: "cpu=2 ram=4 slot=A chassis=ixr-r6 card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28"
 ```
 
+If your SR-OS license file requires a specific UUID, you can define it here:
+
+```yaml
+# note, typically only the cp needs the UUID defined.
+type: "cp: uuid=00001234-5678-9abc-def1-000012345678 cpu=4 ram=6 slot=A chassis=SR-12 card=cpm5 ___ lc: cpu=4 ram=6 max_nics=36 slot=1 chassis=SR-12 card=iom3-xp-c mda/1=m10-1gb+1-10gb"
+```
+
 ### Node configuration
 vr-sros nodes come up with a basic "blank" configuration where only the card/mda are provisioned, as well as the management interfaces such as Netconf, SNMP, gNMI.
 

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -98,13 +98,6 @@ type: "cp: cpu=2 ram=4 chassis=ixr-e slot=A card=cpm-ixr-e ___ lc: cpu=2 ram=4 m
 type: "cpu=2 ram=4 slot=A chassis=ixr-r6 card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28"
 ```
 
-If your SR-OS license file requires a specific UUID, you can define it here:
-
-```yaml
-# note, typically only the cp needs the UUID defined.
-type: "cp: uuid=00001234-5678-9abc-def1-000012345678 cpu=4 ram=6 slot=A chassis=SR-12 card=cpm5 ___ lc: cpu=4 ram=6 max_nics=36 slot=1 chassis=SR-12 card=iom3-xp-c mda/1=m10-1gb+1-10gb"
-```
-
 ### Node configuration
 vr-sros nodes come up with a basic "blank" configuration where only the card/mda are provisioned, as well as the management interfaces such as Netconf, SNMP, gNMI.
 
@@ -133,6 +126,14 @@ cat clab-cert01/sr/tftpboot/config.txt
 
 ### License
 Path to a valid license must be provided for all vr-sros nodes with a [`license`](../nodes.md#license) directive.
+
+If your SR OS license file is issued for a specific UUID, you can define it with custom type definition:
+
+```yaml
+# note, typically only the cp needs the UUID defined.
+type: "cp: uuid=00001234-5678-9abc-def1-000012345678 cpu=4 ram=6 slot=A chassis=SR-12 card=cpm5 ___ lc: cpu=4 ram=6 max_nics=36 slot=1 chassis=SR-12 card=iom3-xp-c mda/1=m10-1gb+1-10gb"
+```
+
 
 ### File mounts
 When a user starts a lab, containerlab creates a node directory for storing [configuration artifacts](../conf-artifacts.md). For `vr-sros` kind containerlab creates `tftpboot` directory where the license file will be copied.


### PR DESCRIPTION
Very simple documentation update to be explicit about how to add UUIDs that are required by some SR-OS license files. 