### PR TITLE
Add feature to configure SRL agents in lab config

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -253,6 +253,10 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		return nil, err
 	}
 	nodeCfg.Binds = binds
+
+  // JvB: initialize agent paths
+	nodeCfg.Agents = c.Config.Topology.GetNodeAgents(nodeName)
+
 	nodeCfg.PortSet, nodeCfg.PortBindings, err = c.Config.Topology.GetNodePorts(nodeName)
 	if err != nil {
 		return nil, err

--- a/clab/config.go
+++ b/clab/config.go
@@ -254,8 +254,10 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 	}
 	nodeCfg.Binds = binds
 
-  // JvB: initialize agent paths
-	nodeCfg.Agents = c.Config.Topology.GetNodeAgents(nodeName)
+  // JvB: initialize agent paths, only for SRL Kind nodes
+	if (nodeCfg.Kind == "srl") {
+	  nodeCfg.Agents = c.Config.Topology.GetNodeAgents(nodeName)
+	}
 
 	nodeCfg.PortSet, nodeCfg.PortBindings, err = c.Config.Topology.GetNodePorts(nodeName)
 	if err != nil {

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -152,7 +152,7 @@ func createCRPDFiles(nodeCfg *types.NodeConfig) error {
 		// copy license file to node specific lab directory
 		src := nodeCfg.License
 		dst = path.Join(nodeCfg.LabDir, "/config/license.conf")
-		if err = utils.CopyFile(src, dst); err != nil {
+		if err = utils.CopyFile(src, dst, 0444); err != nil {
 			return fmt.Errorf("file copy [src %s -> dst %s] failed %v", src, dst, err)
 		}
 		log.Debugf("CopyFile src %s -> dst %s succeeded", src, dst)

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -121,7 +121,7 @@ func createVrSROSFiles(node *types.NodeConfig) error {
 		// copy license file to node specific lab directory
 		src := node.License
 		dst := path.Join(node.LabDir, "/tftpboot/license.txt")
-		if err := utils.CopyFile(src, dst); err != nil {
+		if err := utils.CopyFile(src, dst, 0444); err != nil {
 			return fmt.Errorf("file copy [src %s -> dst %s] failed %v", src, dst, err)
 		}
 		log.Debugf("CopyFile src %s -> dst %s succeeded", src, dst)

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -38,6 +38,9 @@ type NodeDefinition struct {
 	CPU string `yaml:"cpu,omitempty"`
 	// Set node RAM (cgroup or hypervisor)
 	RAM string `yaml:"ram,omitempty"`
+
+	// list of agent YAML files to provision for SRL nodes
+	Agents []string `yaml:"agents,omitempty"`
 }
 
 func (n *NodeDefinition) GetKind() string {
@@ -108,6 +111,13 @@ func (n *NodeDefinition) GetBinds() []string {
 		return nil
 	}
 	return n.Binds
+}
+
+func (n *NodeDefinition) GetAgents() []string {
+	if n == nil {
+		return nil
+	}
+	return n.Agents
 }
 
 func (n *NodeDefinition) GetPorts() []string {

--- a/types/topology.go
+++ b/types/topology.go
@@ -82,6 +82,20 @@ func (t *Topology) GetNodeBinds(name string) []string {
 	return nil
 }
 
+func (t *Topology) GetNodeAgents(name string) []string {
+	if ndef, ok := t.Nodes[name]; ok {
+		if len(ndef.GetAgents()) > 0 {
+			return ndef.GetAgents()
+		}
+		agents := t.GetKind(t.GetNodeKind(name)).GetAgents()
+		if len(agents) > 0 {
+			return agents
+		}
+		return t.GetDefaults().GetAgents()
+	}
+	return nil
+}
+
 func (t *Topology) GetNodePorts(name string) (nat.PortSet, nat.PortMap, error) {
 	if ndef, ok := t.Nodes[name]; ok {
 		// node level ports

--- a/types/types.go
+++ b/types/types.go
@@ -74,6 +74,7 @@ type NodeConfig struct {
 	Cmd              string
 	Env              map[string]string
 	Binds            []string    // Bind mounts strings (src:dest:options)
+	Agents           []string    // Paths to YAML files for SRL agent extensions
 	PortBindings     nat.PortMap // PortBindings define the bindings between the container ports and host ports
 	PortSet          nat.PortSet // PortSet define the ports that should be exposed on a container
 	// container networking mode. if set to `host` the host networking will be used for this node, else bridged network
@@ -107,7 +108,8 @@ type NodeConfig struct {
 func (node *NodeConfig) GenerateConfig(dst, templ string) error {
 	// if startup config is not set, and the config file is already present in the node dir
 	// we do not regenerate the config, since we will take what was saved from the previous run
-	// in other words, the startup config set by a user takes preference and will trigger config generation
+	// in other words, the startup config set by a user takes precedence and will trigger config generation
+	// JvB TODO add a flag 'StartFresh' to allow users to preserve modified startup configs
 	if utils.FileExists(dst) && (node.StartupConfig == "") {
 		log.Debugf("config file '%s' for node '%s' already exists and will not be generated", dst, node.ShortName)
 		return nil

--- a/utils/file.go
+++ b/utils/file.go
@@ -21,7 +21,8 @@ func FileExists(filename string) bool {
 
 // CopyFile copies a file from src to dst. If src and dst files exist, and are
 // the same, then return success. Otherwise, copy the file contents from src to dst.
-func CopyFile(src, dst string) (err error) {
+// mode is the desired target file permissions, e.g. "0644"
+func CopyFile(src, dst string, mode os.FileMode) (err error) {
 	sfi, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -44,20 +45,24 @@ func CopyFile(src, dst string) (err error) {
 			return
 		}
 	}
-	return CopyFileContents(src, dst)
+	return CopyFileContents(src, dst, mode)
 }
 
 // copyFileContents copies the contents of the file named src to the file named
 // by dst. The file will be created if it does not already exist. If the
 // destination file exists, all it's contents will be replaced by the contents
 // of the source file.
-func CopyFileContents(src, dst string) (err error) {
+func CopyFileContents(src, dst string, mode os.FileMode) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return
 	}
 	defer in.Close()
 	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	err = out.Chmod(mode)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
SRL supports the addition of custom agents, which requires deployment of YAML files in /etc/opt/srlinux/appmgr.
This patch allows the user to specify files to be copied there, for specific nodes or for all SRL instances

The patch also sets file permissions appropriately when copying files (although bind-mounted files still become 0777)