### PR TITLE
Bugfix config & templates

### DIFF
--- a/cmd/config_template.go
+++ b/cmd/config_template.go
@@ -49,7 +49,7 @@ var configTemplateCmd = &cobra.Command{
 		}
 
 		for _, n := range configFilter {
-			allConfig[n].Print(true, false)
+			allConfig[n].Print(false, true)
 		}
 
 		return nil

--- a/lab-examples/vr05/sros4.clab.yml
+++ b/lab-examples/vr05/sros4.clab.yml
@@ -5,8 +5,9 @@ topology:
     kind: vr-sros
     image: registry.srlinux.dev/pub/vr-sros:21.2.R1
     license: ~/license/sros.txt
-    labels:
-      isis_iid: 0
+    config:
+      vars:
+        isis_iid: 1
   nodes:
     sr1:
       config:
@@ -34,17 +35,17 @@ topology:
         port: [1/1/c1/1, 1/1/c2/1]
         clab_link_ip: 1.1.1.2/30
         vlan: [99, 99]
-        isis_iid: 0
+        isis_iid: 1
     - endpoints: [sr2:eth1, sr3:eth2]
       vars:
         port: [1/1/c1/1, 1/1/c2/1]
         vlan: 98
-        isis_iid: 0
+        isis_iid: 1
     - endpoints: [sr3:eth1, sr4:eth2]
       vars:
         port: [1/1/c1/1, 1/1/c2/1]
-        isis_iid: 0
+        isis_iid: 1
     - endpoints: [sr4:eth1, sr1:eth2]
       vars:
         port: [1/1/c1/1, 1/1/c2/1]
-        isis_iid: 0
+        isis_iid: 1

--- a/lab-examples/vr05/sros4.clab.yml
+++ b/lab-examples/vr05/sros4.clab.yml
@@ -4,7 +4,7 @@ topology:
   defaults:
     kind: vr-sros
     image: registry.srlinux.dev/pub/vr-sros:21.2.R1
-    license: ~/license/license-sros21.txt
+    license: ~/license/sros.txt
     labels:
       isis_iid: 0
   nodes:

--- a/lab-examples/vr05/vr01.clab.yml
+++ b/lab-examples/vr05/vr01.clab.yml
@@ -8,22 +8,22 @@ topology:
       config:
         vars:
           clab_system_ip: 10.0.50.50/32
-          isis_iid: 0
+          isis_iid: 1
           sid_idx: 11
     sros:
       kind: vr-sros
       image: registry.srlinux.dev/pub/vr-sros:21.2.R1
       type: sr-1
-      license: ~/license/license-sros21.txt
+      license: ~/license/sros.txt
       config:
         vars:
           clab_system_ip: 10.0.50.51/32
           sid_idx: 10
-          isis_iid: 0
+          isis_iid: 1
 
   links:
     - endpoints: ["srl:e1-1", "sros:eth1"]
       vars:
         port: [ethernet-1/1, 1/1/c1/1]
         vlan: 10
-        isis_iid: 0
+        isis_iid: 1

--- a/templates/base__vr-sros.tmpl
+++ b/templates/base__vr-sros.tmpl
@@ -6,7 +6,7 @@
 {{ range .clab_links }}
     {{ expect .port "^\\d+/\\d/" }}
     {{ expect .clab_link_name "string" }}
-    {{ expect .ip "ip" }}
+    {{ expect .clab_link_ip "ip" }}
     {{ optional .vlan "0-4096" }}
     {{ optional .isis_iid "0-31" }}
     {{ optional .sid_idx "0-999" }}
@@ -62,8 +62,8 @@
 /configure port {{ .port }} admin-state enable
 
 /configure router interface {{ .clab_link_name }}
-    ipv4 primary address {{ ip .ip }}
-    ipv4 primary prefix-length {{ ipmask .ip }}
+    ipv4 primary address {{ ip .clab_link_ip }}
+    ipv4 primary prefix-length {{ ipmask .clab_link_ip }}
     port {{ .port }}:{{ default 10 .vlan }}
 
 {{- if .isis_iid }}


### PR DESCRIPTION
Small config bugfix

- integer zeros are also false, so this template test does not execute.
  ```
  {{ if .isis_idx }}
  do some isis config
  {{ end }}
  ```
  "0" would work - this is a string, but the more elegant solution for now is just not to use 0, but 1

  The only long term workaround I can think of at the moment to allow testing for explicit integer zero is to add a new template function... but still need to think this over :-/

- `config template` show was switch around -- it always showed variables

- missed a `clab_link_ip` rename in the `base__vr-sros` template
