### PR TITLE
Updated vr-ros to support startup configs

### DIFF
--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -8,6 +8,7 @@ IgnoreURLs:
   - goreleaser.com # doesn't support `range 0` GETs which htmltest uses
   - https://documentation.nokia.com/cgi-bin/dbaccessfilename.cgi/3HE15836AAADTQZZA01_V1_vSIM%20Installation%20and%20Setup%20Guide%2020.10.R1.pdf # fuck this false positives...
   - https://documentation.nokia.com/cgi-bin/dbaccessfilename.cgi/3HE16113AAAATQZZA01_V1_SR%20Linux%20R20.6%20Software%20Installation.pdf
+  - https://github.com/srl-labs/containerlab/releases/ # gh rate limiters for this particular endpoint are too aggressive
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/manual/kinds/vr-ros.md
+++ b/docs/manual/kinds/vr-ros.md
@@ -12,10 +12,17 @@ MikroTik RouterOS node launched with containerlab can be managed via the followi
     docker exec -it <container-name/id> bash
     ```
 === "CLI"
-    to connect to the vEOS CLI
+    to connect to the vr-ros CLI
     ```bash
     ssh admin@<container-name/id>
     ```
+=== "Telnet"
+    serial port (console) is exposed over TCP port 5000:
+    ```bash
+    # from container host
+    telnet <node-name> 5000
+    ```  
+    You can also connect to the container and use `telnet localhost 5000` if telnet is not available on your container host.
 
 !!!info
     Default user credentials: `admin:admin`
@@ -31,3 +38,22 @@ When containerlab launches vr-ros node, it will assign IPv4/6 address to the `et
 
 Data interfaces `eth1+` needs to be configured with IP addressing manually using CLI/management protocols.
 
+### Node configuration
+vr-ros nodes come up with a basic "blank" configuration where only the management interface and user is provisioned.
+
+#### User defined config
+It is possible to make ROS nodes to boot up with a user-defined startup config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind a user sets the path to the config file that will be mounted to a container and used as a startup config:
+
+```yaml
+name: ros_lab
+topology:
+  nodes:
+    ros:
+      kind: vr-ros
+      startup-config: myconfig.txt
+```
+
+With such topology file containerlab is instructed to take a file `myconfig.txt` from the current working directory, copy it to the lab directory for that specific node under the `/ftpboot/config.auto.rsc` name and mount that dir to the container. This will result in this config to act as a startup config for the node via FTP. Mikrotik will automatically import any file with the .auto.rsc suffix.
+
+### File mounts
+When a user starts a lab, containerlab creates a node directory for storing [configuration artifacts](../conf-artifacts.md). For `vr-ros` kind containerlab creates `ftpboot` directory where the config file will be copied as config.auto.rsc.

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -59,7 +59,7 @@ func (s *vrRos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 func (s *vrRos) Config() *types.NodeConfig { return s.cfg }
 
-func (s *vrRos) PreDeploy(configName, labCADir, labCARoot string) error {
+func (s *vrRos) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
 	return createVrROSFiles(s.cfg)
 }
@@ -75,7 +75,7 @@ func (s *vrRos) GetImages() map[string]string {
 	}
 }
 
-func (s *vrRos) PostDeploy(ctx context.Context, ns map[string]nodes.Node) error {
+func (*vrRos) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
 	return nil
 }
 
@@ -87,7 +87,7 @@ func (s *vrRos) Delete(ctx context.Context) error {
 	return s.runtime.DeleteContainer(ctx, s.Config().LongName)
 }
 
-func (s *vrRos) SaveConfig(ctx context.Context) error {
+func (*vrRos) SaveConfig(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
Updated vr-ros to support startup-config option and updated documentation for the feature

This will take the startup-config option and place it into /ftpboot/config.auto.rsc that Docker will then be able to push via FTP. Mikrotik supports automatic config import for files ending in .auto.rsc which this takes advantage of