### PR TITLE
Fix: in filters exists should be used as operator not match value

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -205,7 +205,7 @@ func FilterFromLabelStrings(labels []string) []*GenericFilter {
 			gf.Field = strings.TrimSpace(subs[0])
 			gf.Match = strings.TrimSpace(subs[1])
 		} else {
-			gf.Match = "exists"
+			gf.Operator = "exists"
 			gf.Field = strings.TrimSpace(s)
 		}
 


### PR DESCRIPTION
In `exec` cmd, in case if `label` flag was passed without `=` operator, `exists` should be assigned as an operator(as it's expected in runtimes method `buildFilterString`). Instead, it's used as match value(which causes filter misconstruction).