### PR TITLE
Added exec property to nodes

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -37,6 +37,15 @@ const (
 	defaultVethLinkMTU = 9500
 	// containerlab's reserved OUI
 	clabOUI = "aa:c1:ab"
+
+	// label names
+	ContainerlabLabel = "containerlab"
+	NodeNameLabel     = "clab-node-name"
+	NodeKindLabel     = "clab-node-kind"
+	NodeTypeLabel     = "clab-node-type"
+	NodeGroupLabel    = "clab-node-group"
+	NodeLabDirLabel   = "clab-node-lab-dir"
+	TopoFileLabel     = "clab-topo-file"
 )
 
 // supported kinds
@@ -188,13 +197,13 @@ func (c *CLab) NewNode(nodeName, nodeRuntime string, nodeDef *types.NodeDefiniti
 	}
 
 	n.Config().Labels = utils.MergeStringMaps(n.Config().Labels, map[string]string{
-		"containerlab":      c.Config.Name,
-		"clab-node-name":    n.Config().ShortName,
-		"clab-node-kind":    n.Config().Kind,
-		"clab-node-type":    n.Config().NodeType,
-		"clab-node-group":   n.Config().Group,
-		"clab-node-lab-dir": n.Config().LabDir,
-		"clab-topo-file":    c.TopoFile.path,
+		ContainerlabLabel: c.Config.Name,
+		NodeNameLabel:     n.Config().ShortName,
+		NodeKindLabel:     n.Config().Kind,
+		NodeTypeLabel:     n.Config().NodeType,
+		NodeGroupLabel:    n.Config().Group,
+		NodeLabDirLabel:   n.Config().LabDir,
+		TopoFileLabel:     c.TopoFile.path,
 	})
 	c.Nodes[nodeName] = n
 
@@ -220,6 +229,7 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		User:            c.Config.Topology.GetNodeUser(nodeName),
 		Entrypoint:      c.Config.Topology.GetNodeEntrypoint(nodeName),
 		Cmd:             c.Config.Topology.GetNodeCmd(nodeName),
+		Exec:            c.Config.Topology.GetNodeExec(nodeName),
 		Env:             c.Config.Topology.GetNodeEnv(nodeName),
 		NetworkMode:     strings.ToLower(c.Config.Topology.GetNodeNetworkMode(nodeName)),
 		MgmtIPv4Address: nodeDef.GetMgmtIPv4(),
@@ -454,7 +464,7 @@ func (c *CLab) VerifyContainersUniqueness(ctx context.Context) error {
 	// the lab name of a currently deploying lab
 	// this ensures lab uniqueness
 	for _, cnt := range containers {
-		if cnt.Labels["containerlab"] == c.Config.Name {
+		if cnt.Labels[ContainerlabLabel] == c.Config.Name {
 			return fmt.Errorf("the '%s' lab has already been deployed. Destroy the lab before deploying a lab with the same name", c.Config.Name)
 		}
 	}

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -373,55 +373,55 @@ func TestLabelsInit(t *testing.T) {
 			got:  "test_data/topo1.yml",
 			node: "node1",
 			want: map[string]string{
-				"containerlab":      "topo1",
-				"clab-node-name":    "node1",
-				"clab-node-kind":    "srl",
-				"clab-node-type":    "ixr6",
-				"clab-node-group":   "",
-				"clab-node-lab-dir": "./clab-topo1/node1",
-				"clab-topo-file":    "./test_data/topo1.yml",
+				ContainerlabLabel: "topo1",
+				NodeNameLabel:     "node1",
+				NodeKindLabel:     "srl",
+				NodeTypeLabel:     "ixr6",
+				NodeGroupLabel:    "",
+				NodeLabDirLabel:   "./clab-topo1/node1",
+				TopoFileLabel:     "./test_data/topo1.yml",
 			},
 		},
 		"custom_node_label": {
 			got:  "test_data/topo1.yml",
 			node: "node2",
 			want: map[string]string{
-				"containerlab":      "topo1",
-				"clab-node-name":    "node2",
-				"clab-node-kind":    "srl",
-				"clab-node-type":    "ixrd2",
-				"clab-node-group":   "",
-				"clab-node-lab-dir": "./clab-topo1/node2",
-				"clab-topo-file":    "./test_data/topo1.yml",
-				"node-label":        "value",
+				ContainerlabLabel: "topo1",
+				NodeNameLabel:     "node2",
+				NodeKindLabel:     "srl",
+				NodeTypeLabel:     "ixrd2",
+				NodeGroupLabel:    "",
+				NodeLabDirLabel:   "./clab-topo1/node2",
+				TopoFileLabel:     "./test_data/topo1.yml",
+				"node-label":      "value",
 			},
 		},
 		"custom_kind_label": {
 			got:  "test_data/topo2.yml",
 			node: "node1",
 			want: map[string]string{
-				"containerlab":      "topo2",
-				"clab-node-name":    "node1",
-				"clab-node-kind":    "srl",
-				"clab-node-type":    "ixrd2",
-				"clab-node-group":   "",
-				"clab-node-lab-dir": "./clab-topo2/node1",
-				"clab-topo-file":    "./test_data/topo2.yml",
-				"kind-label":        "value",
+				ContainerlabLabel: "topo2",
+				NodeNameLabel:     "node1",
+				NodeKindLabel:     "srl",
+				NodeTypeLabel:     "ixrd2",
+				NodeGroupLabel:    "",
+				NodeLabDirLabel:   "./clab-topo2/node1",
+				TopoFileLabel:     "./test_data/topo2.yml",
+				"kind-label":      "value",
 			},
 		},
 		"custom_default_label": {
 			got:  "test_data/topo3.yml",
 			node: "node2",
 			want: map[string]string{
-				"containerlab":      "topo3",
-				"clab-node-name":    "node2",
-				"clab-node-kind":    "srl",
-				"clab-node-type":    "ixrd2",
-				"clab-node-group":   "",
-				"clab-node-lab-dir": "./clab-topo3/node2",
-				"clab-topo-file":    "./test_data/topo3.yml",
-				"default-label":     "value",
+				ContainerlabLabel: "topo3",
+				NodeNameLabel:     "node2",
+				NodeKindLabel:     "srl",
+				NodeTypeLabel:     "ixrd2",
+				NodeGroupLabel:    "",
+				NodeLabDirLabel:   "./clab-topo3/node2",
+				TopoFileLabel:     "./test_data/topo3.yml",
+				"default-label":   "value",
 			},
 		},
 	}
@@ -436,8 +436,8 @@ func TestLabelsInit(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tc.want["clab-node-lab-dir"], _ = resolvePath(tc.want["clab-node-lab-dir"])
-			tc.want["clab-topo-file"], _ = resolvePath(tc.want["clab-topo-file"])
+			tc.want[NodeLabDirLabel], _ = resolvePath(tc.want[NodeLabDirLabel])
+			tc.want[TopoFileLabel], _ = resolvePath(tc.want["clab-topo-file"])
 
 			labels := c.Nodes[tc.node].Config().Labels
 

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -437,7 +437,7 @@ func TestLabelsInit(t *testing.T) {
 			}
 
 			tc.want[NodeLabDirLabel], _ = resolvePath(tc.want[NodeLabDirLabel])
-			tc.want[TopoFileLabel], _ = resolvePath(tc.want["clab-topo-file"])
+			tc.want[TopoFileLabel], _ = resolvePath(tc.want[TopoFileLabel])
 
 			labels := c.Nodes[tc.node].Config().Labels
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -213,13 +213,7 @@ var deployCmd = &cobra.Command{
 			log.Errorf("failed to create hosts file: %v", err)
 		}
 
-		// log new version availability info if ready
-		newVerNotification(vCh)
-
-		// print table summary
-		printContainerInspect(c, containers, c.Config.Mgmt.Network, format)
-
-		// exec cmds specified for containers
+		// exec commands specified for containers with `exec` parameter
 		execJSONResult := make(map[string]map[string]map[string]interface{})
 		for _, cont := range containers {
 			name := cont.Labels[clab.NodeNameLabel]
@@ -227,7 +221,7 @@ var deployCmd = &cobra.Command{
 				rt := node.GetRuntime()
 				contName := strings.TrimLeft(cont.Names[0], "/")
 				if execJSONResult[contName], err = execCmds(ctx, cont, rt, node.Config().Exec, format); err != nil {
-					log.Errorf("Failed to exec cmds for node %s", name)
+					log.Errorf("Failed to exec commands for node %s", name)
 				}
 			}
 		}
@@ -238,6 +232,12 @@ var deployCmd = &cobra.Command{
 			}
 			fmt.Println(string(result))
 		}
+
+		// log new version availability info if ready
+		newVerNotification(vCh)
+
+		// print table summary
+		printContainerInspect(c, containers, c.Config.Mgmt.Network, format)
 
 		return nil
 	},

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -145,10 +145,10 @@ func execCmds(
 		case "plain", "table":
 			contName := strings.TrimLeft(cont.Names[0], "/")
 			if len(stdout) > 0 {
-				log.Infof("%s: %s: stdout:\n%s", contName, cmd, string(stdout))
+				log.Infof("Executed command '%s' on %s. stdout:\n%s", cmd, contName, string(stdout))
 			}
 			if len(stderr) > 0 {
-				log.Infof("%s: %s: stderr:\n%s", contName, cmd, string(stderr))
+				log.Infof("Executed command '%s' on %s. stderr:\n%s", cmd, contName, string(stderr))
 			}
 		}
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -80,15 +80,8 @@ var execCmd = &cobra.Command{
 			return errors.New("no containers found")
 		}
 
-		cmds, err := shlex.Split(execCommand)
-		if err != nil {
-			return err
-		}
-
-		jsonResult := make(map[string]map[string]interface{})
-
+		jsonResult := make(map[string]map[string]map[string]interface{})
 		for _, cont := range containers {
-			var doc interface{}
 			if cont.State != "running" {
 				continue
 			}
@@ -100,30 +93,11 @@ var execCmd = &cobra.Command{
 				return err
 			}
 
-			stdout, stderr, err := nodeRuntime.Exec(ctx, cont.ID, cmds)
-			if err != nil {
-				log.Errorf("%s: failed to execute cmd: %v", cont.Names, err)
-				continue
-			}
 			contName := strings.TrimLeft(cont.Names[0], "/")
-			switch execFormat {
-			case "json":
-				jsonResult[contName] = make(map[string]interface{})
-				err := json.Unmarshal([]byte(stdout), &doc)
-				if err == nil {
-					jsonResult[contName]["stdout"] = doc
-				} else {
-					jsonResult[contName]["stdout"] = string(stdout)
-				}
-				jsonResult[contName]["stderr"] = string(stderr)
-			case "plain":
-				if len(stdout) > 0 {
-					log.Infof("%s: stdout:\n%s", contName, string(stdout))
-				}
-				if len(stderr) > 0 {
-					log.Infof("%s: stderr:\n%s", contName, string(stderr))
-				}
-
+			if jsonResult[contName], err = execCmds(
+				ctx, cont, nodeRuntime, []string{execCommand}, execFormat,
+			); err != nil {
+				return err
 			}
 		}
 		if execFormat == "json" {
@@ -135,6 +109,51 @@ var execCmd = &cobra.Command{
 		}
 		return err
 	},
+}
+
+func execCmds(
+	ctx context.Context,
+	cont types.GenericContainer,
+	runtime runtime.ContainerRuntime,
+	cmds []string,
+	format string,
+) (result map[string]map[string]interface{}, err error) {
+	var doc interface{}
+
+	result = make(map[string]map[string]interface{})
+	for _, cmd := range cmds {
+		c, err := shlex.Split(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		stdout, stderr, err := runtime.Exec(ctx, cont.ID, c)
+		if err != nil {
+			log.Errorf("%s: failed to execute cmd: %v", cont.Names, err)
+			return nil, nil
+		}
+
+		switch format {
+		case "json":
+			result[cmd] = make(map[string]interface{})
+			if json.Unmarshal([]byte(stdout), &doc) == nil {
+				result[cmd]["stdout"] = doc
+			} else {
+				result[cmd]["stdout"] = string(stdout)
+			}
+			result[cmd]["stderr"] = string(stderr)
+		case "plain", "table":
+			contName := strings.TrimLeft(cont.Names[0], "/")
+			if len(stdout) > 0 {
+				log.Infof("%s: %s: stdout:\n%s", contName, cmd, string(stdout))
+			}
+			if len(stderr) > 0 {
+				log.Infof("%s: %s: stderr:\n%s", contName, cmd, string(stderr))
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func init() {

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -336,3 +336,22 @@ my-node:
   image: alpine:3
   runtime: containerd
 ```
+
+### exec
+Containers typically have some process that is launched inside the sandboxed environment. The said process and its arguments are provided via container instructions such as `entrypoint` and `cmd` in Docker's case.
+
+Quite often, it is needed to run additional commands inside the containers when they finished booting. Instead of modifying the `entrypoint` and `cmd` it is possible to use the `exec` parameter and specify a list of commands to execute:
+
+```yaml
+# two commands will be executed for node `my-node` once it finishes booting
+my-node:
+  image: alpine:3
+  kind: linux
+  binds:
+    - myscript.sh:/myscript.sh
+  exec:
+    - echo test123
+    - bash /myscript.sh
+```
+
+The `exec` is particularly helpful to provide some startup configuration for linux nodes such as IP addressing and routing instructions.

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -19,7 +19,7 @@ Verify number of Hosts entries before deploy
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    cat /etc/hosts | wc -l
     Log    ${output}
-    Set Suite Variable  ${HostsFileLines}   ${output}
+    Set Suite Variable    ${HostsFileLines}    ${output}
 
 Deploy ${lab-name} lab
     Log    ${CURDIR}
@@ -27,6 +27,9 @@ Deploy ${lab-name} lab
     ...    sudo containerlab --runtime ${runtime} deploy -t ${CURDIR}/01-linux-nodes.clab.yml
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
+    # ensure exec commands work
+    Should Contain    ${output}    this_is_an_exec_test
+    Should Contain    ${output}    ID=alpine
 
 Inspect ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
@@ -114,7 +117,7 @@ Verify l1 environment has MYVAR variable set
     Should Contain    ${output}    MYVAR is SET
 
 Verify Hosts entries exist
-    [Documentation]     Verification that the expected /etc/hosts entries are created. We are also checking for the HEADER and FOOTER values here, which also contain the lab name.
+    [Documentation]    Verification that the expected /etc/hosts entries are created. We are also checking for the HEADER and FOOTER values here, which also contain the lab name.
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    cat /etc/hosts | grep "${lab-name}" | wc -l
     Log    ${output}
@@ -128,13 +131,13 @@ Destroy ${lab-name} lab
     Should Be Equal As Integers    ${rc}    0
 
 Verify Hosts entries are gone
-    [Documentation]     Verification that the previously created /etc/hosts entries are properly removed. (Again including HEADER and FOOTER).
+    [Documentation]    Verification that the previously created /etc/hosts entries are properly removed. (Again including HEADER and FOOTER).
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    cat /etc/hosts | grep "${lab-name}" | wc -l
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0
-   
+
 Verify Hosts file has same number of lines
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    cat /etc/hosts | wc -l

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -14,6 +14,9 @@ topology:
         - /tmp/clab-01-test.txt:/01-test.txt
       env:
         MYVAR: MYVAR is SET
+      exec:
+        - echo this_is_an_exec_test
+        - cat /etc/os-release
     l2:
       kind: linux
       image: nginx:stable-alpine

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -23,6 +23,8 @@ type NodeDefinition struct {
 	Position             string            `yaml:"position,omitempty"`
 	Entrypoint           string            `yaml:"entrypoint,omitempty"`
 	Cmd                  string            `yaml:"cmd,omitempty"`
+	// list of commands to run in container
+	Exec []string `yaml:"exec,omitempty"`
 	// list of bind mount compatible strings
 	Binds []string `yaml:"binds,omitempty"`
 	// list of port bindings
@@ -233,6 +235,13 @@ func (n *NodeDefinition) GetNodeRAM() string {
 		return ""
 	}
 	return n.RAM
+}
+
+func (n *NodeDefinition) GetExec() []string {
+	if n == nil {
+		return nil
+	}
+	return n.Exec
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/topology.go
+++ b/types/topology.go
@@ -298,6 +298,19 @@ func (t *Topology) GetNodeCmd(name string) string {
 	return ""
 }
 
+func (t *Topology) GetNodeExec(name string) []string {
+	if ndef, ok := t.Nodes[name]; ok {
+		if ndef.GetExec() != nil {
+			return ndef.GetExec()
+		}
+		if t.GetKind(t.GetNodeKind(name)).GetExec() != nil {
+			return t.GetKind(t.GetNodeKind(name)).GetExec()
+		}
+		return t.GetDefaults().GetExec()
+	}
+	return nil
+}
+
 func (t *Topology) GetNodeUser(name string) string {
 	if ndef, ok := t.Nodes[name]; ok {
 		if ndef.GetUser() != "" {

--- a/types/topology.go
+++ b/types/topology.go
@@ -300,13 +300,11 @@ func (t *Topology) GetNodeCmd(name string) string {
 
 func (t *Topology) GetNodeExec(name string) []string {
 	if ndef, ok := t.Nodes[name]; ok {
-		if ndef.GetExec() != nil {
-			return ndef.GetExec()
-		}
-		if t.GetKind(t.GetNodeKind(name)).GetExec() != nil {
-			return t.GetKind(t.GetNodeKind(name)).GetExec()
-		}
-		return t.GetDefaults().GetExec()
+		d := t.GetDefaults().GetExec()
+		k := t.GetKind(t.GetNodeKind(name)).GetExec()
+		n := ndef.GetExec()
+
+		return append(append(d, k...), n...)
 	}
 	return nil
 }

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -35,7 +35,11 @@ var topologyTestSet = map[string]struct {
 					License:       "test_data/lic1.key",
 					Position:      "pos1",
 					Cmd:           "runit",
-					User:          "user1",
+					Exec: []string{
+						"bash test1.sh",
+						"bash test2.sh",
+					},
+					User: "user1",
 					Binds: []string{
 						"a:b",
 						"c:d",
@@ -75,7 +79,11 @@ var topologyTestSet = map[string]struct {
 				License:       "test_data/lic1.key",
 				Position:      "pos1",
 				Cmd:           "runit",
-				User:          "user1",
+				Exec: []string{
+					"bash test1.sh",
+					"bash test2.sh",
+				},
+				User: "user1",
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -109,6 +117,10 @@ var topologyTestSet = map[string]struct {
 					License:       "test_data/lic1.key",
 					Position:      "pos1",
 					Cmd:           "runit",
+					Exec: []string{
+						"bash test1.sh",
+						"bash test2.sh",
+					},
 					Binds: []string{
 						"a:b",
 						"c:d",
@@ -141,6 +153,10 @@ var topologyTestSet = map[string]struct {
 				Position:      "pos1",
 				Cmd:           "runit",
 				User:          "user1",
+				Exec: []string{
+					"bash test1.sh",
+					"bash test2.sh",
+				},
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -170,6 +186,10 @@ var topologyTestSet = map[string]struct {
 				License:       "test_data/lic1.key",
 				Position:      "pos1",
 				Cmd:           "runit",
+				Exec: []string{
+					"bash test1.sh",
+					"bash test2.sh",
+				},
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -200,6 +220,10 @@ var topologyTestSet = map[string]struct {
 				License:       "test_data/lic1.key",
 				Position:      "pos1",
 				Cmd:           "runit",
+				Exec: []string{
+					"bash test1.sh",
+					"bash test2.sh",
+				},
 				Binds: []string{
 					"a:b",
 					"c:d",
@@ -340,6 +364,20 @@ func TestGetNodeCmd(t *testing.T) {
 			t.Errorf("item %q failed", name)
 			t.Errorf("item %q exp %q", name, item.want["node1"].Cmd)
 			t.Errorf("item %q got %q", name, cmd)
+			t.Fail()
+		}
+	}
+}
+
+func TestGetNodeExec(t *testing.T) {
+	for name, item := range topologyTestSet {
+		t.Logf("%q test item", name)
+		exec := item.input.GetNodeExec("node1")
+		t.Logf("%q test item result: %v", name, exec)
+		if !cmp.Equal(item.want["node1"].Exec, exec) {
+			t.Errorf("item %q failed", name)
+			t.Errorf("item %q exp %q", name, item.want["node1"].Exec)
+			t.Errorf("item %q got %q", name, exec)
 			t.Fail()
 		}
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -74,6 +74,7 @@ type NodeConfig struct {
 	User                 string
 	Entrypoint           string
 	Cmd                  string
+	Exec                 []string
 	Env                  map[string]string
 	Binds                []string    // Bind mounts strings (src:dest:options)
 	PortBindings         nat.PortMap // PortBindings define the bindings between the container ports and host ports


### PR DESCRIPTION
Attempt to implement https://github.com/srl-labs/containerlab/issues/598.

This PR implements `exec` list field in `node` component and refactors code(mostly in `cmd/exec.go`). Docs not updated(yet).

Here is topo that was used for testing this feature: https://gist.github.com/GrigoriyMikhalkin/23fe014660a17ae45ee5d0c5d180d0a2