### PR TITLE
Add 'extras' 'agents' config option for SRL nodes

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -243,6 +243,9 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		CPU:             c.Config.Topology.GetNodeCPU(nodeName),
 		RAM:             c.Config.Topology.GetNodeRAM(nodeName),
 		StartupDelay:    c.Config.Topology.GetNodeStartupDelay(nodeName),
+
+		// Extras
+		Agents:		 c.Config.Topology.GetNodeExtras_srl_Agents(nodeName),
 	}
 
 	log.Debugf("node config: %+v", nodeCfg)

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -152,6 +152,22 @@ func (s *srl) PreDeploy(configName, labCADir, labCARoot string) error {
 	s.cfg.TLSCert = string(nodeCerts.Cert)
 	s.cfg.TLSKey = string(nodeCerts.Key)
 
+	// Create appmgr subdir for agent specs and copy files, if needed
+        if s.cfg.Agents != nil {
+		agents := s.cfg.Agents
+                log.Infof("PreDeploy %s copying agent files: %s...",s.cfg.ShortName,agents)
+                appmgr := filepath.Join(s.cfg.LabDir, "config/appmgr/")
+                utils.CreateDirectory(appmgr, 0777)
+                for _, fullpath := range agents {
+                        pathparts := strings.Split(fullpath, "/")
+                        basename := pathparts[ len(pathparts) - 1 ]
+                        dst := filepath.Join(appmgr, basename)
+                        if err := utils.CopyFile(fullpath, dst); err != nil {
+                                return fmt.Errorf("Agent CopyFile src %s -> dst %s failed %v", fullpath, dst, err)
+                        }
+                }
+        }
+
 	return createSRLFiles(s.cfg)
 }
 

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -60,9 +60,12 @@ type NodeDefinition struct {
 }
 
 type NodeExtrasDefinition struct {
-	Agents []string `yaml:"agents,omitempty"`
+	SRL *NodeExtrasDefinition_srl `yaml:"srl,omitempty"`
 }
 
+type NodeExtrasDefinition_srl struct {
+	Agents []string `yaml:"agents,omitempty"`
+}
 
 func (n *NodeDefinition) GetKind() string {
 	if n == nil {
@@ -261,7 +264,14 @@ func (n *NodeDefinition) GetExtras() *NodeExtrasDefinition {
         return n.Extras
 }
 
-func (n *NodeExtrasDefinition) GetAgents() []string {
+func (n *NodeExtrasDefinition) GetExtras_srl() *NodeExtrasDefinition_srl {
+        if n == nil {
+                return nil
+        }
+        return n.SRL
+}
+
+func (n *NodeExtrasDefinition_srl) GetAgents() []string {
         if n == nil {
                 return nil
         }

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -53,17 +53,13 @@ type NodeDefinition struct {
 	// Set node RAM (cgroup or hypervisor)
 	RAM string `yaml:"ram,omitempty"`
 
-	// Extra options, kind specific
+	// Extra options, may be kind specific
 	// Works, but doesn't check that options are valid
 	// Extras   map[string][]string `yaml:"extras,omitempty"`
 	Extras *NodeExtrasDefinition `yaml:"extras,omitempty"`
 }
 
 type NodeExtrasDefinition struct {
-	SRL *NodeExtrasDefinition_srl `yaml:"srl,omitempty"`
-}
-
-type NodeExtrasDefinition_srl struct {
 	Agents []string `yaml:"agents,omitempty"`
 }
 
@@ -262,20 +258,6 @@ func (n *NodeDefinition) GetExtras() *NodeExtrasDefinition {
                 return nil
         }
         return n.Extras
-}
-
-func (n *NodeExtrasDefinition) GetExtras_srl() *NodeExtrasDefinition_srl {
-        if n == nil {
-                return nil
-        }
-        return n.SRL
-}
-
-func (n *NodeExtrasDefinition_srl) GetAgents() []string {
-        if n == nil {
-                return nil
-        }
-        return n.Agents
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -54,12 +54,7 @@ type NodeDefinition struct {
 	RAM string `yaml:"ram,omitempty"`
 
 	// Extra options, kind specific
-	Extras   map[string]*NodeExtrasDefinition `yaml:"extras,omitempty"`
-}
-
-type NodeExtrasDefinition struct {
-	// list of Agent YAML files to be copied to /etc/opt/srlinux/appmgr
-	Agents []string `yaml:"agents,omitempty"`
+	Extras   map[string][]string `yaml:"extras,omitempty"`
 }
 
 func (n *NodeDefinition) GetKind() string {
@@ -252,18 +247,11 @@ func (n *NodeDefinition) GetExec() []string {
 	return n.Exec
 }
 
-func (n *NodeDefinition) GetExtras() map[string]*NodeExtrasDefinition {
-        if n.Extras == nil {
-                return make(map[string]*NodeExtrasDefinition)
-        }
-        return n.Extras
-}
-
-func (n *NodeExtrasDefinition) GetAgents() []string {
-        if n == nil {
+func (n *NodeDefinition) GetAgents() []string {
+        if n == nil || n.Extras == nil {
                 return nil
         }
-        return n.Agents
+        return n.Extras[ "agents" ]
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -54,10 +54,10 @@ type NodeDefinition struct {
 	RAM string `yaml:"ram,omitempty"`
 
 	// Extra options, kind specific
-	Extras   map[string]*NodeExtraDefinition `yaml:"extras,omitempty"`
+	Extras   map[string]*NodeExtrasDefinition `yaml:"extras,omitempty"`
 }
 
-type NodeExtraDefinition struct {
+type NodeExtrasDefinition struct {
 	// list of Agent YAML files to be copied to /etc/opt/srlinux/appmgr
 	Agents []string `yaml:"agents,omitempty"`
 }
@@ -250,6 +250,20 @@ func (n *NodeDefinition) GetExec() []string {
 		return nil
 	}
 	return n.Exec
+}
+
+func (n *NodeDefinition) GetExtras() map[string]*NodeExtrasDefinition {
+        if n.Extras == nil {
+                return make(map[string]*NodeExtrasDefinition)
+        }
+        return n.Extras
+}
+
+func (n *NodeExtrasDefinition) GetAgents() []string {
+        if n == nil {
+                return nil
+        }
+        return n.Agents
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -52,6 +52,14 @@ type NodeDefinition struct {
 	CPU string `yaml:"cpu,omitempty"`
 	// Set node RAM (cgroup or hypervisor)
 	RAM string `yaml:"ram,omitempty"`
+
+	// Extra options, kind specific
+	Extras   map[string]*NodeExtraDefinition `yaml:"extras,omitempty"`
+}
+
+type NodeExtraDefinition struct {
+	// list of Agent YAML files to be copied to /etc/opt/srlinux/appmgr
+	Agents []string `yaml:"agents,omitempty"`
 }
 
 func (n *NodeDefinition) GetKind() string {

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -54,8 +54,15 @@ type NodeDefinition struct {
 	RAM string `yaml:"ram,omitempty"`
 
 	// Extra options, kind specific
-	Extras   map[string][]string `yaml:"extras,omitempty"`
+	// Works, but doesn't check that options are valid
+	// Extras   map[string][]string `yaml:"extras,omitempty"`
+	Extras *NodeExtrasDefinition `yaml:"extras,omitempty"`
 }
+
+type NodeExtrasDefinition struct {
+	Agents []string `yaml:"agents,omitempty"`
+}
+
 
 func (n *NodeDefinition) GetKind() string {
 	if n == nil {
@@ -247,11 +254,18 @@ func (n *NodeDefinition) GetExec() []string {
 	return n.Exec
 }
 
-func (n *NodeDefinition) GetAgents() []string {
-        if n == nil || n.Extras == nil {
+func (n *NodeDefinition) GetExtras() *NodeExtrasDefinition {
+        if n == nil {
                 return nil
         }
-        return n.Extras[ "agents" ]
+        return n.Extras
+}
+
+func (n *NodeExtrasDefinition) GetAgents() []string {
+        if n == nil {
+                return nil
+        }
+        return n.Agents
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/topology.go
+++ b/types/topology.go
@@ -400,6 +400,37 @@ func (t *Topology) GetNodeRAM(name string) string {
 	return ""
 }
 
+// Returns the 'extras' section for the given node's type
+func (t *Topology) GetNodeExtras(name string) *NodeExtrasDefinition_srl {
+	if ndef, ok := t.Nodes[name]; ok {
+		ntype := ndef.GetType()
+		if ntype != "srl" {
+			return nil // for now, only 'srl' extras defined
+		}
+		node_extras := ndef.GetExtras()
+		if node_extras != nil && node_extras.GetExtras_srl() != nil {
+			return node_extras.GetExtras_srl()
+		}
+		kind_extras := t.GetKind(t.GetNodeKind(name)).GetExtras()
+		if kind_extras != nil && kind_extras.GetExtras_srl() != nil {
+			return kind_extras.GetExtras_srl()
+		}
+		default_extras := t.GetDefaults().GetExtras()
+		if default_extras != nil && default_extras.GetExtras_srl() != nil {
+			return default_extras.GetExtras_srl()
+		}
+	}
+	return nil
+}
+
+func (t *Topology) GetNodeExtras_srl_Agents(name string) []string {
+	extras := t.GetNodeExtras(name)
+	if extras != nil {
+		return extras.GetAgents()
+	}
+	return make([]string,0)
+}
+
 func (t *Topology) ImportEnvs() {
 	t.Defaults.ImportEnvs()
 

--- a/types/topology.go
+++ b/types/topology.go
@@ -400,25 +400,18 @@ func (t *Topology) GetNodeRAM(name string) string {
 	return ""
 }
 
-// Returns the 'extras' section for the given node's type
-func (t *Topology) GetNodeExtras(name string) *NodeExtrasDefinition_srl {
+// Returns the 'extras' section for the given node
+func (t *Topology) GetNodeExtras(name string) *NodeExtrasDefinition {
 	if ndef, ok := t.Nodes[name]; ok {
-		ntype := ndef.GetType()
-		if ntype != "srl" {
-			return nil // for now, only 'srl' extras defined
-		}
 		node_extras := ndef.GetExtras()
-		if node_extras != nil && node_extras.GetExtras_srl() != nil {
-			return node_extras.GetExtras_srl()
+		if node_extras != nil {
+			return node_extras
 		}
 		kind_extras := t.GetKind(t.GetNodeKind(name)).GetExtras()
-		if kind_extras != nil && kind_extras.GetExtras_srl() != nil {
-			return kind_extras.GetExtras_srl()
+		if kind_extras != nil {
+			return kind_extras
 		}
-		default_extras := t.GetDefaults().GetExtras()
-		if default_extras != nil && default_extras.GetExtras_srl() != nil {
-			return default_extras.GetExtras_srl()
-		}
+		return t.GetDefaults().GetExtras()
 	}
 	return nil
 }
@@ -426,7 +419,7 @@ func (t *Topology) GetNodeExtras(name string) *NodeExtrasDefinition_srl {
 func (t *Topology) GetNodeExtras_srl_Agents(name string) []string {
 	extras := t.GetNodeExtras(name)
 	if extras != nil {
-		return extras.GetAgents()
+		return extras.Agents
 	}
 	return make([]string,0)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -105,6 +105,9 @@ type NodeConfig struct {
 	// Resource requirements
 	CPU, RAM         string
 	DeploymentStatus string // status that is set by containerlab to indicate deployment stage
+
+	// Extras
+	Agents               []string    // Paths to YAML files for SRL agent extensions
 }
 
 // GenerateConfig generates configuration for the nodes


### PR DESCRIPTION
SR Linux supports custom agents; this feature copies agent YAML files under /etc/opt/srlinux/appmgr

TODO: Documentation (coming next)