### PR TITLE
Removing the need for srl template config

### DIFF
--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -143,8 +143,8 @@ func createCEOSFiles(node *types.NodeConfig) error {
 }
 
 // ceosPostDeploy runs postdeploy actions which are required for ceos nodes
-func ceosPostDeploy(_ context.Context, _ runtime.ContainerRuntime, node *types.NodeConfig) error {
-	d, err := utils.SpawnCLIviaExec("arista_eos", node.LongName)
+func ceosPostDeploy(_ context.Context, r runtime.ContainerRuntime, node *types.NodeConfig) error {
+	d, err := utils.SpawnCLIviaExec("arista_eos", node.LongName, r.GetName())
 	if err != nil {
 		return err
 	}

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -166,7 +166,7 @@ func (s *srl) Deploy(ctx context.Context) error {
 
 func (s *srl) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 	// only perform postdeploy additional config provisioning if there is not startup nor existing config
-	if s.cfg.StartupConfig != "" || utils.FileExists(s.cfg.LabDir+"/config/config.json") {
+	if s.cfg.StartupConfig != "" || utils.FileExists(filepath.Join(s.cfg.LabDir, "config", "config.json")) {
 		return nil
 	}
 

--- a/utils/networkcli.go
+++ b/utils/networkcli.go
@@ -6,6 +6,7 @@ import (
 	"github.com/scrapli/scrapligo/driver/base"
 	"github.com/scrapli/scrapligo/driver/core"
 	"github.com/scrapli/scrapligo/driver/network"
+	"github.com/scrapli/scrapligo/logging"
 	"github.com/scrapli/scrapligo/transport"
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/srlinux-scrapli"
@@ -25,6 +26,9 @@ func SpawnCLIviaExec(platform, contName string) (*network.Driver, error) {
 	var d *network.Driver
 	var err error
 
+	// uncomment to enable logging
+	logging.SetDebugLogger(log.Print)
+
 	switch platform {
 	case "nokia_srlinux":
 		d, err = srlinux.NewSRLinuxDriver(
@@ -33,6 +37,9 @@ func SpawnCLIviaExec(platform, contName string) (*network.Driver, error) {
 			// disable transport timeout
 			base.WithTimeoutTransport(0),
 		)
+		// jack up PtyWidth, since we use `docker exec` to enter certificate and key strings
+		// and these are lengthy
+		d.Transport.BaseTransportArgs.PtyWidth = 5000
 	default:
 		d, err = core.NewCoreDriver(
 			contName,

--- a/utils/networkcli.go
+++ b/utils/networkcli.go
@@ -6,7 +6,6 @@ import (
 	"github.com/scrapli/scrapligo/driver/base"
 	"github.com/scrapli/scrapligo/driver/core"
 	"github.com/scrapli/scrapligo/driver/network"
-	"github.com/scrapli/scrapligo/logging"
 	"github.com/scrapli/scrapligo/transport"
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/srlinux-scrapli"
@@ -25,9 +24,6 @@ var (
 func SpawnCLIviaExec(platform, contName string) (*network.Driver, error) {
 	var d *network.Driver
 	var err error
-
-	// uncomment to enable logging
-	logging.SetDebugLogger(log.Print)
 
 	switch platform {
 	case "nokia_srlinux":

--- a/utils/networkcli.go
+++ b/utils/networkcli.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"time"
 
 	"github.com/scrapli/scrapligo/driver/base"
@@ -17,11 +18,24 @@ var (
 		"arista_eos":    "Cli",
 		"nokia_srlinux": "sr_cli",
 	}
+
+	// map of the cli exec command and its argument per runtime
+	// which is used to spawn CLI session
+	CLIExecCommand = map[string]map[string]string{
+		"docker": {
+			"exec": "docker",
+			"open": "exec -it",
+		},
+		"containerd": {
+			"exec": "ctr",
+			"open": "-n clab task exec -t --exec-id clab",
+		},
+	}
 )
 
 // SpawnCLIviaExec spawns a CLI session over container runtime exec function
 // end ensures the CLI is available to be used for sending commands over
-func SpawnCLIviaExec(platform, contName string) (*network.Driver, error) {
+func SpawnCLIviaExec(platform, contName, runtime string) (*network.Driver, error) {
 	var d *network.Driver
 	var err error
 
@@ -50,9 +64,8 @@ func SpawnCLIviaExec(platform, contName string) (*network.Driver, error) {
 		return nil, err
 	}
 
-	// TODO: implement for ctr (containerd)
-	execCmd := "docker"
-	openCmd := []string{"exec", "-it"}
+	execCmd := CLIExecCommand[runtime]["exec"]
+	openCmd := strings.Split(CLIExecCommand[runtime]["open"], " ")
 
 	t, _ := d.Transport.Impl.(transport.SystemTransport)
 	t.SetExecCmd(execCmd)


### PR DESCRIPTION
This PR removes the need to have a default config for SRL. Having the default config poses some problems, as default/factory config grows over time (for example 21.6.2 added ldp and the relevant ACLs) and we need to somehow know which config is relevant for which version.

The approach taken in this PR is as follows:

1. instead of using the default config and template it with TLS/gnmi/json-rpc blobs we let srlinux to start with factory config
2. once it has started, we add the TLS/gnmi/json-rpc config blocks using scrapligo over the factory config that this SRL booted with

@karimra I would like to ask your opinion on this draft approach 


close #608 