### PR TITLE
add newline to the last ignite udev rule

### DIFF
--- a/runtime/ignite/iginite.go
+++ b/runtime/ignite/iginite.go
@@ -217,7 +217,7 @@ func (c *IgniteRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 	}
 	defer os.Remove(udevFile.Name())
 
-	if _, err := udevFile.Write([]byte(strings.Join(udevRules, "\n"))); err != nil {
+	if _, err := udevFile.Write([]byte(strings.Join(udevRules, "\n") + "\n")); err != nil {
 		return nil, err
 	}
 	if err := udevFile.Close(); err != nil {


### PR DESCRIPTION
Older versions of `systemd-udevd` require new line at the end of the file, otherwise error `invalid key/value pair` is occurring.