### PR TITLE
docs: veth links MTU fix

### DIFF
--- a/docs/cmd/tools/veth/create.md
+++ b/docs/cmd/tools/veth/create.md
@@ -30,7 +30,7 @@ vEth interface endpoint A is set with `--a-endpoint | -a` flag.
 vEth interface endpoint B is set with `--b-endpoint | -b` flag.
 
 #### mtu
-vEth interface MTU is set to `65000` by default, and can be changed with `--mtu | -m` flag.
+vEth interface MTU is set to `9500` by default, and can be changed with `--mtu | -m` flag.
 
 ### Examples
 

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -215,7 +215,7 @@ Management network is used to provide management access to the NOS containers, i
 
 The above diagram shows how links are created in the topology definition file. In this example, the datapath consists of the two virtual point-to-point wires between SR Linux and cEOS containers. These links are created on-demand by containerlab itself.
 
-The p2p links are provided by the `veth` device pairs where each end of the `veth` pair is attached to a respective container. The MTU on these veth links is set to 65000, so a regular 9212 MTU on the network links shouldn't be a problem.
+The p2p links are provided by the `veth` device pairs where each end of the `veth` pair is attached to a respective container. The MTU on these veth links is set to 9500, so a regular 9212 MTU on the network links shouldn't be a problem.
 
 ### host links
 It is also possible to interconnect container' data interface not with other container or add it to a [bridge](kinds/bridge.md), but to attach it to a host's root namespace. This is, for example, needed to create a L2 connectivity between containerlab nodes running on different VMs (aka multi-node labs).


### PR DESCRIPTION
[In 0.15 release](https://containerlab.srlinux.dev/rn/0.15/#miscellaneous), default MTU for veth links has been [changed to 9500](https://github.com/srl-labs/containerlab/blob/dd122d0510f4545bd185f2bd11acdb497eefa52a/clab/config.go#L37). Docs still mention old value(65000).