### PR TITLE
Refactor GenericContainer type struct to use pass by value semantics

### DIFF
--- a/clab/hostsfile.go
+++ b/clab/hostsfile.go
@@ -67,13 +67,11 @@ func generateHostsEntries(containers []types.GenericContainer, labname string) [
 		if len(cont.Names) == 0 {
 			continue
 		}
-		if cont.NetworkSettings.Set {
-			if cont.NetworkSettings.IPv4addr != "" {
-				fmt.Fprintf(&entries, "%s\t%s\n", cont.NetworkSettings.IPv4addr, strings.TrimLeft(cont.Names[0], "/"))
-			}
-			if cont.NetworkSettings.IPv6addr != "" {
-				fmt.Fprintf(&v6entries, "%s\t%s\n", cont.NetworkSettings.IPv6addr, strings.TrimLeft(cont.Names[0], "/"))
-			}
+		if cont.NetworkSettings.IPv4addr != "" {
+			fmt.Fprintf(&entries, "%s\t%s\n", cont.NetworkSettings.IPv4addr, strings.TrimLeft(cont.Names[0], "/"))
+		}
+		if cont.NetworkSettings.IPv6addr != "" {
+			fmt.Fprintf(&v6entries, "%s\t%s\n", cont.NetworkSettings.IPv6addr, strings.TrimLeft(cont.Names[0], "/"))
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -260,11 +260,11 @@ func setFlags(conf *clab.Config) {
 	if mgmtNetName != "" {
 		conf.Mgmt.Network = mgmtNetName
 	}
-	if mgmtIPv4Subnet.String() != "<nil>" {
-		conf.Mgmt.IPv4Subnet = mgmtIPv4Subnet.String()
+	if v4 := mgmtIPv4Subnet.String(); v4 != "<nil>" {
+		conf.Mgmt.IPv4Subnet = v4
 	}
-	if mgmtIPv6Subnet.String() != "<nil>" {
-		conf.Mgmt.IPv6Subnet = mgmtIPv6Subnet.String()
+	if v6 := mgmtIPv6Subnet.String(); v6 != "<nil>" {
+		conf.Mgmt.IPv6Subnet = v6
 	}
 }
 
@@ -277,14 +277,12 @@ func enrichNodes(containers []types.GenericContainer, nodesMap map[string]nodes.
 			if strings.ToLower(node.Config().NetworkMode) == "host" {
 				continue
 			}
-
-			if c.NetworkSettings.Set {
+			if c.NetworkSettings != (types.GenericMgmtIPs{}) {
 				node.Config().MgmtIPv4Address = c.NetworkSettings.IPv4addr
 				node.Config().MgmtIPv4PrefixLength = c.NetworkSettings.IPv4pLen
 				node.Config().MgmtIPv6Address = c.NetworkSettings.IPv6addr
 				node.Config().MgmtIPv6PrefixLength = c.NetworkSettings.IPv6pLen
 			}
-
 			node.Config().ContainerID = c.ID
 		}
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -226,26 +226,16 @@ func printContainerInspect(c *clab.CLab, containers []types.GenericContainer, fo
 }
 
 func getContainerIPv4(ctr types.GenericContainer) string {
-	if !ctr.NetworkSettings.Set {
-		return ""
-	}
-
 	if ctr.NetworkSettings.IPv4addr == "" {
-		return "NA"
+		return "N/A"
 	}
-
 	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv4addr, ctr.NetworkSettings.IPv4pLen)
 
 }
 
 func getContainerIPv6(ctr types.GenericContainer) string {
-	if !ctr.NetworkSettings.Set {
-		return ""
-	}
-
 	if ctr.NetworkSettings.IPv6addr == "" {
-		return "NA"
+		return "N/A"
 	}
-
 	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv6addr, ctr.NetworkSettings.IPv6pLen)
 }

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -232,8 +232,8 @@ func (c *ContainerdRuntime) CreateContainer(ctx context.Context, node *types.Nod
 		portmappings := []portMapping{}
 
 		for contdatasl, hostdata := range node.PortBindings {
-			//fmt.Printf("%+v", hostdata)
-			//fmt.Printf("%+v", contdatasl)
+			// fmt.Printf("%+v", hostdata)
+			// fmt.Printf("%+v", contdatasl)
 			for _, x := range hostdata {
 				hostport, err := strconv.Atoi(x.HostPort)
 				if err != nil {
@@ -380,8 +380,8 @@ func cniInit(cId, ifName string, mgmtNet *types.MgmtNet) (*libcni.CNIConfig, *li
 	cnirc := &libcni.RuntimeConf{
 		ContainerID: cId,
 		IfName:      ifName,
-		//// NetNS must be set later, can just be determined after container start
-		//NetNS:          node.NSPath,
+		// // NetNS must be set later, can just be determined after container start
+		// NetNS:          node.NSPath,
 		CapabilityArgs: make(map[string]interface{}),
 	}
 	return cnic, cncl, cnirc, nil
@@ -621,26 +621,23 @@ func (c *ContainerdRuntime) produceGenericContainerList(ctx context.Context, inp
 	return result, nil
 }
 
-func extractIPInfoFromLabels(labels map[string]string) (*types.GenericMgmtIPs, error) {
+func extractIPInfoFromLabels(labels map[string]string) (types.GenericMgmtIPs, error) {
 	var ipv4mask int
 	var ipv6mask int
 	var err error
-	isSet := false
 	if val, exists := labels["clab.ipv4.netmask"]; exists {
-		isSet = true
 		ipv4mask, err = strconv.Atoi(val)
 		if err != nil {
-			return nil, err
+			return types.GenericMgmtIPs{}, err
 		}
 	}
 	if val, exists := labels["clab.ipv6.netmask"]; exists {
-		isSet = true
 		ipv6mask, err = strconv.Atoi(val)
 		if err != nil {
-			return nil, err
+			return types.GenericMgmtIPs{}, err
 		}
 	}
-	return &types.GenericMgmtIPs{Set: isSet, IPv4addr: labels["clab.ipv4.addr"], IPv4pLen: ipv4mask, IPv6addr: labels["clab.ipv6.addr"], IPv6pLen: ipv6mask}, nil
+	return types.GenericMgmtIPs{IPv4addr: labels["clab.ipv4.addr"], IPv4pLen: ipv4mask, IPv6addr: labels["clab.ipv6.addr"], IPv6pLen: ipv6mask}, nil
 }
 
 func timeSinceInHuman(since time.Time) string {
@@ -705,7 +702,7 @@ func (c *ContainerdRuntime) exec(ctx context.Context, containername string, cmd 
 	}
 
 	process, err := task.Exec(ctx, clabExecId, pspec, ioCreator)
-	//task, err := container.NewTask(ctx, cio.NewCreator(cio_opt))
+	// task, err := container.NewTask(ctx, cio.NewCreator(cio_opt))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -465,16 +465,14 @@ func (c *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 
 	for _, i := range inputContainers {
 		ctr := types.GenericContainer{
-			Names:   i.Names,
-			ID:      i.ID,
-			ShortID: i.ID[:12],
-			Image:   i.Image,
-			State:   i.State,
-			Status:  i.Status,
-			Labels:  i.Labels,
-			NetworkSettings: &types.GenericMgmtIPs{
-				Set: false,
-			},
+			Names:           i.Names,
+			ID:              i.ID,
+			ShortID:         i.ID[:12],
+			Image:           i.Image,
+			State:           i.State,
+			Status:          i.Status,
+			Labels:          i.Labels,
+			NetworkSettings: types.GenericMgmtIPs{},
 		}
 		bridgeName := c.Mgmt.Network
 		// if bridgeName is "", try to find a network created by clab that the container is connected to
@@ -491,7 +489,6 @@ func (c *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 			ctr.NetworkSettings.IPv4pLen = ifcfg.IPPrefixLen
 			ctr.NetworkSettings.IPv6addr = ifcfg.GlobalIPv6Address
 			ctr.NetworkSettings.IPv6pLen = ifcfg.GlobalIPv6PrefixLen
-			ctr.NetworkSettings.Set = true
 		}
 		result = append(result, ctr)
 	}

--- a/runtime/ignite/iginite.go
+++ b/runtime/ignite/iginite.go
@@ -335,14 +335,12 @@ func (*IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]types.Gene
 
 	for _, i := range input {
 		ctr := types.GenericContainer{
-			Names:   []string{i.Name},
-			ID:      i.GetUID().String(),
-			ShortID: i.PrefixedID(),
-			Labels:  i.Labels,
-			Image:   i.Spec.Image.OCI.Normalized(),
-			NetworkSettings: &types.GenericMgmtIPs{
-				Set: false,
-			},
+			Names:           []string{i.Name},
+			ID:              i.GetUID().String(),
+			ShortID:         i.PrefixedID(),
+			Labels:          i.Labels,
+			Image:           i.Spec.Image.OCI.Normalized(),
+			NetworkSettings: types.GenericMgmtIPs{},
 		}
 
 		if i.Status.Runtime.ID != "" && len(i.Status.Runtime.ID) > 12 {
@@ -358,7 +356,6 @@ func (*IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]types.Gene
 			// TODO: figure out what to do with this
 			ctr.NetworkSettings.IPv4pLen = 24
 
-			ctr.NetworkSettings.Set = true
 			break
 		}
 

--- a/types/types.go
+++ b/types/types.go
@@ -92,7 +92,7 @@ type NodeConfig struct {
 	TLSKey               string
 	TLSAnchor            string
 	NSPath               string   // network namespace path for this node
-	Publish              []string //list of ports to publish with mysocketctl
+	Publish              []string // list of ports to publish with mysocketctl
 	ExtraHosts           []string // Extra /etc/hosts entries for all nodes
 	// container labels
 	Labels map[string]string
@@ -174,11 +174,10 @@ type GenericContainer struct {
 	Status          string
 	Labels          map[string]string
 	Pid             int
-	NetworkSettings *GenericMgmtIPs
+	NetworkSettings GenericMgmtIPs
 }
 
 type GenericMgmtIPs struct {
-	Set      bool
 	IPv4addr string
 	IPv4pLen int
 	IPv6addr string


### PR DESCRIPTION
Brings memory safety to working with NetworkSettings struct inside the container struct.
Currently implemented logic with NetworkSettings.Set bool doesn't work with nil-pointers and will panic. Also there's no need for pointers in the first place