### PR TITLE
Make "clab configure" to skip nodes without templates or credentials

### DIFF
--- a/clab/config/send.go
+++ b/clab/config/send.go
@@ -17,6 +17,9 @@ func Send(cs *NodeConfig, action string) error {
 	}
 
 	if ct == "ssh" {
+		if len(nodes.DefaultCredentials[cs.TargetNode.Kind]) < 2 {
+			return fmt.Errorf("SSH credentials for node %s of type %s not found, cannot configure", cs.TargetNode.ShortName, cs.TargetNode.Kind)
+		}
 		tx, err = transport.NewSSHTransport(
 			cs.TargetNode,
 			transport.WithUserNamePassword(

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -71,19 +71,18 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 		for _, baseN := range TemplateNames {
 			tmplN := fmt.Sprintf("%s__%s.tmpl", baseN, nc.Vars[vkRole])
 			log.Debugf("Looking up template %v", tmplN)
-			l := tmpl.Lookup(tmplN)
-			if l == nil {
+			if l := tmpl.Lookup(tmplN); l == nil {
 				err := LoadTemplates(tmpl, fmt.Sprintf("%s", nc.Vars[vkRole]))
 				if err != nil {
 					log.Warnf("Unable to load template %s; skipping", tmplN)
 					continue
 				}
 				l = tmpl.Lookup(tmplN)
-			}
-			log.Debugf("Got a lookup result %+v (of type %T)", l, l)
-			if l == nil {
-				log.Warnf("No template found for %s; skipping..", nc.TargetNode.ShortName)
-				continue
+				log.Debugf("Got a lookup result %+v (of type %T)", l, l)
+				if l == nil {
+					log.Warnf("No template found for %s; skipping..", nc.TargetNode.ShortName)
+					continue
+				}
 			}
 			var buf strings.Builder
 			err := tmpl.ExecuteTemplate(&buf, tmplN, nc.Vars)

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -38,7 +38,7 @@ func LoadTemplates(tmpl *template.Template, role string) error {
 		fn := filepath.Join(p, fmt.Sprintf("*__%s.tmpl", role))
 		_, err := tmpl.ParseGlob(fn)
 		if err != nil {
-			return fmt.Errorf("could not load templates from %s: %s", fn, err)
+			return fmt.Errorf("could not load templates from %s: %w", fn, err)
 		}
 	}
 	return nil
@@ -68,22 +68,26 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 	tmpl := template.New("").Funcs(jT.Funcs)
 
 	for _, nc := range allnodes {
-
 		for _, baseN := range TemplateNames {
 			tmplN := fmt.Sprintf("%s__%s.tmpl", baseN, nc.Vars[vkRole])
-
-			if tmpl.Lookup(tmplN) == nil {
+			log.Debugf("Looking up template %v", tmplN)
+			l := tmpl.Lookup(tmplN)
+			if l == nil {
 				err := LoadTemplates(tmpl, fmt.Sprintf("%s", nc.Vars[vkRole]))
 				if err != nil {
-					return err
+					log.Warnf("Unable to load template %s; skipping", tmplN)
+					continue
 				}
-				if tmpl.Lookup(tmplN) == nil {
-					return fmt.Errorf("template not found %s", tmplN)
-				}
+				l = tmpl.Lookup(tmplN)
 			}
-
+			log.Debugf("Got a lookup result %+v (of type %T)", l, l)
+			if l == nil {
+				log.Warnf("No template found for %s; skipping..", nc.TargetNode.ShortName)
+				continue
+			}
 			var buf strings.Builder
 			err := tmpl.ExecuteTemplate(&buf, tmplN, nc.Vars)
+			log.Debugf("Executed a template %s with an error code %v", tmplN, err)
 			if err != nil {
 				nc.Print(true, true)
 				return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -107,7 +107,7 @@ func configRun(_ *cobra.Command, args []string) error {
 
 		err = config.Send(cs, action)
 		if err != nil {
-			log.Errorf("%s: %s", cs.TargetNode.ShortName, err)
+			log.Warnf("%s: %s", cs.TargetNode.ShortName, err)
 		}
 	}
 	wg.Add(len(configFilter))


### PR DESCRIPTION
Lazy fix for #651. It is still going to connect to all nodes (if we have credentials) but won't send anything without a template.