### PR TITLE
Updated endpoint list schema to match the node name schema

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -238,7 +238,7 @@
                     "minItems": 2,
                     "items": {
                         "type": "string",
-                        "pattern": "^[\\w\\s-/]+:[\\w\\s-/]+$"
+                        "pattern": "^.*:[\\w\\s-/]+$"
                     },
                     "uniqueItems": true
                 }

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -238,7 +238,7 @@
                     "minItems": 2,
                     "items": {
                         "type": "string",
-                        "pattern": "^.*:[\\w\\s-/]+$"
+                        "pattern": "^\\S+:\\S+$"
                     },
                     "uniqueItems": true
                 }


### PR DESCRIPTION
Fixes #705 

This uses the same naming pattern as the nodes (line 301)

