### PR TITLE
auto enabled sr linux interfaces

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -238,7 +238,7 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		MgmtIPv6Address: nodeDef.GetMgmtIPv6(),
 		Publish:         c.Config.Topology.GetNodePublish(nodeName),
 		Sysctls:         make(map[string]string),
-		Endpoints:       make([]*types.Endpoint, 0),
+		Endpoints:       make([]types.Endpoint, 0),
 		Sandbox:         c.Config.Topology.GetNodeSandbox(nodeName),
 		Kernel:          c.Config.Topology.GetNodeKernel(nodeName),
 		Runtime:         c.Config.Topology.GetNodeRuntime(nodeName),
@@ -342,7 +342,7 @@ func (c *CLab) NewEndpoint(e string) *types.Endpoint {
 		c.m.Lock()
 		if n, ok := c.Nodes[nName]; ok {
 			endpoint.Node = n.Config()
-			n.Config().Endpoints = append(n.Config().Endpoints, endpoint)
+			n.Config().Endpoints = append(n.Config().Endpoints, *endpoint)
 		}
 		c.m.Unlock()
 	}

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -73,6 +73,7 @@ By default, `ixrd2` type will be used by containerlab.
 Based on the provided type, containerlab will generate the topology file that will be mounted to the SR Linux container and make it boot in a chosen HW variant.
 ### Node configuration
 SR Linux uses a `/etc/opt/srlinux/config.json` file to persist its configuration. By default, containerlab starts nodes of `srl` kind with a basic "default" config, and with the `startup-config` parameter, it is possible to provide a custom config file that will be used as a startup one.
+
 #### Default node configuration
 When a node is defined without the `startup-config` statement present, containerlab will make [additional configurations](https://github.com/srl-labs/containerlab/blob/master/nodes/srl/srl.go#L38) on top of the factory config:
 
@@ -89,6 +90,13 @@ topology:
 ```
 
 The generated config will be saved by the path `clab-<lab_name>/<node-name>/config/config.json`. Using the example topology presented above, the exact path to the config will be `clab-srl_lab/srl1/config/config.json`.
+
+Additional configurations that containerlab adds on top of the factory config:
+
+* enabling interfaces (`admin-state enable`) referenced in the topology's `links` section
+* enabling LLDP
+* enabling gNMI/JSON-RPC
+* creating tls server certificate
 
 #### User defined startup config
 It is possible to make SR Linux nodes boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind a user sets the path to the local config file that will be used as a startup config.

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -51,13 +51,13 @@ set / system json-rpc-server admin-state enable network-instance mgmt https admi
 set / system lldp admin-state enable
 set / system aaa authentication idle-timeout 7200
 {{/* enabling interfaces referenced as endpoints for a node (both e1-2 and e1-3-1 notations) */}}
-{{ range $ep := .Endpoints }}
+{{- range $ep := .Endpoints }}
 {{- $parts := ($ep.EndpointName | strings.ReplaceAll "e" "" | strings.Split "-") -}}
 set / interface ethernet-{{index $parts 0}}/{{index $parts 1}} admin-state enable
   {{- if eq (len $parts) 3 }}
 set / interface ethernet-{{index $parts 0}}/{{index $parts 1}}/{{index $parts 2}} admin-state enable
   {{- end }}
-{{- end }}
+{{ end -}}
 commit save`
 )
 

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -29,6 +29,16 @@ Verify links in node srl2
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
+Verify e1-1 interface have been admin enabled on srl1
+    [Documentation]
+    ...    This test cases ensures that e1-1 interface referenced in links section
+    ...    has been automatically admin enabled
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    ethernet-1/1 is up
+
 Verify srl2 accepted user-provided CLI config
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "sr_cli 'info /system information location'"

--- a/types/types.go
+++ b/types/types.go
@@ -97,7 +97,7 @@ type NodeConfig struct {
 	// container labels
 	Labels map[string]string
 	// Slice of pointers to local endpoints
-	Endpoints []*Endpoint
+	Endpoints []Endpoint
 	// Ignite sandbox and kernel imageNames
 	Sandbox, Kernel string
 	// Configured container runtime


### PR DESCRIPTION
SR Linux interfaces which are referenced in `links` section will be `admin-state enabled` once the node boots