### PR TITLE
added logging of clab version

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,6 +48,9 @@ var deployCmd = &cobra.Command{
 	PreRunE:      sudoCheck,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
+
+		log.Infof("Containerlab v%s started", version)
+
 		opts := []clab.ClabOption{
 			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo, varsFile),


### PR DESCRIPTION
fix #719 

the first log line will tell which clab version is being run. I don't want to pollute it with the path, as this is not a common behaviour for cli tools.


```
❯ clab dep -t srl.clab.yml 
INFO[0000] Containerlab v0.0.0 started  
```