### PR TITLE
Use Docker authentication when needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/podman/v3 v3.4.4
 	github.com/digitalocean/go-openvswitch v0.0.0-20201214180534-ce0f183468d8
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
@@ -92,7 +93,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/disiqueira/gotree/v3 v3.0.2 // indirect
 	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -20,7 +20,7 @@ type DockerConfig struct {
 	Auths map[string]DockerConfigAuth
 }
 
-func GetImageDomainName(imageName string) string {
+func getImageDomainName(imageName string) string {
 	var imageDomainName string
 
 	imageRef, err := reference.ParseNormalizedNamed(imageName)
@@ -34,7 +34,7 @@ func GetImageDomainName(imageName string) string {
 	return imageDomainName
 }
 
-func GetDockerConfigPath(configPath string) (string, error) {
+func getDockerConfigPath(configPath string) (string, error) {
 	const dockerDefaultConfigDir = ".docker"
 	const dockerDefaultConfigFile = "config.json"
 	var dockerConfigError error
@@ -58,7 +58,7 @@ func GetDockerConfigPath(configPath string) (string, error) {
 func GetDockerConfig(configPath string) (*DockerConfig, error) {
 	var dockerConfig DockerConfig
 
-	dockerConfigPath, err := GetDockerConfigPath(configPath)
+	dockerConfigPath, err := getDockerConfigPath(configPath)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func GetDockerAuth(dockerConfig *DockerConfig, imageName string) (string, error)
 	const authStringLength = 2
 	const authStringSep = ":"
 
-	imageDomain := GetImageDomainName(imageName)
+	imageDomain := getImageDomainName(imageName)
 
 	if domainConfig, ok := dockerConfig.Auths[imageDomain]; ok {
 		decodedAuth, err := base64.URLEncoding.DecodeString(domainConfig.Auth)

--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -21,17 +21,22 @@ type DockerConfig struct {
 }
 
 func GetImageDomainName(imageName string) string {
+	var imageDomainName string
+
 	imageRef, err := reference.ParseNormalizedNamed(imageName)
 	if err != nil {
-		panic(err)
+		imageDomainName = ""
+		log.Errorf("Unable to fetch image normalized name, error: %v", err)
+	} else {
+		imageDomainName = reference.Domain(imageRef)
 	}
 
-	domainName := reference.Domain(imageRef)
-
-	return domainName
+	return imageDomainName
 }
 
 func GetDockerConfigPath(configPath string) (string, error) {
+	const dockerDefaultConfigDir = ".docker"
+	const dockerDefaultConfigFile = "config.json"
 	var dockerConfigError error
 	var dockerConfigPath string
 
@@ -42,7 +47,7 @@ func GetDockerConfigPath(configPath string) (string, error) {
 			dockerConfigError = err
 		}
 
-		dockerConfigPath = path.Join(homeDir, ".docker", "config.json")
+		dockerConfigPath = path.Join(homeDir, dockerDefaultConfigDir, dockerDefaultConfigFile)
 	} else {
 		dockerConfigPath = configPath
 	}
@@ -60,13 +65,13 @@ func GetDockerConfig(configPath string) (*DockerConfig, error) {
 
 	file, err := os.ReadFile(dockerConfigPath)
 	if err != nil {
-		log.Errorf("Unable to read docker config, error: %v", err)
+		log.Infof("Could not read docker config: %v", err)
 		return nil, err
 	}
 
 	jsonError := json.Unmarshal(file, &dockerConfig)
 	if jsonError != nil {
-		log.Errorf("Unable to Unmarshal docker config, error: %v", jsonError)
+		log.Errorf("Failed to unmarshal docker config: %v", jsonError)
 		return nil, jsonError
 	}
 

--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -1,0 +1,94 @@
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+)
+
+func GetImageDomainName(imageName string) string {
+	imageRef, err := reference.ParseNormalizedNamed(imageName)
+	if err != nil {
+		panic(err)
+	}
+
+	domainName := reference.Domain(imageRef)
+
+	return domainName
+}
+
+func GetDockerConfigPath(configPath string) (string, error) {
+	var dockerConfigError error
+	var dockerConfigPath string
+
+	if configPath == "" {
+		homeDir, err := os.UserHomeDir()
+
+		if err != nil {
+			dockerConfigError = err
+		}
+
+		dockerConfigPath = path.Join(homeDir, ".docker", "config.json")
+	} else {
+		dockerConfigPath = configPath
+	}
+
+	return dockerConfigPath, dockerConfigError
+}
+
+func GetDockerConfig(configPath string) (*DockerConfig, error) {
+	dockerConfigPath, err := GetDockerConfigPath(configPath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.ReadFile(dockerConfigPath)
+	if err != nil {
+		log.Errorf("Unable to read docker config, error: %v", err)
+		return nil, err
+	}
+
+	var dockerConfig DockerConfig
+	jsonError := json.Unmarshal(file, &dockerConfig)
+
+	if jsonError != nil {
+		log.Errorf("Unable to Unmarshal docker config, error: %v", jsonError)
+		return nil, jsonError
+	}
+
+	return &dockerConfig, nil
+}
+
+func GetDockerAuth(dockerConfig *DockerConfig, imageName string) (string, error) {
+	imageDomain := GetImageDomainName(imageName)
+
+	if authString, ok := dockerConfig.Auths[imageDomain]["auth"]; ok {
+		decodedAuth, err := base64.URLEncoding.DecodeString(authString)
+		if err != nil {
+			return "", err
+		}
+
+		decodedAuthSplit := strings.Split(string(decodedAuth), ":")
+		authConfig := types.AuthConfig{
+			Username: decodedAuthSplit[0],
+			Password: decodedAuthSplit[1],
+		}
+
+		encodedJSON, err := json.Marshal(authConfig)
+		if err != nil {
+			return "", err
+		}
+
+		authString := base64.URLEncoding.EncodeToString(encodedJSON)
+		return authString, nil
+	}
+
+	return "", nil
+}

--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -4,12 +4,17 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	dockerDefaultConfigDir  = ".docker"
+	dockerDefaultConfigFile = "config.json"
 )
 
 type DockerConfigAuth struct {
@@ -35,24 +40,17 @@ func getImageDomainName(imageName string) string {
 }
 
 func getDockerConfigPath(configPath string) (string, error) {
-	const dockerDefaultConfigDir = ".docker"
-	const dockerDefaultConfigFile = "config.json"
-	var dockerConfigError error
-	var dockerConfigPath string
-
+	var err error
 	if configPath == "" {
 		homeDir, err := os.UserHomeDir()
-
 		if err != nil {
-			dockerConfigError = err
+			return "", err
 		}
 
-		dockerConfigPath = path.Join(homeDir, dockerDefaultConfigDir, dockerDefaultConfigFile)
-	} else {
-		dockerConfigPath = configPath
+		configPath = filepath.Join(homeDir, dockerDefaultConfigDir, dockerDefaultConfigFile)
 	}
 
-	return dockerConfigPath, dockerConfigError
+	return configPath, err
 }
 
 func GetDockerConfig(configPath string) (*DockerConfig, error) {

--- a/runtime/docker/auth_test.go
+++ b/runtime/docker/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/srl-labs/containerlab/utils"
 )
 
@@ -29,11 +30,23 @@ func TestGetImageDomainName(t *testing.T) {
 }
 
 func TestGetDockerConfigPath(t *testing.T) {
-	want := "/some/path/config.json"
-	got, _ := getDockerConfigPath(want)
+	td := map[string]map[string]string{
+		"fixed-path": {
+			"path": "/some/path/config.json",
+			"want": "/some/path/config.json",
+		},
+		"default": {
+			"path": "",
+			"want": "~/.docker/config.json",
+		},
+	}
 
-	if got != want {
-		t.Errorf("Invalid docker config path, got %v, want %v", got, want)
+	for _, in := range td {
+		got, _ := getDockerConfigPath(in["path"])
+		want, _ := homedir.Expand(in["want"])
+		if got != want {
+			t.Errorf("Invalid docker config path, got %v, want %v", got, in["want"])
+		}
 	}
 }
 

--- a/runtime/docker/auth_test.go
+++ b/runtime/docker/auth_test.go
@@ -16,6 +16,8 @@ var imageDomainNameTests = []imageDomainNameTest{
 	{imageName: "alpine", want: "docker.io"},
 	{imageName: "docker.io/alpine:3.14", want: "docker.io"},
 	{imageName: "example.com/example/alpine", want: "example.com"},
+	{imageName: ".invalid_format", want: ""},
+	{imageName: "", want: ""},
 }
 
 func TestGetImageDomainName(t *testing.T) {

--- a/runtime/docker/auth_test.go
+++ b/runtime/docker/auth_test.go
@@ -1,0 +1,89 @@
+package docker
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/srl-labs/containerlab/utils"
+)
+
+type imageDomainNameTest struct {
+	imageName, want string
+}
+
+var imageDomainNameTests = []imageDomainNameTest{
+	{imageName: "alpine", want: "docker.io"},
+	{imageName: "docker.io/alpine:3.14", want: "docker.io"},
+	{imageName: "example.com/example/alpine", want: "example.com"},
+}
+
+func TestGetImageDomainName(t *testing.T) {
+	for _, test := range imageDomainNameTests {
+		if got := GetImageDomainName(test.imageName); got != test.want {
+			t.Errorf("Image domain names do not match, got %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestGetDockerConfigPath(t *testing.T) {
+	want := "/some/path/config.json"
+	got, _ := GetDockerConfigPath(want)
+
+	if got != want {
+		t.Errorf("Invalid docker config path, got %v, want %v", got, want)
+	}
+}
+
+func TestGetDockerAuthContainsExpectedUser(t *testing.T) {
+	// Verify that the resulting auth string contains the expected user for the given domain
+	imageName := utils.GetCanonicalImageName("test.example.com/repository/alpine")
+	dockerConfig, _ := GetDockerConfig("test_data/docker.config")
+
+	want := "testuser1"
+
+	got, err := GetDockerAuth(dockerConfig, imageName)
+
+	if err != nil {
+		t.Errorf("Error gettin docker auth, %v", err)
+	}
+
+	if err != nil {
+		t.Errorf("Error decodeing auth string, error %v", err)
+	}
+
+	decodedAuthString, err := base64.URLEncoding.DecodeString(got)
+	contains := strings.Contains(string(decodedAuthString), want)
+
+	if contains != true {
+		t.Errorf("Invalid docker auth, %v does not contain %v", string(decodedAuthString), want)
+	}
+}
+
+func TestGetDockerAuthEmpty(t *testing.T) {
+	imageName := utils.GetCanonicalImageName("alpine")
+	dockerConfig, _ := GetDockerConfig("test_data/docker.config")
+	want := ""
+
+	got, err := GetDockerAuth(dockerConfig, imageName)
+
+	if err != nil {
+		t.Errorf("Error gettin docker auth, %v", err)
+	}
+
+	if err != nil {
+		t.Errorf("Error decodeing auth string, error %v", err)
+	}
+
+	if got != want {
+		t.Errorf("Expected empty auth string, got %v, want %v", got, want)
+	}
+}
+
+func TestGetDockerAuthEmptyGivenInvalidDockerConfig(t *testing.T) {
+	got, _ := GetDockerConfig("test_data/invalid_docker.config")
+
+	if got != nil {
+		t.Errorf("Expected empty auth string, got %v, want %v", got, nil)
+	}
+}

--- a/runtime/docker/auth_test.go
+++ b/runtime/docker/auth_test.go
@@ -22,7 +22,7 @@ var imageDomainNameTests = []imageDomainNameTest{
 
 func TestGetImageDomainName(t *testing.T) {
 	for _, test := range imageDomainNameTests {
-		if got := GetImageDomainName(test.imageName); got != test.want {
+		if got := getImageDomainName(test.imageName); got != test.want {
 			t.Errorf("Image domain names do not match, got %v, want %v", got, test.want)
 		}
 	}
@@ -30,7 +30,7 @@ func TestGetImageDomainName(t *testing.T) {
 
 func TestGetDockerConfigPath(t *testing.T) {
 	want := "/some/path/config.json"
-	got, _ := GetDockerConfigPath(want)
+	got, _ := getDockerConfigPath(want)
 
 	if got != want {
 		t.Errorf("Invalid docker config path, got %v, want %v", got, want)

--- a/runtime/docker/auth_test.go
+++ b/runtime/docker/auth_test.go
@@ -52,7 +52,7 @@ func TestGetDockerAuthContainsExpectedUser(t *testing.T) {
 		t.Errorf("Error decodeing auth string, error %v", err)
 	}
 
-	decodedAuthString, err := base64.URLEncoding.DecodeString(got)
+	decodedAuthString, _ := base64.URLEncoding.DecodeString(got)
 	contains := strings.Contains(string(decodedAuthString), want)
 
 	if contains != true {
@@ -60,7 +60,7 @@ func TestGetDockerAuthContainsExpectedUser(t *testing.T) {
 	}
 }
 
-func TestGetDockerAuthEmpty(t *testing.T) {
+func TestGetDockerAuthGivenNoMatchingDomain(t *testing.T) {
 	imageName := utils.GetCanonicalImageName("alpine")
 	dockerConfig, _ := GetDockerConfig("test_data/docker.config")
 	want := ""
@@ -80,7 +80,27 @@ func TestGetDockerAuthEmpty(t *testing.T) {
 	}
 }
 
-func TestGetDockerAuthEmptyGivenInvalidDockerConfig(t *testing.T) {
+func TestGetDockerAuthGivenMissingAuthString(t *testing.T) {
+	imageName := utils.GetCanonicalImageName("bad.example.com/alpine")
+	dockerConfig, _ := GetDockerConfig("test_data/docker.config")
+	want := ""
+
+	got, err := GetDockerAuth(dockerConfig, imageName)
+
+	if err != nil {
+		t.Errorf("Error gettin docker auth, %v", err)
+	}
+
+	if err != nil {
+		t.Errorf("Error decodeing auth string, error %v", err)
+	}
+
+	if got != want {
+		t.Errorf("Expected empty auth string, got %v, want %v", got, want)
+	}
+}
+
+func TestGetDockerAuthGivenInvalidDockerConfig(t *testing.T) {
 	got, _ := GetDockerConfig("test_data/invalid_docker.config")
 
 	if got != nil {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -400,9 +400,10 @@ func (c *DockerRuntime) PullImageIfRequired(ctx context.Context, imageName strin
 	}
 
 	canonicalImageName := utils.GetCanonicalImageName(imageName)
-	dockerConfig, err := GetDockerConfig("")
 	authString := ""
 
+	// get docker config based on an empty path (default docker config path will be assumed)
+	dockerConfig, err := GetDockerConfig("")
 	if err != nil {
 		log.Infof("Skipping authenticated pull")
 	} else {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -51,14 +51,6 @@ type DockerRuntime struct {
 	Mgmt   *types.MgmtNet
 }
 
-type DockerConfigAuth struct {
-	Auth string
-}
-
-type DockerConfig struct {
-	Auths map[string]DockerConfigAuth
-}
-
 func (c *DockerRuntime) Init(opts ...runtime.RuntimeOption) error {
 	var err error
 	log.Debug("Runtime: Docker")

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -51,8 +51,12 @@ type DockerRuntime struct {
 	Mgmt   *types.MgmtNet
 }
 
+type DockerConfigAuth struct {
+	Auth string
+}
+
 type DockerConfig struct {
-	Auths map[string]map[string]string
+	Auths map[string]DockerConfigAuth
 }
 
 func (c *DockerRuntime) Init(opts ...runtime.RuntimeOption) error {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -405,7 +405,7 @@ func (c *DockerRuntime) PullImageIfRequired(ctx context.Context, imageName strin
 	// get docker config based on an empty path (default docker config path will be assumed)
 	dockerConfig, err := GetDockerConfig("")
 	if err != nil {
-		log.Infof("Skipping authenticated pull")
+		log.Debug("docker config file not found")
 	} else {
 		authString, err = GetDockerAuth(dockerConfig, canonicalImageName)
 		if err != nil {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -400,8 +400,8 @@ func (c *DockerRuntime) PullImageIfRequired(ctx context.Context, imageName strin
 	}
 
 	canonicalImageName := utils.GetCanonicalImageName(imageName)
-	authString := ""
 	dockerConfig, err := GetDockerConfig("")
+	authString := ""
 
 	if err != nil {
 		log.Infof("Skipping authenticated pull")

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -400,15 +400,12 @@ func (c *DockerRuntime) PullImageIfRequired(ctx context.Context, imageName strin
 	}
 
 	canonicalImageName := utils.GetCanonicalImageName(imageName)
-
-	dockerConfig, err := GetDockerConfig("")
-	if err != nil {
-		log.Infof("Unable to load docker config file, skipping authenticated pull. Error: %v", err)
-	}
-
 	authString := ""
+	dockerConfig, err := GetDockerConfig("")
 
-	if dockerConfig != nil {
+	if err != nil {
+		log.Infof("Skipping authenticated pull")
+	} else {
 		authString, err = GetDockerAuth(dockerConfig, canonicalImageName)
 		if err != nil {
 			return err

--- a/runtime/docker/test_data/docker.config
+++ b/runtime/docker/test_data/docker.config
@@ -1,0 +1,10 @@
+{
+    "auths": {
+        "test.example.com": {
+            "auth": "dGVzdHVzZXIxOnRlc3RwYXNzMQo="
+        },
+        "other.example.com": {
+            "auth": "dGVzdHVzZXI6dGVzdHBhc3MK"
+        }
+    }
+}

--- a/runtime/docker/test_data/docker.config
+++ b/runtime/docker/test_data/docker.config
@@ -5,6 +5,8 @@
         },
         "other.example.com": {
             "auth": "dGVzdHVzZXI6dGVzdHBhc3MK"
+        },
+        "bad.example.com": {
         }
     }
 }

--- a/runtime/docker/test_data/invalid_docker.config
+++ b/runtime/docker/test_data/invalid_docker.config
@@ -1,0 +1,10 @@
+{
+    "auths": {
+        "test.example.com": {
+            "auth": "dGVzdHVzZXIxOnRlc3RwYXNzMQo="
+        }
+        "other.example.com": {
+            "auth": "dGVzdHVzZXI6dGVzdHBhc3MK"
+        }
+    }
+}


### PR DESCRIPTION
This PR enables authenticated image pulls when using the Docker runtime by leveraging an existing Docker configuration file. The authentication mechanism used in this PR assumes that the docker credential store is `$HOME/.docker/config.json`. Closes #741 

**Scenarios where registry credentials are used**:
* If an image must be pulled from a registry, the image domain is used to locate authentication credentials in the docker config. If a match is found the credentials are included in the image pull request.

**Scenarios where registry credentials are not used**:
* If an image must be pulled from a registry and a matching authentication credential is not found in the docker config, credentials will not be included in the image pull request.
* If the docker configuration file is missing, unreadable, or is invalid then the credentials will not be included.
* If the image domain does not match a registry defined in the config file, then the credentials will not be included.
