### PR TITLE
added on-failure restart policy for linux nodes

### DIFF
--- a/docs/manual/kinds/linux.md
+++ b/docs/manual/kinds/linux.md
@@ -39,3 +39,7 @@ Containerlab tries to deliver the same level of flexibility in container configu
 * [user](../nodes.md#user) - to set a user that will be used inside the container system
 * [cmd](../nodes.md#cmd) - to provide a command that will be executed when the container is started
 * [publish](../nodes.md#publish) - to provide expose container' service via [myscoket.io integration](../published-ports.md)
+
+!!!note
+    Nodes of `linux` kind will have a `on-failure` restart policy when run with docker runtime. This means that if container fails/exits with a non zero return code, docker will restart this container automatically.  
+    When restarted, the container will loose all non-`eth0` interfaces. These can be re-added manually with [tools veth](../../cmd/tools/veth/create.md) command.

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -337,6 +337,12 @@ func (c *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 		}
 	}
 
+	// regular linux containers may benefit from automatic restart on failure
+	// note, that veth pairs added to this container (outside of eth0) will be lost on restart
+	if node.Kind == "linux" {
+		containerHostConfig.RestartPolicy.Name = "on-failure"
+	}
+
 	cont, err := c.Client.ContainerCreate(
 		nctx,
 		containerConfig,


### PR DESCRIPTION
fix #744 

This PR adds `on-failure` restart policy for nodes of `linux` kind. This is done to ensure longevity of linux based nodes which have just a management `eth0` interface.

It is possible to re-attach veth interfaces to a restarted container with `tools veth create` command, but this requires the other end of a veth to allow hot-plugging of interfaces.