### PR TITLE
Adding public keys in ~/.ssh/authorized_keys 

### DIFF
--- a/clab/authz_keys.go
+++ b/clab/authz_keys.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	authzFName  = "authorized_keys"
-	pubKeysGlob = "~/.ssh/*.pub"
+	clabAuthzFName = "authorized_keys"
+	pubKeysGlob    = "~/.ssh/*.pub"
+	authKeysFile   = "~/.ssh/authorized_keys"
 )
 
 // CreateAuthzKeysFile creats the authorized_keys file in the lab directory
 // if any files ~/.ssh/*.pub found
 func (c *CLab) CreateAuthzKeysFile() error {
-
 	b := new(bytes.Buffer)
 
 	p, err := resolvePath(pubKeysGlob)
@@ -33,6 +33,15 @@ func (c *CLab) CreateAuthzKeysFile() error {
 	all, err := filepath.Glob(p)
 	if err != nil {
 		return fmt.Errorf("failed globbing the path %s", p)
+	}
+
+	f, err := resolvePath(authKeysFile)
+	if err != nil {
+		return fmt.Errorf("failed resolving path %s", authKeysFile)
+	}
+	if utils.FileExists(f) {
+		log.Debugf("%s found, adding the public keys it contains", f)
+		all = append(all, f)
 	}
 
 	if len(all) == 0 {
@@ -47,11 +56,11 @@ func (c *CLab) CreateAuthzKeysFile() error {
 		b.Write(rb)
 	}
 
-	authzKeysFPath := filepath.Join(c.Dir.Lab, authzFName)
-	if err := utils.CreateFile(authzKeysFPath, b.String()); err != nil {
+	clabAuthzKeysFPath := filepath.Join(c.Dir.Lab, clabAuthzFName)
+	if err := utils.CreateFile(clabAuthzKeysFPath, b.String()); err != nil {
 		return err
 	}
 
 	// ensure authz_keys will have the permissions allowing it to be read by anyone
-	return os.Chmod(authzKeysFPath, 0644) // skipcq: GSC-G302
+	return os.Chmod(clabAuthzKeysFPath, 0644) // skipcq: GSC-G302
 }

--- a/clab/authz_keys.go
+++ b/clab/authz_keys.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	clabAuthzFName = "authorized_keys"
-	pubKeysGlob    = "~/.ssh/*.pub"
-	authKeysFile   = "~/.ssh/authorized_keys"
+	clabAuthzKeysFName = "authorized_keys"
+	pubKeysGlob        = "~/.ssh/*.pub"
+	// authorized keys file path on a clab host that is used to create the clabAuthzKeys file
+	authzKeysFPath = "~/.ssh/authorized_keys"
 )
 
 // CreateAuthzKeysFile creats the authorized_keys file in the lab directory
@@ -35,10 +36,11 @@ func (c *CLab) CreateAuthzKeysFile() error {
 		return fmt.Errorf("failed globbing the path %s", p)
 	}
 
-	f, err := resolvePath(authKeysFile)
+	f, err := resolvePath(authzKeysFPath)
 	if err != nil {
-		return fmt.Errorf("failed resolving path %s", authKeysFile)
+		return fmt.Errorf("failed resolving path %s", authzKeysFPath)
 	}
+
 	if utils.FileExists(f) {
 		log.Debugf("%s found, adding the public keys it contains", f)
 		all = append(all, f)
@@ -56,7 +58,7 @@ func (c *CLab) CreateAuthzKeysFile() error {
 		b.Write(rb)
 	}
 
-	clabAuthzKeysFPath := filepath.Join(c.Dir.Lab, clabAuthzFName)
+	clabAuthzKeysFPath := filepath.Join(c.Dir.Lab, clabAuthzKeysFName)
 	if err := utils.CreateFile(clabAuthzKeysFPath, b.String()); err != nil {
 		return err
 	}

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -249,7 +249,7 @@ banner  cli  config.json  devices  tls  ztp
 The topology file that defines the emulated hardware type is driven by the value of the kinds `type` parameter. Depending on a specified `type`, the appropriate content will be populated into the `topology.yml` file that will get mounted to `/tmp/topology.yml` directory inside the container in `ro` mode.
 
 #### authorized keys
-Additionally, containerlab will mount the `authorized_keys` file that will contain contents of every public key found in `~/.ssh` directory. This file will be mounted to `~/.ssh/authorized_keys` path for the following users:
+Additionally, containerlab will mount the `authorized_keys` file that will have contents of every public key found in `~/.ssh` directory as well as the contents of a `~/.ssh/authorized_keys` file if it exists[^2]. This file will be mounted to `~/.ssh/authorized_keys` path for the following users:
 
 * `root`
 * `linuxadmin`
@@ -258,3 +258,4 @@ Additionally, containerlab will mount the `authorized_keys` file that will conta
 This will enable passwordless access for the users above if any public key is found in the user's directory.
 
 [^1]: The `authorized_keys` file will be created with the content of all found public keys. This file will be bind-mounted using the respecting paths inside SR Linux to enable password-less access.
+[^2]: If running with `sudo`, add `-E` flag to sudo to preserve user' home directory for this feature to work as expected.


### PR DESCRIPTION
1/ adding ~/.ssh/authorized_keys as valid public keys for the container.
2/ renaming for clarification/ambiguity:
     authzKeysFPath to clabAuthzKeysFPath
     authzFName to clabAuthzFName