### PR TITLE
Shared netns support aka network-mode: container 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN_DIR = $$(pwd)/bin
 BINARY = $$(pwd)/bin/containerlab
-MKDOCS_VER = 7.3.6
+MKDOCS_VER = 8.2.1
 
 all: build
 

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -318,6 +318,19 @@ my-node:
 
 The `network-mode` configuration option set to `host` will launch the node in the [host networking mode](https://docs.docker.com/network/host/).
 
+Additionally, a node can join network namespace of another container - by referencing the node in the format of `container:parent_node_name`:
+
+```yaml
+# example node definition with shared network namespace
+my-node:
+  kind: linux
+sidecar-node:
+  kind: linux
+  network-mode: container:my-node
+  startup-delay: 10
+```
+Note: startup-delay is required in this case in order to properly initialize the namespace of a parent container.
+
 ### runtime
 By default containerlab nodes will be started by `docker` container runtime. Besides that, containerlab has experimental support for `podman`, `containerd`, and `ignite` runtimes.
 

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -318,7 +318,7 @@ my-node:
 
 The `network-mode` configuration option set to `host` will launch the node in the [host networking mode](https://docs.docker.com/network/host/).
 
-Additionally, a node can join network namespace of another container - by referencing the node in the format of `container:parent_node_name`:
+Additionally, a node can join network namespace of another container - by referencing the node in the format of `container:parent_node_name`[^2]:
 
 ```yaml
 # example node definition with shared network namespace
@@ -326,10 +326,12 @@ my-node:
   kind: linux
 sidecar-node:
   kind: linux
-  network-mode: container:my-node
-  startup-delay: 10
+  network-mode: container:my-node # (1)
+  startup-delay: 10 # (2)
 ```
-Note: startup-delay is required in this case in order to properly initialize the namespace of a parent container.
+
+1.  `my-node` portion of a `network-mode` property instructs `sidecar-node` to join the network namespace of a `my-node`.
+2.  `startup-delay` is required in this case in order to properly initialize the namespace of a parent container.
 
 ### runtime
 By default containerlab nodes will be started by `docker` container runtime. Besides that, containerlab has experimental support for `podman`, `containerd`, and `ignite` runtimes.
@@ -422,3 +424,4 @@ my-node:
 ```
 
 [^1]: [docker runtime resources constraints](https://docs.docker.com/config/containers/resource_constraints/).
+[^2]: this deployment model makes two containers to use a shared network namespace, similar to a Kubernetes pod construct.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - search.suggest
+    - content.code.annotate
 
   language: en
   palette:

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -300,8 +300,9 @@ func (c *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 		PortBindings: node.PortBindings,
 		Sysctls:      node.Sysctls,
 		Privileged:   true,
-		NetworkMode:  container.NetworkMode(c.Mgmt.Network),
-		ExtraHosts:   node.ExtraHosts, // add static /etc/hosts entries
+		// Network mode will be defined below via switch
+		NetworkMode: "",
+		ExtraHosts:  node.ExtraHosts, // add static /etc/hosts entries
 	}
 	var resources container.Resources
 	if node.Memory != "" {
@@ -320,10 +321,25 @@ func (c *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 	}
 	containerHostConfig.Resources = resources
 	containerNetworkingConfig := &network.NetworkingConfig{}
-
-	switch node.NetworkMode {
+	netns := strings.SplitN(node.NetworkMode, ":", 2)
+	switch netns[0] {
+	case "container":
+		// We expect exactly two arguments in this case ("container" keyword & cont. name/ID)
+		if len(netns) != 2 {
+			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netns)
+		}
+		// also cont. ID shouldn't be empty
+		if netns[1] == "" {
+			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netns)
+		}
+		// Extract lab/topo prefix to provide a full (long) container name. Hackish way.
+		prefix := strings.SplitN(node.LongName, node.ShortName, 2)[0]
+		// Compile the net spec
+		containerHostConfig.NetworkMode = container.NetworkMode("container:" + prefix + netns[1])
+		// unset the hostname as it is not supported in this case
+		containerConfig.Hostname = ""
 	case "host":
-		containerHostConfig.NetworkMode = container.NetworkMode("host")
+		containerHostConfig.NetworkMode = "host"
 	default:
 		containerHostConfig.NetworkMode = container.NetworkMode(c.Mgmt.Network)
 

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -321,21 +321,22 @@ func (c *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 	}
 	containerHostConfig.Resources = resources
 	containerNetworkingConfig := &network.NetworkingConfig{}
-	netns := strings.SplitN(node.NetworkMode, ":", 2)
-	switch netns[0] {
+
+	netMode := strings.SplitN(node.NetworkMode, ":", 2)
+	switch netMode[0] {
 	case "container":
 		// We expect exactly two arguments in this case ("container" keyword & cont. name/ID)
-		if len(netns) != 2 {
-			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netns)
+		if len(netMode) != 2 {
+			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netMode)
 		}
 		// also cont. ID shouldn't be empty
-		if netns[1] == "" {
-			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netns)
+		if netMode[1] == "" {
+			return nil, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", node.ShortName, netMode)
 		}
 		// Extract lab/topo prefix to provide a full (long) container name. Hackish way.
 		prefix := strings.SplitN(node.LongName, node.ShortName, 2)[0]
 		// Compile the net spec
-		containerHostConfig.NetworkMode = container.NetworkMode("container:" + prefix + netns[1])
+		containerHostConfig.NetworkMode = container.NetworkMode("container:" + prefix + netMode[1])
 		// unset the hostname as it is not supported in this case
 		containerConfig.Hostname = ""
 	case "host":

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -287,6 +287,8 @@ func (r *PodmanRuntime) DeleteContainer(ctx context.Context, contName string) er
 			log.Warnf("Unable to stop %q gracefully: %v", contName, err)
 		}
 	}
+	// and do a force removal in the end
+	force = true
 	err = containers.Remove(ctx, contName, &containers.RemoveOptions{Force: &force})
 	return err
 }

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -163,14 +163,15 @@ func (r *PodmanRuntime) createContainerSpec(ctx context.Context, cfg *types.Node
 	case "container":
 		// We expect exactly two arguments in this case ("container" keyword & cont. name/ID)
 		if len(netns) != 2 {
-			return sg, fmt.Errorf("container network mode was specified, but no container name was found: %q", netns)
+			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netns)
 		}
 		// also cont. ID shouldn't be empty
 		if netns[1] == "" {
-			return sg, fmt.Errorf("container network mode was specified, but no container name was found: %q", netns)
+			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netns)
 		}
 		// Extract lab/topo prefix to provide a full (long) container name. Hackish way.
 		prefix := strings.SplitN(cfg.LongName, cfg.ShortName, 2)[0]
+		// Compile the net spec
 		specNetConfig = specgen.ContainerNetworkConfig{
 			NetNS: specgen.Namespace{
 				NSMode: "container",

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -158,16 +158,17 @@ func (r *PodmanRuntime) createContainerSpec(ctx context.Context, cfg *types.Node
 	specHCheckConfig := specgen.ContainerHealthCheckConfig{}
 	// Everything below is related to network spec of a container
 	specNetConfig := specgen.ContainerNetworkConfig{}
-	netns := strings.SplitN(cfg.NetworkMode, ":", 2)
-	switch netns[0] {
+
+	netMode := strings.SplitN(cfg.NetworkMode, ":", 2)
+	switch netMode[0] {
 	case "container":
 		// We expect exactly two arguments in this case ("container" keyword & cont. name/ID)
-		if len(netns) != 2 {
-			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netns)
+		if len(netMode) != 2 {
+			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netMode)
 		}
 		// also cont. ID shouldn't be empty
-		if netns[1] == "" {
-			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netns)
+		if netMode[1] == "" {
+			return sg, fmt.Errorf("container network mode was specified for container %q, but no container name was found: %q", cfg.ShortName, netMode)
 		}
 		// Extract lab/topo prefix to provide a full (long) container name. Hackish way.
 		prefix := strings.SplitN(cfg.LongName, cfg.ShortName, 2)[0]
@@ -175,7 +176,7 @@ func (r *PodmanRuntime) createContainerSpec(ctx context.Context, cfg *types.Node
 		specNetConfig = specgen.ContainerNetworkConfig{
 			NetNS: specgen.Namespace{
 				NSMode: "container",
-				Value:  prefix + netns[1]},
+				Value:  prefix + netMode[1]},
 		}
 	case "host":
 		specNetConfig = specgen.ContainerNetworkConfig{
@@ -224,7 +225,7 @@ func (r *PodmanRuntime) createContainerSpec(ctx context.Context, cfg *types.Node
 			// NetworkOptions:      nil,
 		}
 	default:
-		return sg, fmt.Errorf("network Mode %q is not currently supported with Podman", netns)
+		return sg, fmt.Errorf("network Mode %q is not currently supported with Podman", netMode)
 	}
 	// Compile the final spec
 	sg = specgen.SpecGenerator{

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -387,7 +387,6 @@ func (r *PodmanRuntime) netOpts(_ context.Context) (network.CreateOptions, error
 	if r.Mgmt.IPv4Gw != "" && r.Mgmt.IPv4Gw != "0.0.0.0" {
 		toReturn.WithGateway(net.ParseIP(r.Mgmt.IPv4Gw))
 	}
-	// TODO: MTU?
 	return toReturn, nil
 }
 


### PR DESCRIPTION
As discussed previously, MVP for shared net namespaces. I took a naïve approach here and reused the existing network-mode construct.