### PR TITLE
Ansible docker connection inventory compatibility

### DIFF
--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -36,6 +36,9 @@ func (c *CLab) generateAnsibleInventory(w io.Writer) error {
 {{- range $nodes}}
         {{.LongName}}:
           ansible_host: {{.MgmtIPv4Address}}
+          {{- if (eq $kind "linux") }}
+          ansible_docker_host: {{.LongName}}
+		  {{- end -}}
 {{- end}}
 {{- end}}
 {{- range $name, $nodes := .Groups}}

--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -35,10 +35,9 @@ func (c *CLab) generateAnsibleInventory(w io.Writer) error {
       hosts:
 {{- range $nodes}}
         {{.LongName}}:
+		{{- if (eq (index .Labels "ansible-no-host-var") "") }}
           ansible_host: {{.MgmtIPv4Address}}
-          {{- if (eq $kind "linux") }}
-          ansible_docker_host: {{.LongName}}
-		  {{- end -}}
+		{{- end -}}
 {{- end}}
 {{- end}}
 {{- range $name, $nodes := .Groups}}

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -30,13 +30,11 @@ func TestGenerateAnsibleInventory(t *testing.T) {
 		},
 		"case2": {
 			got: "test_data/topo8_ansible_groups.yml",
-            want: `all:
+			want: `all:
   children:
     linux:
       hosts:
         clab-topo8_ansible_groups-node4:
-          ansible_host: 172.100.100.14
-          ansible_docker_host: clab-topo8_ansible_groups-node4
     srl:
       hosts:
         clab-topo8_ansible_groups-node1:

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -30,8 +30,13 @@ func TestGenerateAnsibleInventory(t *testing.T) {
 		},
 		"case2": {
 			got: "test_data/topo8_ansible_groups.yml",
-			want: `all:
+            want: `all:
   children:
+    linux:
+      hosts:
+        clab-topo8_ansible_groups-node4:
+          ansible_host: 172.100.100.14
+          ansible_docker_host: clab-topo8_ansible_groups-node4
     srl:
       hosts:
         clab-topo8_ansible_groups-node1:

--- a/clab/test_data/topo8_ansible_groups.yml
+++ b/clab/test_data/topo8_ansible_groups.yml
@@ -21,6 +21,7 @@ topology:
       labels:
         node-label: value
         ansible-group: extra_group
+
     node3:
       kind: srl
       license: test_data/node1.lic
@@ -29,3 +30,9 @@ topology:
       labels:
         node-label: value
         ansible-group: extra_group
+
+    node4:
+      kind: linux
+      image: alpine:3
+      mgmt_ipv4: 172.100.100.14
+

--- a/clab/test_data/topo8_ansible_groups.yml
+++ b/clab/test_data/topo8_ansible_groups.yml
@@ -35,4 +35,6 @@ topology:
       kind: linux
       image: alpine:3
       mgmt_ipv4: 172.100.100.14
+      labels:
+        ansible-no-host-var: true
 

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -46,9 +46,28 @@ Lab nodes are grouped under their kinds in the inventory so that the users can s
               ansible_host: <mgmt-ipv4-address>
     ```
 
-When a lab node is of `kind: linux`, container additionally generates a `ansible_docker_host` variable for the inventory. This is useful when using the [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin.
+If you want to use the [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin, you can set the `ansible-no-host-var` label on a node to not generate the `ansible_host` variable in the inventory. This is useful as the connection plugin will now use the `inventory_hostname` when executing via Docker.
 
-
+=== "topology file"
+    ```yaml
+    name: ansible
+    topology:
+    defaults:
+      labels:
+        ansible-no-host-var: "true"
+    nodes:
+      node1:
+      node2:
+    ```
+=== "generated ansible inventory"
+    ```yaml
+    all:
+      children:
+        linux:
+          hosts:
+            clab-ansible-node1:
+            clab-ansible-node2:
+    ```
 === "ansible docker host inventory file"
     ``` yaml
     all:

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -70,16 +70,6 @@ Note that without the `ansible_host` variable, the connection plugin will use th
             clab-ansible-node1:
             clab-ansible-node2:
     ```
-=== "ansible docker host inventory file"
-    ``` yaml
-    all:
-      children:
-        linux:
-          hosts:
-            clab-ansible-linux-host:
-              ansible_host: <mgmt-ipv4-address>
-              ansible_docker_host: clab-ansible-linux-host
-    ```
 
 ## User-defined groups
 Users can enforce custom grouping of nodes in the inventory by adding the `ansible-inventory` label to the node definition:

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -46,6 +46,20 @@ Lab nodes are grouped under their kinds in the inventory so that the users can s
               ansible_host: <mgmt-ipv4-address>
     ```
 
+When a lab node is of `kind: linux`, container additionally generates a `ansible_docker_host` variable for the inventory. This is useful when using the [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin.
+
+
+=== "ansible docker host inventory file"
+    ``` yaml
+    all:
+      children:
+        linux:
+          hosts:
+            clab-ansible-linux-host:
+              ansible_host: <mgmt-ipv4-address>
+              ansible_docker_host: clab-ansible-linux-host
+    ```
+
 ## User-defined groups
 Users can enforce custom grouping of nodes in the inventory by adding the `ansible-inventory` label to the node definition:
 

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -46,18 +46,20 @@ Lab nodes are grouped under their kinds in the inventory so that the users can s
               ansible_host: <mgmt-ipv4-address>
     ```
 
-If you want to use the [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin, you can set the `ansible-no-host-var` label on a node to not generate the `ansible_host` variable in the inventory. This is useful as the connection plugin will now use the `inventory_hostname` when executing via Docker.
+## Removing `ansible_host` var
+If you want to use a plugin[^1] that doesn't play well with the `ansible_host` variable injected by containerlab in the inventory file, you can leverage the `ansible-no-host-var` label. The label can be set on per-node, kind, or default levels; if set, containerlab will not generate the `ansible_host` variable in the inventory for the nodes with that label.  
+Note that without the `ansible_host` variable, the connection plugin will use the `inventory_hostname` and resolve the name accordingly if network reachability is needed.
 
 === "topology file"
     ```yaml
     name: ansible
-    topology:
-    defaults:
-      labels:
-        ansible-no-host-var: "true"
-    nodes:
-      node1:
-      node2:
+      topology:
+        defaults:
+          labels:
+            ansible-no-host-var: "true"
+        nodes:
+          node1:
+          node2:
     ```
 === "generated ansible inventory"
     ```yaml
@@ -115,3 +117,5 @@ As a result of this configuration, the generated inventory will look like this:
         clab-custom-groups-node1:
           ansible_host: 172.100.100.11
 ```
+
+[^1]: For example [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,7 +215,8 @@ markdown_extensions:
   - pymdownx.snippets:
       check_paths: true
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde


### PR DESCRIPTION
As per my comment https://github.com/srl-labs/containerlab/issues/649#issuecomment-1047252521 I realized I could just, implement this myself 👯 

Currently `ansible_docker_host` is added as a var to all nodes of `kind: linux`, this is a naive assumption and could probably be more of an opt-in option, but let's see how the PR plays out.

Test case updated, and I _think_ I've managed to document the behaviour in `docs/`, too.