### PR TITLE
resolve relative topology paths 

### DIFF
--- a/clab/authz_keys.go
+++ b/clab/authz_keys.go
@@ -26,20 +26,14 @@ const (
 func (c *CLab) CreateAuthzKeysFile() error {
 	b := new(bytes.Buffer)
 
-	p, err := resolvePath(pubKeysGlob)
-	if err != nil {
-		return fmt.Errorf("failed resolving path %s", pubKeysGlob)
-	}
+	p := utils.ResolvePath(pubKeysGlob, c.TopoFile.dir)
 
 	all, err := filepath.Glob(p)
 	if err != nil {
 		return fmt.Errorf("failed globbing the path %s", p)
 	}
 
-	f, err := resolvePath(authzKeysFPath)
-	if err != nil {
-		return fmt.Errorf("failed resolving path %s", authzKeysFPath)
-	}
+	f := utils.ResolvePath(authzKeysFPath, c.TopoFile.dir)
 
 	if utils.FileExists(f) {
 		log.Debugf("%s found, adding the public keys it contains", f)

--- a/clab/file.go
+++ b/clab/file.go
@@ -30,6 +30,7 @@ const (
 // TopoFile type is a struct which defines parameters of the topology file
 type TopoFile struct {
 	path     string // topo file path
+	dir      string // topo file dir path
 	fullName string // file name with extension
 	name     string // file name without extension
 }
@@ -80,11 +81,13 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 		return err
 	}
 
-	file := filepath.Base(topo)
+	topoDir := filepath.Dir(topoAbsPath)
+
 	c.TopoFile = &TopoFile{
 		path:     topoAbsPath,
-		fullName: file,
-		name:     strings.TrimSuffix(file, path.Ext(file)),
+		dir:      topoDir,
+		fullName: fileBase,
+		name:     strings.TrimSuffix(fileBase, path.Ext(fileBase)),
 	}
 	return nil
 }

--- a/clab/test_data/topo1.yml
+++ b/clab/test_data/topo1.yml
@@ -4,16 +4,16 @@ topology:
     node1:
       kind: srl
       type: ixr6
-      license: test_data/node1.lic
+      license: node1.lic
       binds:
-        - test_data/node1.lic:/dst
+        - node1.lic:/dst
       env:
         env1: val1
         env2: val2
       mgmt_ipv4: 172.100.100.11
     node2:
       kind: srl
-      license: test_data/node1.lic
+      license: node1.lic
       user: custom
       mgmt_ipv4: 172.100.100.12
       labels:

--- a/clab/test_data/topo2.yml
+++ b/clab/test_data/topo2.yml
@@ -2,7 +2,7 @@ name: topo2
 topology:
   kinds:
     srl:
-      license: test_data/kind.lic
+      license: kind.lic
       type: ixrd2
       env:
         env1: val1
@@ -13,8 +13,8 @@ topology:
     node1:
       kind: srl
       binds:
-        - test_data/node1.lic:/dst1
-        - test_data/kind.lic:/dst2
+        - node1.lic:/dst1
+        - kind.lic:/dst2
     node2:
       kind: srl
       type: ixr10

--- a/clab/test_data/topo3.yml
+++ b/clab/test_data/topo3.yml
@@ -1,9 +1,9 @@
 name: topo3
 topology:
   defaults:
-    license: test_data/default.lic
+    license: default.lic
     binds:
-      - test_data/default.lic:/dst
+      - default.lic:/dst
     type: ixrd2
     env:
       env1: val1

--- a/clab/test_data/topo4.yml
+++ b/clab/test_data/topo4.yml
@@ -1,9 +1,9 @@
 name: topo4
 topology:
   defaults:
-    license: test_data/default.lic
+    license: default.lic
     binds:
-      - test_data/default.lic:/dst3
+      - default.lic:/dst3
     env:
       env1: global
       env2: global
@@ -11,9 +11,9 @@ topology:
     user: customglobal
   kinds:
     srl:
-      license: test_data/kind.lic
+      license: kind.lic
       binds:
-        - test_data/kind.lic:/dst2
+        - kind.lic:/dst2
       env:
         env2: kind
         env4: kind
@@ -22,9 +22,9 @@ topology:
     node1:
       kind: srl
       type: ixr6
-      license: test_data/node1.lic
+      license: node1.lic
       binds:
-        - test_data/node1.lic:/dst1
+        - node1.lic:/dst1
       env:
         env1: node
         env5: node

--- a/clab/test_data/topo5.yml
+++ b/clab/test_data/topo5.yml
@@ -3,11 +3,11 @@ topology:
   kinds:
     srl:
       binds:
-        - test_data/kind.lic:/dst
+        - kind.lic:/dst
   nodes:
     node1:
       kind: srl
       type: ixr6
-      license: test_data/node1.lic
+      license: node1.lic
       binds:
-        - test_data/node1.lic:/dst2
+        - node1.lic:/dst2

--- a/clab/test_data/topo8_ansible_groups.yml
+++ b/clab/test_data/topo8_ansible_groups.yml
@@ -4,9 +4,9 @@ topology:
     node1:
       kind: srl
       type: ixr6
-      license: test_data/node1.lic
+      license: node1.lic
       binds:
-        - test_data/node1.lic:/dst
+        - node1.lic:/dst
       env:
         env1: val1
         env2: val2
@@ -15,7 +15,7 @@ topology:
         ansible-group: spine
     node2:
       kind: srl
-      license: test_data/node1.lic
+      license: node1.lic
       user: custom
       mgmt_ipv4: 172.100.100.12
       labels:
@@ -24,7 +24,7 @@ topology:
 
     node3:
       kind: srl
-      license: test_data/node1.lic
+      license: node1.lic
       user: custom
       mgmt_ipv4: 172.100.100.13
       labels:
@@ -37,4 +37,3 @@ topology:
       mgmt_ipv4: 172.100.100.14
       labels:
         ansible-no-host-var: true
-

--- a/clab/test_data/topo9.yml
+++ b/clab/test_data/topo9.yml
@@ -1,9 +1,9 @@
 name: topo4
 topology:
   defaults:
-    license: test_data/default.lic
+    license: default.lic
     binds:
-      - test_data/default.lic:/dst
+      - default.lic:/dst
     env:
       env1: global
       env2: global
@@ -11,9 +11,9 @@ topology:
     user: customglobal
   kinds:
     srl:
-      license: test_data/kind.lic
+      license: kind.lic
       binds:
-        - test_data/kind.lic:/dst
+        - kind.lic:/dst
       env:
         env2: kind
         env4: kind
@@ -22,9 +22,9 @@ topology:
     node1:
       kind: srl
       type: ixr6
-      license: test_data/node1.lic
+      license: node1.lic
       binds:
-        - test_data/node1.lic:/dst
+        - node1.lic:/dst
       env:
         env1: node
         env5: ${CONTAINERLAB_TEST_ENV5}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -95,17 +94,12 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 			clab.WithTopoFile(topo, varsFile),
 		)
 		log.Debugf("going through extracted topos for destroy, got a topo file %v and generated opts list %+v", topo, opts)
-		c, err := clab.NewContainerLab(opts...)
+		nc, err := clab.NewContainerLab(opts...)
 		if err != nil {
 			return err
 		}
-		// change to the dir where topo file is located
-		// to resolve relative paths of license/configs in ParseTopology
-		if err = os.Chdir(filepath.Dir(topo)); err != nil {
-			return err
-		}
 
-		labs = append(labs, c)
+		labs = append(labs, nc)
 	}
 
 	var errs []error

--- a/types/topology.go
+++ b/types/topology.go
@@ -1,11 +1,7 @@
 package types
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/docker/go-connections/nat"
-	"github.com/mitchellh/go-homedir"
 	"github.com/srl-labs/containerlab/utils"
 )
 
@@ -150,7 +146,6 @@ func (t *Topology) GetNodeConfigDispatcher(name string) *ConfigDispatcher {
 func (t *Topology) GetNodeStartupConfig(name string) (string, error) {
 	var cfg string
 	if ndef, ok := t.Nodes[name]; ok {
-		var err error
 		cfg = ndef.GetStartupConfig()
 		if t.GetKind(t.GetNodeKind(name)).GetStartupConfig() != "" && cfg == "" {
 			cfg = t.GetKind(t.GetNodeKind(name)).GetStartupConfig()
@@ -158,14 +153,7 @@ func (t *Topology) GetNodeStartupConfig(name string) (string, error) {
 		if cfg == "" {
 			cfg = t.GetDefaults().GetStartupConfig()
 		}
-		if cfg != "" {
-			cfg, err = resolvePath(cfg)
-			if err != nil {
-				return "", err
-			}
-			_, err = os.Stat(cfg)
-			return cfg, err
-		}
+
 	}
 	return cfg, nil
 }
@@ -199,23 +187,18 @@ func (t *Topology) GetNodeEnforceStartupConfig(name string) bool {
 func (t *Topology) GetNodeLicense(name string) (string, error) {
 	var license string
 	if ndef, ok := t.Nodes[name]; ok {
-		var err error
+
 		license = ndef.GetLicense()
 		if t.GetKind(t.GetNodeKind(name)).GetLicense() != "" && license == "" {
 			license = t.GetKind(t.GetNodeKind(name)).GetLicense()
 		}
+
 		if license == "" {
 			license = t.GetDefaults().GetLicense()
 		}
-		if license != "" {
-			license, err = resolvePath(license)
-			if err != nil {
-				return "", err
-			}
-			_, err = os.Stat(license)
-			return license, err
-		}
+
 	}
+
 	return license, nil
 }
 
@@ -440,26 +423,4 @@ func (t *Topology) ImportEnvs() {
 	for _, n := range t.Nodes {
 		n.ImportEnvs()
 	}
-}
-
-//resolvePath resolves a string path by expanding `~` to home dir or getting Abs path for the given path
-func resolvePath(p string) (string, error) {
-	if p == "" {
-		return "", nil
-	}
-	var err error
-	switch {
-	// resolve ~/ path
-	case p[0] == '~':
-		p, err = homedir.Expand(p)
-		if err != nil {
-			return "", err
-		}
-	default:
-		p, err = filepath.Abs(p)
-		if err != nil {
-			return "", err
-		}
-	}
-	return p, nil
 }

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -315,7 +315,7 @@ func TestGetNodeConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantedConfig, err := resolvePath(item.want["node1"].StartupConfig)
+		wantedConfig := item.want["node1"].StartupConfig
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -350,7 +350,7 @@ func TestGetNodeLicense(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantedLicense, err := resolvePath(item.want["node1"].License)
+		wantedLicense := item.want["node1"].License
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/utils/file.go
+++ b/utils/file.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -144,4 +145,33 @@ func ReadFileContent(file string) ([]byte, error) {
 	b, err := ioutil.ReadFile(file)
 
 	return b, err
+}
+
+// ExpandHome expands `~` char in the path to home path of a current user in provided path p.
+func ExpandHome(p string) string {
+	userPath, _ := os.UserHomeDir()
+
+	p = strings.Replace(p, "~", userPath, 1)
+
+	return p
+}
+
+// ResolvePath resolves a string path by expanding `~` to home dir
+// or resolving a relative path by joining it with the base path
+func ResolvePath(p, base string) string {
+	if p == "" {
+		return p
+	}
+
+	switch {
+	// resolve ~/ path
+	case p[0] == '~':
+		p = ExpandHome(p)
+	case p[0] == '/':
+		return p
+	default:
+		// join relative path with the base path
+		p = filepath.Join(base, p)
+	}
+	return p
 }


### PR DESCRIPTION
This PR fixes a long standing issue with containerlab not being able to track relative paths properly when `clab` is called not from the dir that hosts the topology file.

This PR fixes the logic for path resolver, to resolve relative paths relative to the topology file in `binds` and `license` config options.

This also fixes bulk deletion (`clab des -a`) to delete labs deployed from topos from various directories.