### PR TITLE
adds ceos support for extras

### DIFF
--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -215,6 +215,22 @@ clab-srlceos01/ceos
 
 9 directories, 11 files
 ```
+## ceos-specific overrides
+
+If there is a need to provide additional ceos-lab specific configuration or overrides to the ceos node in the topology, these can be added using the `ceos-overrides` extra.  These additional files will be copied to the node's flash directory for evaluation on startup.  
+
+```yaml
+name: ceos_lowrider
+topology:
+  nodes:
+    ceos1:
+      kind: ceos
+      ...
+      extras:
+        ceos-overrides:
+        - ceos-config
+        - toggle_override
+```
 
 ## Lab examples
 The following labs feature cEOS node:

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -174,12 +174,12 @@ In addition to cli commands such as `write memory` user can take advantage of th
 To start an Arista cEOS node containerlab uses the configuration instructions described in Arista Forums[^1]. The exact parameters are outlined below.
 
 === "Startup command"
-    `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=4 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
+    `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=1 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
 === "Environment variables"
     `CEOS:1`  
     `EOS_PLATFORM":ceoslab`  
     `container:docker`  
-    `ETBA:4`  
+    `ETBA:1`  
     `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
     `INTFTYPE:eth`  
     `MAPETH0:1`  

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -215,22 +215,24 @@ clab-srlceos01/ceos
 
 9 directories, 11 files
 ```
-## ceos-specific overrides
+## Copy to `flash`
 
-If there is a need to provide additional ceos-lab specific configuration or overrides to the ceos node in the topology, these can be added using the `copy-to-flash` extra.  These additional files will be copied to the node's flash directory for evaluation on startup.  
+If there is a need to copy ceos-specific configuration or override files to the ceos node in the topology use `.extras.ceos-copy-to-flash` config option. These files will be copied to the node's flash directory and evaluated on startup.
 
 ```yaml
-name: ceos_lowrider
+name: ceos
 topology:
   nodes:
     ceos1:
       kind: ceos
       ...
       extras:
-        copy-to-flash:
-        - ceos-config
+        ceos-copy-to-flash:
+        - ceos-config # (1)!
         - toggle_override
 ```
+
+1. Paths are relative to the topology file. Absolute paths like `~/some/path` or `/some/path` are also possible.
 
 ## Lab examples
 The following labs feature a cEOS node:

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -217,7 +217,7 @@ clab-srlceos01/ceos
 ```
 ## ceos-specific overrides
 
-If there is a need to provide additional ceos-lab specific configuration or overrides to the ceos node in the topology, these can be added using the `ceos-overrides` extra.  These additional files will be copied to the node's flash directory for evaluation on startup.  
+If there is a need to provide additional ceos-lab specific configuration or overrides to the ceos node in the topology, these can be added using the `copy-to-flash` extra.  These additional files will be copied to the node's flash directory for evaluation on startup.  
 
 ```yaml
 name: ceos_lowrider
@@ -227,13 +227,13 @@ topology:
       kind: ceos
       ...
       extras:
-        ceos-overrides:
+        copy-to-flash:
         - ceos-config
         - toggle_override
 ```
 
 ## Lab examples
-The following labs feature cEOS node:
+The following labs feature a cEOS node:
 
 - [SR Linux and cEOS](../../lab-examples/srl-ceos.md)
 

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -28,7 +28,7 @@ var (
 		"CEOS":                                "1",
 		"EOS_PLATFORM":                        "ceoslab",
 		"container":                           "docker",
-		"ETBA":                                "4",
+		"ETBA":                                "1",
 		"SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT": "1",
 		"INTFTYPE":                            "eth",
 		"MAPETH0":                             "1",

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -144,7 +144,9 @@ func createCEOSFiles(node *types.NodeConfig) error {
 		for _, extrapath := range extras {
 			basename := filepath.Base(extrapath)
 			dest := filepath.Join(flash, basename)
-			if err := utils.CopyFile(extrapath, dest, 0644); err != nil {
+
+			topoDir := filepath.Dir(filepath.Dir(node.LabDir)) // topo dir is needed to resolve extrapaths
+			if err := utils.CopyFile(utils.ResolvePath(extrapath, topoDir), dest, 0644); err != nil {
 				return fmt.Errorf("extras: copy-to-flash %s -> %s failed %v", extrapath, dest, err)
 			}
 		}

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -137,15 +137,15 @@ func createCEOSFiles(node *types.NodeConfig) error {
 	}
 
 	// if extras have been provided copy these into the flash directory
-	if node.Extras != nil && len(node.Extras.CeosOverrides) != 0 {
-		extras := node.Extras.CeosOverrides
+	if node.Extras != nil && len(node.Extras.CeosCopyToFlash) != 0 {
+		extras := node.Extras.CeosCopyToFlash
 		flash := filepath.Join(node.LabDir, "flash")
 
 		for _, extrapath := range extras {
 			basename := filepath.Base(extrapath)
 			dest := filepath.Join(flash, basename)
 			if err := utils.CopyFile(extrapath, dest, 0644); err != nil {
-				return fmt.Errorf("ceos-override copy %s -> %s failed %v", extrapath, dest, err)
+				return fmt.Errorf("extras: copy-to-flash %s -> %s failed %v", extrapath, dest, err)
 			}
 		}
 	}

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -136,6 +136,20 @@ func createCEOSFiles(node *types.NodeConfig) error {
 		return err
 	}
 
+	// if extras have been provided copy these into the flash directory
+	if node.Extras != nil && len(node.Extras.CeosOverrides) != 0 {
+		extras := node.Extras.CeosOverrides
+		flash := filepath.Join(node.LabDir, "flash")
+
+		for _, extrapath := range extras {
+			basename := filepath.Base(extrapath)
+			dest := filepath.Join(flash, basename)
+			if err := utils.CopyFile(extrapath, dest, 0644); err != nil {
+				return fmt.Errorf("ceos-override copy %s -> %s failed %v", extrapath, dest, err)
+			}
+		}
+	}
+
 	// sysmac is a system mac that is +1 to Ma0 mac
 	m, err := net.ParseMAC(node.MacAddress)
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -238,7 +238,7 @@ func (cd *ConfigDispatcher) GetVars() map[string]interface{} {
 
 // Extras contains extra node parameters which are not entitled to be part of a generic node config
 type Extras struct {
-	SRLAgents     []string `yaml:"srl-agents,omitempty"`     // Nokia SR Linux agents. As of now just the agents spec files can be provided here
-	MysocketProxy string   `yaml:"mysocket-proxy,omitempty"` // Proxy address that mysocketctl will use
-	CeosOverrides []string `yaml:"ceos-overrides,omitempty"` // additional ceos-lab config options (ceos-config toggles_override, etc)
+	SRLAgents       []string `yaml:"srl-agents,omitempty"`     // Nokia SR Linux agents. As of now just the agents spec files can be provided here
+	MysocketProxy   string   `yaml:"mysocket-proxy,omitempty"` // Proxy address that mysocketctl will use
+	CeosCopyToFlash []string `yaml:"copy-to-flash,omitempty"`  // additional ceos-lab config options (ceos-config toggles_override, etc)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -240,4 +240,5 @@ func (cd *ConfigDispatcher) GetVars() map[string]interface{} {
 type Extras struct {
 	SRLAgents     []string `yaml:"srl-agents,omitempty"`     // Nokia SR Linux agents. As of now just the agents spec files can be provided here
 	MysocketProxy string   `yaml:"mysocket-proxy,omitempty"` // Proxy address that mysocketctl will use
+	CeosOverrides []string `yaml:"ceos-overrides,omitempty"` // additional ceos-lab config options (ceos-config toggles_override, etc)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -238,7 +238,7 @@ func (cd *ConfigDispatcher) GetVars() map[string]interface{} {
 
 // Extras contains extra node parameters which are not entitled to be part of a generic node config
 type Extras struct {
-	SRLAgents       []string `yaml:"srl-agents,omitempty"`     // Nokia SR Linux agents. As of now just the agents spec files can be provided here
-	MysocketProxy   string   `yaml:"mysocket-proxy,omitempty"` // Proxy address that mysocketctl will use
-	CeosCopyToFlash []string `yaml:"copy-to-flash,omitempty"`  // additional ceos-lab config options (ceos-config toggles_override, etc)
+	SRLAgents       []string `yaml:"srl-agents,omitempty"`         // Nokia SR Linux agents. As of now just the agents spec files can be provided here
+	MysocketProxy   string   `yaml:"mysocket-proxy,omitempty"`     // Proxy address that mysocketctl will use
+	CeosCopyToFlash []string `yaml:"ceos-copy-to-flash,omitempty"` // paths to files which are to be copied to ceos flash dir
 }


### PR DESCRIPTION
## overview

ceos allows some parameters to be overridden or additional options to be set by placing files within the `flash` directory. this PR adds support for a ceos-specific "extra" to copy user provided files into the flash directory on startup. 

additionally, this PR sets the EBTA environment value to be "1" which is the preferred setting.