### PR TITLE
Implement docker ulimits

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -335,11 +335,7 @@ func (d *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 	var rlimit unix.Rlimit
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 		log.Warnf("Unable to retrieve rlimit_NOFILE value: %v", err)
-		rlimit.Cur = rLimitMaxValue
 		rlimit.Max = rLimitMaxValue
-	}
-	if rlimit.Cur > rLimitMaxValue {
-		rlimit.Cur = rLimitMaxValue
 	}
 	if rlimit.Max > rLimitMaxValue {
 		rlimit.Max = rLimitMaxValue
@@ -347,7 +343,7 @@ func (d *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 	ulimit := units.Ulimit{
 		Name: "nofile",
 		Hard: int64(rlimit.Max),
-		Soft: int64(rlimit.Cur),
+		Soft: int64(rlimit.Max),
 	}
 	resources.Ulimits = []*units.Ulimit{&ulimit}
 	containerHostConfig := &container.HostConfig{

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -584,7 +584,9 @@ func (*DockerRuntime) buildFilterString(gfilters []*types.GenericFilter) filters
 func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerTypes.Container, inputNetworkResources []dockerTypes.NetworkResource) ([]types.GenericContainer, error) {
 	var result []types.GenericContainer
 
-	for _, i := range inputContainers {
+	for idx := range inputContainers {
+		i := inputContainers[idx]
+
 		ctr := types.GenericContainer{
 			Names:           i.Names,
 			ID:              i.ID,
@@ -598,7 +600,9 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 		bridgeName := d.mgmt.Network
 		// if bridgeName is "", try to find a network created by clab that the container is connected to
 		if bridgeName == "" && inputNetworkResources != nil {
-			for _, nr := range inputNetworkResources {
+			for idx := range inputNetworkResources {
+				nr := inputNetworkResources[idx]
+
 				if _, ok := i.NetworkSettings.Networks[nr.Name]; ok {
 					bridgeName = nr.Name
 					break

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -9,14 +9,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/docker/go-units"
-	"golang.org/x/sys/unix"
 	"io"
 	"io/ioutil"
 	"path"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/docker/go-units"
+	"golang.org/x/sys/unix"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -580,7 +581,7 @@ func (*DockerRuntime) buildFilterString(gfilters []*types.GenericFilter) filters
 }
 
 // Transform docker-specific to generic container format
-func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerTypes.Container, inputNetworkRessources []dockerTypes.NetworkResource) ([]types.GenericContainer, error) {
+func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerTypes.Container, inputNetworkResources []dockerTypes.NetworkResource) ([]types.GenericContainer, error) {
 	var result []types.GenericContainer
 
 	for _, i := range inputContainers {
@@ -596,8 +597,8 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 		}
 		bridgeName := d.mgmt.Network
 		// if bridgeName is "", try to find a network created by clab that the container is connected to
-		if bridgeName == "" && inputNetworkRessources != nil {
-			for _, nr := range inputNetworkRessources {
+		if bridgeName == "" && inputNetworkResources != nil {
+			for _, nr := range inputNetworkResources {
 				if _, ok := i.NetworkSettings.Networks[nr.Name]; ok {
 					bridgeName = nr.Name
 					break


### PR DESCRIPTION
Fix #824 

In this implementation both soft & hard limits will be set to rlimit.max (or 2^20, whichever is lower) because by default unix.rlimit returns the limits of the current process (containerlab binary in this case).
I assume that should be good enough, but if we encounter any issues (someone runs clab on a system with a very low rlimit.max? which is unlikely) we can rework the logic.
