### PR TITLE
Better OS detection

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -34,12 +34,27 @@ detectOS() {
     # Minimalist GNU for Windows
     mingw*) OS='windows' ;;
     esac
-
-    if type "rpm" &>/dev/null; then
-        PKG_FORMAT="rpm"
-    elif type "dpkg" &>/dev/null; then
-        PKG_FORMAT="deb"
+    
+    if [ -f /etc/os-release ]; then
+        OS_ID="$(. /etc/os-release && echo "$ID")"
     fi
+    case "${OS_ID}" in
+        ubuntu|debian|raspbian)
+            PKG_FORMAT="deb"
+        ;;
+        
+        centos|rhel|sles)
+            PKG_FORMAT="rpm"
+        ;;
+        
+        *)
+            if type "rpm" &>/dev/null; then
+                PKG_FORMAT="rpm"
+            elif type "dpkg" &>/dev/null; then
+                PKG_FORMAT="deb"
+            fi
+        ;;
+    esac
 }
 
 # runs the given command as root (detects if we are root already)


### PR DESCRIPTION
This PR adds better OS detection using `/etc/os-release` to avoid edge cases where the `rpm` binary is installed on Debian systems.