### PR TITLE
Auto export topology-data.json when running deploy

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -22,16 +22,16 @@ import (
 )
 
 type CLab struct {
-	Config        *Config
-	TopoFile      *TopoFile
-	m             *sync.RWMutex
-	Nodes         map[string]nodes.Node
-	Links         map[int]*types.Link
-	Runtimes      map[string]runtime.ContainerRuntime
-	globalRuntime string
-	Dir           *Directory
+	Config        *Config                             `json:"config,omitempty"`
+	TopoFile      *TopoFile                           `json:"topofile,omitempty"`
+	m             *sync.RWMutex                       `json:"m,omitempty"`
+	Nodes         map[string]nodes.Node               `json:"nodes,omitempty"`
+	Links         map[int]*types.Link                 `json:"links,omitempty"`
+	Runtimes      map[string]runtime.ContainerRuntime `json:"runtimes,omitempty"`
+	globalRuntime string                              `json:"global-runtime,omitempty"`
+	Dir           *Directory                          `json:"dir,omitempty"`
 
-	timeout time.Duration
+	timeout time.Duration `json:"timeout,omitempty"`
 }
 
 type Directory struct {

--- a/clab/config.go
+++ b/clab/config.go
@@ -50,6 +50,7 @@ const (
 	NodeMgmtNetBr     = "clab-mgmt-net-bridge"
 
 	// clab specific topology variables
+	clabDirVar = "__clabDir__"
 	nodeDirVar = "__clabNodeDir__"
 )
 
@@ -684,20 +685,20 @@ func (c *CLab) resolveBindPaths(binds []string, nodedir string) error {
 		elems := strings.Split(binds[i], ":")
 
 		// replace special variable
-		r := strings.NewReplacer(nodeDirVar, nodedir)
+		r := strings.NewReplacer(clabDirVar, c.Dir.Lab, nodeDirVar, nodedir)
 		hp := r.Replace(elems[0])
 		hp = utils.ResolvePath(hp, c.TopoFile.dir)
 
 		_, err := os.Stat(hp)
 		if err != nil {
-			// check if the hostpath mount has a reference to ansible-inventory.yml
-			// if that is the case, we do not emit an error on missing file, since this file
+			// check if the hostpath mount has a reference to ansible-inventory.yml or topology-data.json
+			// if that is the case, we do not emit an error on missing file, since these files
 			// will be created by containerlab upon lab deployment
 			labdir := filepath.Base(filepath.Dir(nodedir))
 			s := strings.Split(hp, string(os.PathSeparator))
 			// creating a path from last two elements of a resolved host path
 			h := filepath.Join(s[len(s)-2], s[len(s)-1])
-			if h != filepath.Join(labdir, "ansible-inventory.yml") {
+			if h != filepath.Join(labdir, "ansible-inventory.yml") && h != filepath.Join(labdir, "topology-data.json") {
 				return fmt.Errorf("failed to verify bind path: %v", err)
 			}
 		}

--- a/clab/export.go
+++ b/clab/export.go
@@ -14,15 +14,11 @@ import (
 )
 
 type topoData struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	//	Config topoConfig                   `json:"configuration,omitempty"`
-	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
-	Links []Link                       `json:"links,omitempty"`
-}
-
-type topoConfig struct {
-	Name string `json:"name,omitempty"`
+	Name   string                       `json:"name"`
+	Type   string                       `json:"type"`
+	Config *Config                      `json:"configuration,omitempty"`
+	Nodes  map[string]*types.NodeConfig `json:"nodes,omitempty"`
+	Links  []Link                       `json:"links,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
@@ -38,10 +34,11 @@ func (c *CLab) GenerateExports() error {
 // generates and writes topology data file to w
 func (c *CLab) exportTopologyData(w io.Writer) error {
 	d := topoData{
-		Name:  c.Config.Name,
-		Type:  "clab",
-		Nodes: make(map[string]*types.NodeConfig),
-		Links: make([]Link, 0, len(c.Links)),
+		Name:   c.Config.Name,
+		Type:   "clab",
+		Config: c.Config,
+		Nodes:  make(map[string]*types.NodeConfig),
+		Links:  make([]Link, 0, len(c.Links)),
 	}
 
 	for _, n := range c.Nodes {

--- a/clab/export.go
+++ b/clab/export.go
@@ -21,8 +21,11 @@ import (
 const defaultTopologyExportTemplate = "/etc/containerlab/templates/export/auto.tmpl"
 
 // GenerateExports generate various export files and writes it to a lab location
-func (c *CLab) GenerateExports(f io.Writer) error {
-	p := defaultTopologyExportTemplate
+func (c *CLab) GenerateExports(f io.Writer, p string) error {
+	if p == "" {
+		p = defaultTopologyExportTemplate
+	}
+
 	n := filepath.Base(p)
 	err := c.exportTopologyDataWithTemplate(f, n, p)
 	if err != nil {
@@ -80,6 +83,8 @@ func (c *CLab) exportTopologyDataWithTemplate(w io.Writer, n string, p string) e
 	if err != nil {
 		return err
 	}
+	log.Debugf("Exported topology data using %s template", p)
+
 	return err
 }
 
@@ -105,5 +110,6 @@ func (c *CLab) exportTopologyDataWithDefaultTemplate(w io.Writer) error {
 	if err != nil {
 		return err
 	}
+	log.Debug("Exported topology data using built-in template")
 	return err
 }

--- a/clab/export.go
+++ b/clab/export.go
@@ -109,6 +109,10 @@ func (c *CLab) exportTopologyDataWithTemplate(w io.Writer, n string, p string) e
 			a, _ := json.Marshal(v)
 			return string(a)
 		},
+		"marshal_indent": func(v interface{}, prefix string, indent string) string {
+			a, _ := json.MarshalIndent(v, prefix, indent)
+			return string(a)
+		},
 	}).ParseFiles(p)
 
 	if err != nil {

--- a/clab/export.go
+++ b/clab/export.go
@@ -31,6 +31,7 @@ type NodeInterface struct {
 	Node      string `json:"node,omitempty"`
 	Interface string `json:"interface,omitempty"`
 	MAC       string `json:"mac,omitempty"`
+	Peer      string `json:"peer,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
@@ -69,11 +70,13 @@ func (c *CLab) exportTopologyData(w io.Writer) error {
 			Node:      l.A.Node.ShortName,
 			Interface: l.A.EndpointName,
 			MAC:       l.A.MAC,
+			Peer:      "z",
 		}
 		intmap["z"] = NodeInterface{
 			Node:      l.B.Node.ShortName,
 			Interface: l.B.EndpointName,
 			MAC:       l.B.MAC,
+			Peer:      "a",
 		}
 		d.Links = append(d.Links, intmap)
 	}

--- a/clab/export.go
+++ b/clab/export.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"os"
 	"path/filepath"
 	"text/template"
 
@@ -22,16 +21,10 @@ import (
 const defaultTopologyExportTemplate = "/etc/containerlab/templates/export/auto.tmpl"
 
 // GenerateExports generate various export files and writes it to a lab location
-func (c *CLab) GenerateExports() error {
-	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
-	f, err := os.Create(topoDataFPath)
-	if err != nil {
-		return err
-	}
-
+func (c *CLab) GenerateExports(f io.Writer) error {
 	p := defaultTopologyExportTemplate
 	n := filepath.Base(p)
-	err = c.exportTopologyDataWithTemplate(f, n, p)
+	err := c.exportTopologyDataWithTemplate(f, n, p)
 	if err != nil {
 		log.Warningf("Cannot parse export template %s", p)
 		log.Warningf("Details: %s", err)

--- a/clab/export.go
+++ b/clab/export.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package clab
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/template"
+
+	"github.com/srl-labs/containerlab/types"
+)
+
+// GenerateExports generate various export files and writes it to a lab location
+func (c *CLab) GenerateExports() error {
+
+	topologyGraphFPath := filepath.Join(c.Dir.Lab, "topology-graph.json")
+	_, err = os.Create(topologyGraphFPath)
+	if err != nil {
+		return err
+	}
+
+	return c.generateTopologyGraph(f)
+}
+
+// generateTopologyGraph generates and writes topology graph file to w
+func (c *CLab) generateTopologyGraph(w io.Writer) error {
+
+	invT :=
+		`{
+      "nodes": [
+        {{- range $nodes}}
+      ],
+      "links": [
+      ]
+}
+`
+	type inv struct {
+		// clab nodes aggregated by their kind
+		Nodes map[string][]*types.NodeConfig
+		// clab nodes aggregated by user-defined groups
+		Groups map[string][]*types.NodeConfig
+	}
+
+	i := inv{
+		Nodes:  make(map[string][]*types.NodeConfig),
+		Groups: make(map[string][]*types.NodeConfig),
+	}
+
+	for _, n := range c.Nodes {
+		i.Nodes[n.Config().Kind] = append(i.Nodes[n.Config().Kind], n.Config())
+		if n.Config().Labels["ansible-group"] != "" {
+			i.Groups[n.Config().Labels["ansible-group"]] = append(i.Groups[n.Config().Labels["ansible-group"]], n.Config())
+		}
+	}
+
+	// sort nodes by name as they are not sorted originally
+	for _, nodes := range i.Nodes {
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].ShortName < nodes[j].ShortName
+		})
+	}
+
+	// sort nodes-per-group by name as they are not sorted originally
+	for _, nodes := range i.Groups {
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].ShortName < nodes[j].ShortName
+		})
+	}
+
+	t, err := template.New("graph").Parse(invT)
+	if err != nil {
+		return err
+	}
+	err = t.Execute(w, i)
+	if err != nil {
+		return err
+	}
+	return err
+
+}

--- a/clab/export.go
+++ b/clab/export.go
@@ -14,8 +14,15 @@ import (
 )
 
 type topoData struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	//	Config topoConfig                   `json:"configuration,omitempty"`
 	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
 	Links []Link                       `json:"links,omitempty"`
+}
+
+type topoConfig struct {
+	Name string `json:"name,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
@@ -31,6 +38,8 @@ func (c *CLab) GenerateExports() error {
 // generates and writes topology data file to w
 func (c *CLab) exportTopologyData(w io.Writer) error {
 	d := topoData{
+		Name:  c.Config.Name,
+		Type:  "clab",
 		Nodes: make(map[string]*types.NodeConfig),
 		Links: make([]Link, 0, len(c.Links)),
 	}

--- a/clab/export.go
+++ b/clab/export.go
@@ -6,6 +6,7 @@ package clab
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -55,6 +56,16 @@ type TopologyExport struct {
 func (c *CLab) exportTopologyDataWithTemplate(w io.Writer, n string, p string) error {
 	t, err := template.New(n).
 		Funcs(gomplate.CreateFuncs(context.Background(), new(data.Data))).
+		Funcs(template.FuncMap{
+			"ToJSON": func(v interface{}) string {
+				a, _ := json.Marshal(v)
+				return string(a)
+			},
+			"ToJSONPretty": func(v interface{}, prefix string, indent string) string {
+				a, _ := json.MarshalIndent(v, prefix, indent)
+				return string(a)
+			},
+		}).
 		ParseFiles(p)
 
 	if err != nil {

--- a/clab/export.go
+++ b/clab/export.go
@@ -91,6 +91,10 @@ func (c *CLab) exportTopologyDataWithDefaultTemplate(w io.Writer) error {
 }`
 
 	t, err := template.New("default").Parse(tdef)
+	if err != nil {
+		return err
+	}
+
 	e := TopologyExport{
 		Name: c.Config.Name,
 		Type: "clab",

--- a/clab/export.go
+++ b/clab/export.go
@@ -15,6 +15,8 @@ import (
 	"github.com/srl-labs/containerlab/types"
 )
 
+const defaultTopologyExportTemplate = "/etc/containerlab/templates/export/auto.tmpl"
+
 // GenerateExports generate various export files and writes it to a lab location
 func (c *CLab) GenerateExports() error {
 	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
@@ -23,9 +25,9 @@ func (c *CLab) GenerateExports() error {
 		return err
 	}
 
-	p := "/etc/containerlab/templates/export/auto.tmpl"
+	p := defaultTopologyExportTemplate
 	// Name for the template, has to match the file name part of the full path above
-	n := "auto.tmpl"
+	n := filepath.Base(p)
 	err = c.exportTopologyDataWithTemplate(f, n, p)
 	if err != nil {
 		log.Warningf("Cannot parse export template %s", p)

--- a/clab/export.go
+++ b/clab/export.go
@@ -16,13 +16,11 @@ import (
 
 // GenerateExports generate various export files and writes it to a lab location
 func (c *CLab) GenerateExports() error {
-
 	topologyGraphFPath := filepath.Join(c.Dir.Lab, "topology-graph.json")
-	_, err = os.Create(topologyGraphFPath)
+	f, err := os.Create(topologyGraphFPath)
 	if err != nil {
 		return err
 	}
-
 	return c.generateTopologyGraph(f)
 }
 

--- a/clab/export.go
+++ b/clab/export.go
@@ -5,14 +5,25 @@
 package clab
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
-	"text/template"
 
 	"github.com/srl-labs/containerlab/types"
 )
+
+type topoGraph struct {
+	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
+	//	Links []link `json:"links,omitempty"`
+}
+
+type link struct {
+	Source         string `json:"source,omitempty"`
+	SourceEndpoint string `json:"source_endpoint,omitempty"`
+	Target         string `json:"target,omitempty"`
+	TargetEndpoint string `json:"target_endpoint,omitempty"`
+}
 
 // GenerateExports generate various export files and writes it to a lab location
 func (c *CLab) GenerateExports() error {
@@ -26,57 +37,24 @@ func (c *CLab) GenerateExports() error {
 
 // generateTopologyGraph generates and writes topology graph file to w
 func (c *CLab) generateTopologyGraph(w io.Writer) error {
-
-	invT :=
-		`{
-      "nodes": [
-        {{- range $nodes}}
-      ],
-      "links": [
-      ]
-}
-`
-	type inv struct {
-		// clab nodes aggregated by their kind
-		Nodes map[string][]*types.NodeConfig
-		// clab nodes aggregated by user-defined groups
-		Groups map[string][]*types.NodeConfig
-	}
-
-	i := inv{
-		Nodes:  make(map[string][]*types.NodeConfig),
-		Groups: make(map[string][]*types.NodeConfig),
+	g := topoGraph{
+		Nodes: make(map[string]*types.NodeConfig),
+		//Links: make([]c.Link, 0, len(c.Links)),
 	}
 
 	for _, n := range c.Nodes {
-		i.Nodes[n.Config().Kind] = append(i.Nodes[n.Config().Kind], n.Config())
-		if n.Config().Labels["ansible-group"] != "" {
-			i.Groups[n.Config().Labels["ansible-group"]] = append(i.Groups[n.Config().Labels["ansible-group"]], n.Config())
-		}
+		cfg := n.Config()
+		// Empty NodeConfig.Endpoints slice to avoid cyclic references incompatible with json.Marshal()
+		cfg.Endpoints = make([]types.Endpoint, 0, 0)
+		g.Nodes[n.Config().ShortName] = cfg
 	}
 
-	// sort nodes by name as they are not sorted originally
-	for _, nodes := range i.Nodes {
-		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].ShortName < nodes[j].ShortName
-		})
-	}
-
-	// sort nodes-per-group by name as they are not sorted originally
-	for _, nodes := range i.Groups {
-		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].ShortName < nodes[j].ShortName
-		})
-	}
-
-	t, err := template.New("graph").Parse(invT)
+	b, err := json.Marshal(g)
 	if err != nil {
 		return err
 	}
-	err = t.Execute(w, i)
-	if err != nil {
-		return err
-	}
-	return err
 
+	w.Write(b)
+
+	return nil
 }

--- a/clab/export.go
+++ b/clab/export.go
@@ -54,10 +54,7 @@ func (c *CLab) exportTopologyData(w io.Writer) error {
 	}
 
 	for _, n := range c.Nodes {
-		cfg := n.Config()
-		// Empty NodeConfig.Endpoints slice to avoid cyclic references incompatible with json.Marshal()
-		cfg.Endpoints = make([]types.Endpoint, 0, 0)
-		d.Nodes[n.Config().ShortName] = cfg
+		d.Nodes[n.Config().ShortName] = n.Config()
 	}
 
 	for _, l := range c.Links {

--- a/clab/export.go
+++ b/clab/export.go
@@ -15,14 +15,7 @@ import (
 
 type topoGraph struct {
 	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
-	//	Links []link `json:"links,omitempty"`
-}
-
-type link struct {
-	Source         string `json:"source,omitempty"`
-	SourceEndpoint string `json:"source_endpoint,omitempty"`
-	Target         string `json:"target,omitempty"`
-	TargetEndpoint string `json:"target_endpoint,omitempty"`
+	Links []Link                       `json:"links,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
@@ -39,7 +32,7 @@ func (c *CLab) GenerateExports() error {
 func (c *CLab) generateTopologyGraph(w io.Writer) error {
 	g := topoGraph{
 		Nodes: make(map[string]*types.NodeConfig),
-		//Links: make([]c.Link, 0, len(c.Links)),
+		Links: make([]Link, 0, len(c.Links)),
 	}
 
 	for _, n := range c.Nodes {
@@ -47,6 +40,15 @@ func (c *CLab) generateTopologyGraph(w io.Writer) error {
 		// Empty NodeConfig.Endpoints slice to avoid cyclic references incompatible with json.Marshal()
 		cfg.Endpoints = make([]types.Endpoint, 0, 0)
 		g.Nodes[n.Config().ShortName] = cfg
+	}
+
+	for _, l := range c.Links {
+		g.Links = append(g.Links, Link{
+			Source:         l.A.Node.ShortName,
+			SourceEndpoint: l.A.EndpointName,
+			Target:         l.B.Node.ShortName,
+			TargetEndpoint: l.B.EndpointName,
+		})
 	}
 
 	b, err := json.Marshal(g)

--- a/clab/export.go
+++ b/clab/export.go
@@ -13,24 +13,24 @@ import (
 	"github.com/srl-labs/containerlab/types"
 )
 
-type topoGraph struct {
+type topoData struct {
 	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
 	Links []Link                       `json:"links,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
 func (c *CLab) GenerateExports() error {
-	topologyGraphFPath := filepath.Join(c.Dir.Lab, "topology-graph.json")
-	f, err := os.Create(topologyGraphFPath)
+	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
+	f, err := os.Create(topoDataFPath)
 	if err != nil {
 		return err
 	}
-	return c.generateTopologyGraph(f)
+	return c.exportTopologyData(f)
 }
 
-// generateTopologyGraph generates and writes topology graph file to w
-func (c *CLab) generateTopologyGraph(w io.Writer) error {
-	g := topoGraph{
+// generates and writes topology data file to w
+func (c *CLab) exportTopologyData(w io.Writer) error {
+	d := topoData{
 		Nodes: make(map[string]*types.NodeConfig),
 		Links: make([]Link, 0, len(c.Links)),
 	}
@@ -39,11 +39,11 @@ func (c *CLab) generateTopologyGraph(w io.Writer) error {
 		cfg := n.Config()
 		// Empty NodeConfig.Endpoints slice to avoid cyclic references incompatible with json.Marshal()
 		cfg.Endpoints = make([]types.Endpoint, 0, 0)
-		g.Nodes[n.Config().ShortName] = cfg
+		d.Nodes[n.Config().ShortName] = cfg
 	}
 
 	for _, l := range c.Links {
-		g.Links = append(g.Links, Link{
+		d.Links = append(d.Links, Link{
 			Source:         l.A.Node.ShortName,
 			SourceEndpoint: l.A.EndpointName,
 			Target:         l.B.Node.ShortName,
@@ -51,7 +51,7 @@ func (c *CLab) generateTopologyGraph(w io.Writer) error {
 		})
 	}
 
-	b, err := json.Marshal(g)
+	b, err := json.Marshal(d)
 	if err != nil {
 		return err
 	}

--- a/clab/export.go
+++ b/clab/export.go
@@ -14,11 +14,17 @@ import (
 )
 
 type topoData struct {
-	Name   string                       `json:"name"`
-	Type   string                       `json:"type"`
-	Config *Config                      `json:"configuration,omitempty"`
-	Nodes  map[string]*types.NodeConfig `json:"nodes,omitempty"`
-	Links  []Link                       `json:"links,omitempty"`
+	Name  string                       `json:"name"`
+	Type  string                       `json:"type"`
+	Clab  ClabConfig                   `json:"clab,omitempty"`
+	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
+	Links []Link                       `json:"links,omitempty"`
+}
+
+type ClabConfig struct {
+	Prefix     *string        `json:"prefix,omitempty"`
+	Mgmt       *types.MgmtNet `json:"mgmt,omitempty"`
+	ConfigPath string         `json:"config-path,omitempty"`
 }
 
 // GenerateExports generate various export files and writes it to a lab location
@@ -33,12 +39,18 @@ func (c *CLab) GenerateExports() error {
 
 // generates and writes topology data file to w
 func (c *CLab) exportTopologyData(w io.Writer) error {
+	cc := ClabConfig{
+		c.Config.Prefix,
+		c.Config.Mgmt,
+		c.Config.ConfigPath,
+	}
+
 	d := topoData{
-		Name:   c.Config.Name,
-		Type:   "clab",
-		Config: c.Config,
-		Nodes:  make(map[string]*types.NodeConfig),
-		Links:  make([]Link, 0, len(c.Links)),
+		Name:  c.Config.Name,
+		Type:  "clab",
+		Clab:  cc,
+		Nodes: make(map[string]*types.NodeConfig),
+		Links: make([]Link, 0, len(c.Links)),
 	}
 
 	for _, n := range c.Nodes {

--- a/clab/export.go
+++ b/clab/export.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/srl-labs/containerlab/types"
 )
@@ -41,7 +42,8 @@ func (c *CLab) GenerateExports() error {
 	if err != nil {
 		return err
 	}
-	return c.exportTopologyData(f)
+	//return c.exportTopologyData(f)
+	return c.exportTopologyDataWithTemplate(f, "auto.tmpl", "/etc/containerlab/templates/export/auto.tmpl")
 }
 
 // generates and writes topology data file to w
@@ -89,4 +91,24 @@ func (c *CLab) exportTopologyData(w io.Writer) error {
 	w.Write(b)
 
 	return nil
+}
+
+// generates and writes topology data file to w using a template
+func (c *CLab) exportTopologyDataWithTemplate(w io.Writer, n string, p string) error {
+	t, err := template.New(n).Funcs(template.FuncMap{
+		"marshal": func(v interface{}) string {
+			a, _ := json.Marshal(v)
+			return string(a)
+		},
+	}).ParseFiles(p)
+
+	if err != nil {
+		return err
+	}
+
+	err = t.Execute(w, c)
+	if err != nil {
+		return err
+	}
+	return err
 }

--- a/clab/export.go
+++ b/clab/export.go
@@ -78,7 +78,7 @@ func (c *CLab) exportTopologyData(w io.Writer) error {
 		d.Links = append(d.Links, intmap)
 	}
 
-	b, err := json.Marshal(d)
+	b, err := json.MarshalIndent(d, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/clab/export.go
+++ b/clab/export.go
@@ -14,27 +14,6 @@ import (
 	"github.com/srl-labs/containerlab/types"
 )
 
-type TopologyData struct {
-	Name       string                       `json:"name"`
-	Type       string                       `json:"type"`
-	ClabConfig ClabConfig                   `json:"clabconfig,omitempty"`
-	Nodes      map[string]*types.NodeConfig `json:"nodes,omitempty"`
-	Links      []map[string]NodeInterface   `json:"links,omitempty"`
-}
-
-type ClabConfig struct {
-	Prefix     *string        `json:"prefix,omitempty"`
-	Mgmt       *types.MgmtNet `json:"mgmt,omitempty"`
-	ConfigPath string         `json:"config-path,omitempty"`
-}
-
-type NodeInterface struct {
-	Node      string `json:"node,omitempty"`
-	Interface string `json:"interface,omitempty"`
-	MAC       string `json:"mac,omitempty"`
-	Peer      string `json:"peer,omitempty"`
-}
-
 // GenerateExports generate various export files and writes it to a lab location
 func (c *CLab) GenerateExports() error {
 	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
@@ -42,55 +21,7 @@ func (c *CLab) GenerateExports() error {
 	if err != nil {
 		return err
 	}
-	//return c.exportTopologyData(f)
 	return c.exportTopologyDataWithTemplate(f, "auto.tmpl", "/etc/containerlab/templates/export/auto.tmpl")
-}
-
-// generates and writes topology data file to w
-func (c *CLab) exportTopologyData(w io.Writer) error {
-	cc := ClabConfig{
-		c.Config.Prefix,
-		c.Config.Mgmt,
-		c.Config.ConfigPath,
-	}
-
-	d := TopologyData{
-		Name:       c.Config.Name,
-		Type:       "clab",
-		ClabConfig: cc,
-		Nodes:      make(map[string]*types.NodeConfig),
-		Links:      make([]map[string]NodeInterface, 0, len(c.Links)),
-	}
-
-	for _, n := range c.Nodes {
-		d.Nodes[n.Config().ShortName] = n.Config()
-	}
-
-	for _, l := range c.Links {
-		intmap := make(map[string]NodeInterface)
-		intmap["a"] = NodeInterface{
-			Node:      l.A.Node.ShortName,
-			Interface: l.A.EndpointName,
-			MAC:       l.A.MAC,
-			Peer:      "z",
-		}
-		intmap["z"] = NodeInterface{
-			Node:      l.B.Node.ShortName,
-			Interface: l.B.EndpointName,
-			MAC:       l.B.MAC,
-			Peer:      "a",
-		}
-		d.Links = append(d.Links, intmap)
-	}
-
-	b, err := json.MarshalIndent(d, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	w.Write(b)
-
-	return nil
 }
 
 // This struct will hold a combination of CLab structure, which is mostly derived from topology.yaml,

--- a/clab/export.go
+++ b/clab/export.go
@@ -14,11 +14,11 @@ import (
 )
 
 type topoData struct {
-	Name  string                       `json:"name"`
-	Type  string                       `json:"type"`
-	Clab  ClabConfig                   `json:"clab,omitempty"`
-	Nodes map[string]*types.NodeConfig `json:"nodes,omitempty"`
-	Links []Link                       `json:"links,omitempty"`
+	Name       string                       `json:"name"`
+	Type       string                       `json:"type"`
+	ClabConfig ClabConfig                   `json:"clabconfig,omitempty"`
+	Nodes      map[string]*types.NodeConfig `json:"nodes,omitempty"`
+	Links      []Link                       `json:"links,omitempty"`
 }
 
 type ClabConfig struct {
@@ -46,11 +46,11 @@ func (c *CLab) exportTopologyData(w io.Writer) error {
 	}
 
 	d := topoData{
-		Name:  c.Config.Name,
-		Type:  "clab",
-		Clab:  cc,
-		Nodes: make(map[string]*types.NodeConfig),
-		Links: make([]Link, 0, len(c.Links)),
+		Name:       c.Config.Name,
+		Type:       "clab",
+		ClabConfig: cc,
+		Nodes:      make(map[string]*types.NodeConfig),
+		Links:      make([]Link, 0, len(c.Links)),
 	}
 
 	for _, n := range c.Nodes {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -124,6 +124,13 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// in an similar fashion, create an empty topology graph file
+	topologyGraphFPath := filepath.Join(c.Dir.Lab, "topology-graph.json")
+	_, err = os.Create(topologyGraphFPath)
+	if err != nil {
+		return err
+	}
+
 	cfssllog.Level = cfssllog.LevelError
 	if debug {
 		cfssllog.Level = cfssllog.LevelDebug
@@ -201,6 +208,10 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	enrichNodes(containers, c.Nodes)
 
 	if err := c.GenerateInventories(); err != nil {
+		return err
+	}
+
+	if err := c.GenerateExports(); err != nil {
 		return err
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -125,8 +125,8 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	}
 
 	// in an similar fashion, create an empty topology graph file
-	topologyGraphFPath := filepath.Join(c.Dir.Lab, "topology-graph.json")
-	_, err = os.Create(topologyGraphFPath)
+	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
+	_, err = os.Create(topoDataFPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -126,7 +126,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// in an similar fashion, create an empty topology graph file
 	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
-	_, err = os.Create(topoDataFPath)
+	topoDataF, err := os.Create(topoDataFPath)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err := c.GenerateExports(); err != nil {
+	if err := c.GenerateExports(topoDataF); err != nil {
 		return err
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,6 +41,9 @@ var maxWorkers uint
 // skipPostDeploy flag
 var skipPostDeploy bool
 
+// template file for topology data export
+var exportTemplate string
+
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
 	Use:          "deploy",
@@ -61,6 +64,7 @@ func init() {
 	deployCmd.Flags().BoolVarP(&reconfigure, "reconfigure", "", false, "regenerate configuration artifacts and overwrite the previous ones if any")
 	deployCmd.Flags().UintVarP(&maxWorkers, "max-workers", "", 0, "limit the maximum number of workers creating nodes and virtual wires")
 	deployCmd.Flags().BoolVarP(&skipPostDeploy, "skip-post-deploy", "", false, "skip post deploy action")
+	deployCmd.Flags().StringVarP(&exportTemplate, "export-template", "", "", "template file for topology data export")
 }
 
 func deployFn(_ *cobra.Command, _ []string) error {
@@ -124,7 +128,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// in an similar fashion, create an empty topology graph file
+	// in an similar fashion, create an empty topology data file
 	topoDataFPath := filepath.Join(c.Dir.Lab, "topology-data.json")
 	topoDataF, err := os.Create(topoDataFPath)
 	if err != nil {
@@ -211,7 +215,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err := c.GenerateExports(topoDataF); err != nil {
+	if err := c.GenerateExports(topoDataF, exportTemplate); err != nil {
 		return err
 	}
 

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -48,8 +48,11 @@ In a busy compute the runtime may respond longer than anticipated, in that case 
 
 The default timeout is set to 2 minutes and can be changed to values like `30s, 10m`.
 
-#### skip-post-deploy
-With `--skip-post-deploy` flag it is possible to skip post deployment actions.
+#### export-template
+The local `--export-template` flag allows a user to specify a custom Go template to be used as a schema for exporting topology data into `topology-data.json` under the lab directory. Without this flag, the default template path is `/etc/containerlab/templates/export/auto.tmpl`. For example, to export full topology data instead of a subset of fields exported by default, use `--export-template /etc/containerlab/templates/export/full.tmpl`. Note, some fields exported via `full.tmpl` might contain sensitive information like TLS private keys. To customize export data, it is recommended to start with a copy of `auto.tmpl` and change it according to your needs.
+
+#### max-workers
+With `--max-workers` flag it is possible to limit the amout of concurrent workers that create containers or wire virtual links. By default the number of workers equals the number of nodes/links to create.
 
 ### Examples
 

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -108,4 +108,131 @@ As a result of this configuration, the generated inventory will look like this:
           ansible_host: 172.100.100.11
 ```
 
+## Topology Data
+Every time a user runs a `deploy` command, clab automatically exports comprehensive information about the topology into `topology-data.json` file in the lab directory.
+
+The topology data file contains the following top-level sections, or keys:
+
+```json
+{
+  "name": "<topology name>",
+  "type": "clab",
+  "clabconfig": {<top-level information about the lab, like management network details>},
+  "nodes": {<detailed information about every node in the topology, including dynamic information like management IP addresses>},
+  "links": [<entries for every link between nopology nodes, including interface names and allocated MAC addresses>]
+}
+````
+
+
+=== "topology file srl02.clab.yml"
+    ```yaml
+    name: srl02
+
+    topology:
+      kinds:
+        srl:
+          type: ixr6
+          image: ghcr.io/nokia/srlinux
+      nodes:
+        srl1:
+          kind: srl
+        srl2:
+          kind: srl
+
+      links:
+        - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+    ```
+=== "sample generated topology-data.json"
+    ```json
+    {
+      "name": "srl02",
+      "type": "clab",
+      "clabconfig": {
+        "prefix": "clab",
+        "mgmt": {
+          "network": "clab",
+          "bridge": "br-<...>",
+          "ipv4_subnet": "172.20.20.0/24",
+          "ipv6_subnet": "2001:172:20:20::/64",
+          "mtu": "1500",
+          "external-access": true
+        },
+        "config-path": "<full path to a directory with srl02.clab.yml>"
+      },
+      "nodes": {
+        "srl1": {
+          "shortname": "srl1",
+          "longname": "clab-srl02-srl1",
+          "fqdn": "srl1.srl02.io",
+          "labdir": "<full path to the lab node directory>",
+          "kind": "srl",
+          "nodetype": "ixr6",
+          "image": "ghcr.io/nokia/srlinux",
+          "user": "0:0",
+          "cmd": "sudo bash -c 'touch /.dockerenv && /opt/srlinux/bin/sr_linux'",
+          "mgmtipv4address": "172.20.20.2",
+          "mgmtipv4prefixLength": 24,
+          "mgmtipv6address": "2001:172:20:20::2",
+          "mgmtipv6prefixLength": 64,
+          "containerid": "<container id>",
+          "nspath": "/proc/<...>/ns/net",
+          "labels": {
+            "clab-mgmt-net-bridge": "br-<...>",
+            "clab-node-group": "",
+            "clab-node-kind": "srl",
+            "clab-node-lab-dir": "<full path to the lab node directory>",
+            "clab-node-name": "srl1",
+            "clab-node-type": "ixr6",
+            "clab-topo-file": "<full path to the srl02.clab.yml file>",
+            "containerlab": "srl02"
+          },
+          "deploymentstatus": "created"
+        },
+        "srl2": {
+          "shortname": "srl2",
+          "longname": "clab-srl02-srl2",
+          "fqdn": "srl2.srl02.io",
+          "labdir": "<full path to the lab node directory>",,
+          "index": 1,
+          "kind": "srl",
+          "nodetype": "ixr6",
+          "image": "ghcr.io/nokia/srlinux",
+          "user": "0:0",
+          "cmd": "sudo bash -c 'touch /.dockerenv && /opt/srlinux/bin/sr_linux'",
+          "mgmtipv4address": "172.20.20.3",
+          "mgmtipv4prefixLength": 24,
+          "mgmtipv6address": "2001:172:20:20::3",
+          "mgmtipv6prefixLength": 64,
+          "containerid": "<container id>",
+          "nspath": "/proc/<...>/ns/net",
+          "labels": {
+            "clab-mgmt-net-bridge": "br-<...>",
+            "clab-node-group": "",
+            "clab-node-kind": "srl",
+            "clab-node-lab-dir": "<full path to the lab node directory>",
+            "clab-node-name": "srl2",
+            "clab-node-type": "ixr6",
+            "clab-topo-file": "<full path to the srl02.clab.yml file>",
+            "containerlab": "srl02"
+          },
+          "deploymentstatus": "created"
+        }
+      },
+      "links": [
+        {
+          "a": {
+            "node": "srl1",
+            "interface": "e1-1",
+            "mac": "<mac address>"
+          },
+          "z": {
+            "node": "srl2",
+            "interface": "e1-1",
+            "mac": "<mac address>"
+          }
+        }
+      ]
+    }
+    ```
+
 [^1]: For example [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin.

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -224,11 +224,13 @@ The topology data file contains the following top-level sections, or keys:
             "node": "srl1",
             "interface": "e1-1",
             "mac": "<mac address>"
+            "peer": "z"
           },
           "z": {
             "node": "srl2",
             "interface": "e1-1",
             "mac": "<mac address>"
+            "peer": "a"
           }
         }
       ]

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -117,9 +117,9 @@ The topology data file contains the following top-level sections, or keys:
 {
   "name": "<topology name>",
   "type": "clab",
-  "clabconfig": {<top-level information about the lab, like management network details>},
-  "nodes": {<detailed information about every node in the topology, including dynamic information like management IP addresses>},
-  "links": [<entries for every link between nopology nodes, including interface names and allocated MAC addresses>]
+  "clabconfig": {"<top-level information about the lab, like management network details>"},
+  "nodes": {"<detailed information about every node in the topology, including dynamic information like management IP addresses>"},
+  "links": ["<entries for every link between nopology nodes, including interface names and allocated MAC addresses>"]
 }
 ````
 

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -159,7 +159,7 @@ topology:
 
     Notice how `__clabNodeDir__` hides the directory structure and node names and removes the verbosity of the previous approach.
 
-    Another special variable the clab file can use is `__clabDir__`. In the example above, it would expand into `clab-mylab` folder. With `__clabDir__` variable it becomes convenient to bind files like `ansible-inventory.yml` or `topology-data.json` that clab automatically creates:
+    Another special variable the containerlab topology file can use is `__clabDir__`. In the example above, it would expand into `clab-mylab` folder. With `__clabDir__` variable it becomes convenient to bind files like `ansible-inventory.yml` or `topology-data.json` that containerlab automatically creates:
 
     ```yaml
     name: mylab
@@ -170,7 +170,7 @@ topology:
             - __clabDir__/ansible-inventory.yml:/ansible-inventory.yml:ro
         graphite:
           binds:
-            - __clabDir__/topology-data.json::/var/www/localhost/htdocs/clab/topology-data.json:ro
+            - __clabDir__/topology-data.json::/htdocs/clab/topology-data.json:ro
     ```
 
 Binds defined on multiple levels (defaults -> kind -> node) will be merged with the duplicated values removed (the lowest level takes precedence).

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -159,6 +159,20 @@ topology:
 
     Notice how `__clabNodeDir__` hides the directory structure and node names and removes the verbosity of the previous approach.
 
+    Another special variable the clab file can use is `__clabDir__`. In the example above, it would expand into `clab-mylab` folder. With `__clabDir__` variable it becomes convenient to bind files like `ansible-inventory.yml` or `topology-data.json` that clab automatically creates:
+
+    ```yaml
+    name: mylab
+    topology:
+      nodes:
+        ansible:
+          binds:
+            - __clabDir__/ansible-inventory.yml:/ansible-inventory.yml:ro
+        graphite:
+          binds:
+            - __clabDir__/topology-data.json::/var/www/localhost/htdocs/clab/topology-data.json:ro
+    ```
+
 Binds defined on multiple levels (defaults -> kind -> node) will be merged with the duplicated values removed (the lowest level takes precedence).
 
 ### ports

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -3,12 +3,29 @@
   "type": "{{ .Type }}",
   "clabconfig": {
     "prefix": "{{ .Clab.Config.Prefix }}",
-    {{ $input := .Clab.Config.Mgmt }}
-    "mgmt": {{ data.ToJSONPretty " " $input }},
+    {{ $input := .Clab.Config.Mgmt }}"mgmt": {{ data.ToJSONPretty "      " $input }},
     "config-path": "{{ .Clab.Config.ConfigPath }}"
   },
-  {{ $input := .NodeConfigs }}
-  "nodes": {{ data.ToJSONPretty " " $input }},
+  "nodes": { {{$i:=0}}{{range $n, $c := .NodeConfigs}}{{if $i}},{{end}}
+    "{{$n}}": {
+      "index": "{{$c.Index}}",
+      "shortname": "{{$c.ShortName}}",
+      "longname": "{{$c.LongName}}",
+      "fqdn": "{{$c.Fqdn}}",
+      "group": "{{$c.Group}}",
+      "labdir": "{{$c.LabDir}}",
+      "kind": "{{$c.Kind}}",
+      "image": "{{$c.Image}}",
+      "mgmt-net": "{{$c.MgmtNet}}",
+      "mgmt-intf": "{{$c.MgmtIntf}}",
+      "mgmt-ipv4-address": "{{$c.MgmtIPv4Address}}",
+      "mgmt-ipv4-prefix-length": {{$c.MgmtIPv4PrefixLength}},
+      "mgmt-ipv6-address": "{{$c.MgmtIPv6Address}}",
+      "mgmt-ipv6-prefix-length": {{$c.MgmtIPv6PrefixLength}},
+      "mac-address": "{{$c.MacAddress}}",
+      {{ $input := $c.Labels }}"labels": {{ data.ToJSONPretty "        " $input }}
+    }{{$i = add $i 1}}{{end}}
+  },
   "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}
     {
       "a": {

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -3,10 +3,12 @@
   "type": "{{ .Type }}",
   "clabconfig": {
     "prefix": "{{ .Clab.Config.Prefix }}",
-    "mgmt": {{ marshal_indent .Clab.Config.Mgmt "    " "  " }},
+    {{ $input := .Clab.Config.Mgmt }}
+    "mgmt": {{ data.ToJSONPretty " " $input }},
     "config-path": "{{ .Clab.Config.ConfigPath }}"
   },
-  "nodes": {{ marshal_indent .NodeConfigs "  " "  " }},
+  {{ $input := .NodeConfigs }}
+  "nodes": {{ data.ToJSONPretty " " $input }},
   "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}
     {
       "a": {

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -3,10 +3,10 @@
   "type": "{{ .Type }}",
   "clabconfig": {
     "prefix": "{{ .Clab.Config.Prefix }}",
-    "mgmt": {{ marshal .Clab.Config.Mgmt }},
+    "mgmt": {{ marshal_indent .Clab.Config.Mgmt "    " "  " }},
     "config-path": "{{ .Clab.Config.ConfigPath }}"
   },
-  "nodes": {{ marshal .NodeConfigs }},
+  "nodes": {{ marshal_indent .NodeConfigs "  " "  " }},
   "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}
     {
       "a": {

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -1,10 +1,12 @@
 {
   "name": "{{ .Name }}",
   "type": "{{ .Type }}",
-  "clabconfig": {
-    "prefix": "{{ .Clab.Config.Prefix }}",
-    {{ $input := .Clab.Config.Mgmt }}"mgmt": {{ data.ToJSONPretty "      " $input }},
-    "config-path": "{{ .Clab.Config.ConfigPath }}"
+  "clab": {
+    "config": {
+      "prefix": "{{ .Clab.Config.Prefix }}",
+      "mgmt": {{ ToJSONPretty .Clab.Config.Mgmt "        " "  "}},
+      "config-path": "{{ .Clab.Config.ConfigPath }}"
+    }
   },
   "nodes": { {{$i:=0}}{{range $n, $c := .NodeConfigs}}{{if $i}},{{end}}
     "{{$n}}": {
@@ -23,7 +25,7 @@
       "mgmt-ipv6-address": "{{$c.MgmtIPv6Address}}",
       "mgmt-ipv6-prefix-length": {{$c.MgmtIPv6PrefixLength}},
       "mac-address": "{{$c.MacAddress}}",
-      {{ $input := $c.Labels }}"labels": {{ data.ToJSONPretty "        " $input }}
+      "labels": {{ToJSONPretty $c.Labels "        " "  "}}
     }{{$i = add $i 1}}{{end}}
   },
   "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -1,13 +1,13 @@
 {
-  "name": "{{ .Config.Name }}",
-  "type": "clab",
+  "name": "{{ .Name }}",
+  "type": "{{ .Type }}",
   "clabconfig": {
-    "prefix": "{{ .Config.Prefix }}",
-    "mgmt": {{ marshal .Config.Mgmt }},
-    "config-path": "{{ .Config.ConfigPath }}"
+    "prefix": "{{ .Clab.Config.Prefix }}",
+    "mgmt": {{ marshal .Clab.Config.Mgmt }},
+    "config-path": "{{ .Clab.Config.ConfigPath }}"
   },
-  "nodes": {{ marshal .Nodes }},
-  "links": [{{range $i, $l := .Links}}{{if $i}},{{end}}
+  "nodes": {{ marshal .NodeConfigs }},
+  "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}
     {
       "a": {
         "node": "{{ $l.A.Node.ShortName }}",
@@ -22,6 +22,5 @@
         "peer": "a"
       }
     }{{end}}
-  ],
-  "clab": {{ marshal . }}
+  ]
 }

--- a/templates/export/auto.tmpl
+++ b/templates/export/auto.tmpl
@@ -1,0 +1,27 @@
+{
+  "name": "{{ .Config.Name }}",
+  "type": "clab",
+  "clabconfig": {
+    "prefix": "{{ .Config.Prefix }}",
+    "mgmt": {{ marshal .Config.Mgmt }},
+    "config-path": "{{ .Config.ConfigPath }}"
+  },
+  "nodes": {{ marshal .Nodes }},
+  "links": [{{range $i, $l := .Links}}{{if $i}},{{end}}
+    {
+      "a": {
+        "node": "{{ $l.A.Node.ShortName }}",
+        "interface": "{{ $l.A.EndpointName }}",
+        "mac": "{{ $l.A.MAC }}",
+        "peer": "z"
+      },
+      "z": {
+        "node": "{{ $l.B.Node.ShortName }}",
+        "interface": "{{ $l.B.EndpointName }}",
+        "mac": "{{ $l.B.MAC }}",
+        "peer": "a"
+      }
+    }{{end}}
+  ],
+  "clab": {{ marshal . }}
+}

--- a/templates/export/full.tmpl
+++ b/templates/export/full.tmpl
@@ -1,0 +1,24 @@
+{
+  "name": "{{ .Name }}",
+  "type": "{{ .Type }}",
+  "nodes": { {{$i:=0}}{{range $n, $c := .NodeConfigs}}{{if $i}},{{end}}{{ $k := dict "tls-key" $c.TLSKey }}
+    "{{$n}}": {{ $cj := $c | data.ToJSON | data.JSON }} {{ $dst := coll.Merge $cj $k }}{{ ToJSONPretty $dst "    " "  " }}{{$i = add $i 1}}{{end}}
+  },
+  "links": [{{range $i, $l := .Clab.Links}}{{if $i}},{{end}}
+    {
+      "a": {
+        "node": "{{ $l.A.Node.ShortName }}",
+        "interface": "{{ $l.A.EndpointName }}",
+        "mac": "{{ $l.A.MAC }}",
+        "peer": "z"
+      },
+      "z": {
+        "node": "{{ $l.B.Node.ShortName }}",
+        "interface": "{{ $l.B.EndpointName }}",
+        "mac": "{{ $l.B.MAC }}",
+        "peer": "a"
+      }
+    }{{end}}
+  ],
+  "clab": {{ ToJSONPretty .Clab "  " "  "}}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -55,65 +55,62 @@ type MgmtNet struct {
 
 // NodeConfig is a struct that contains the information of a container element
 type NodeConfig struct {
-	ShortName            string // name of the Node inside topology YAML
-	LongName             string // containerlab-prefixed unique container name
-	Fqdn                 string
-	LabDir               string // LabDir is a directory related to the node, it contains config items and/or other persistent state
-	Index                int
-	Group                string
-	Kind                 string
-	StartupConfig        string // path to config template file that is used for startup config generation
-	StartupDelay         uint   // optional delay (in seconds) to wait before creating this node
-	EnforceStartupConfig bool   // when set to true will enforce the use of startup-config, even when config is present in the lab directory
-	ResStartupConfig     string // path to config file that is actually mounted to the container and is a result of templation
-	Config               *ConfigDispatcher
-	ResConfig            string // path to config file that is actually mounted to the container and is a result of templation
-	NodeType             string
-	Position             string
-	License              string
-	Image                string
-	Sysctls              map[string]string
-	User                 string
-	Entrypoint           string
-	Cmd                  string
-	Exec                 []string
-	Env                  map[string]string
-	Binds                []string    // Bind mounts strings (src:dest:options)
-	PortBindings         nat.PortMap // PortBindings define the bindings between the container ports and host ports
-	PortSet              nat.PortSet // PortSet define the ports that should be exposed on a container
-	// container networking mode. if set to `host` the host networking will be used for this node, else bridged network
-	NetworkMode          string
-	MgmtNet              string // name of the docker network this node is connected to with its first interface
-	MgmtIntf             string // can be used to be rendered by the default node template 
-	MgmtIPv4Address      string
-	MgmtIPv4PrefixLength int
-	MgmtIPv6Address      string
-	MgmtIPv6PrefixLength int
-	MacAddress           string
-	ContainerID          string
-	TLSCert              string
-	TLSKey               string
-	TLSAnchor            string
-	NSPath               string   // network namespace path for this node
-	Publish              []string // list of ports to publish with mysocketctl
-	ExtraHosts           []string // Extra /etc/hosts entries for all nodes
-	// container labels
-	Labels map[string]string
-	// Slice of pointers to local endpoints
-	Endpoints []Endpoint
+	ShortName            string            `json:"shortname,omitempty"` // name of the Node inside topology YAML
+	LongName             string            `json:"longname,omitempty"`  // containerlab-prefixed unique container name
+	Fqdn                 string            `json:"fqdn,omitempty"`
+	LabDir               string            `json:"labdir,omitempty"` // LabDir is a directory related to the node, it contains config items and/or other persistent state
+	Index                int               `json:"index,omitempty"`
+	Group                string            `json:"group,omitempty"`
+	Kind                 string            `json:"kind,omitempty"`
+	StartupConfig        string            `json:"startupconfig,omitempty"`        // path to config template file that is used for startup config generation
+	StartupDelay         uint              `json:"startupdelay,omitempty"`         // optional delay (in seconds) to wait before creating this node
+	EnforceStartupConfig bool              `json:"enforcestartupconfig,omitempty"` // when set to true will enforce the use of startup-config, even when config is present in the lab directory
+	ResStartupConfig     string            `json:"resstartupconfig,omitempty"`     // path to config file that is actually mounted to the container and is a result of templation
+	Config               *ConfigDispatcher `json:"-"`                              // Do not marshal into JSON - internals
+	ResConfig            string            `json:"resconfig,omitempty"`            // path to config file that is actually mounted to the container and is a result of templation
+	NodeType             string            `json:"nodetype,omitempty"`
+	Position             string            `json:"position,omitempty"`
+	License              string            `json:"license,omitempty"`
+	Image                string            `json:"image,omitempty"`
+	Sysctls              map[string]string `json:"-"` // Do not marshal into JSON - internals
+	User                 string            `json:"user,omitempty"`
+	Entrypoint           string            `json:"entrypoint,omitempty"`
+	Cmd                  string            `json:"cmd,omitempty"`
+	Exec                 []string          `json:"-"`                      // Do not marshal into JSON - potentially high volume of low value data
+	Env                  map[string]string `json:"-"`                      // Do not marshal into JSON - potentially highly sensitive data like passwords
+	Binds                []string          `json:"-"`                      // Bind mounts strings (src:dest:options). Do not marshal into JSON - potentially sensitive data
+	PortBindings         nat.PortMap       `json:"portbindings,omitempty"` // PortBindings define the bindings between the container ports and host ports
+	PortSet              nat.PortSet       `json:"portset,omitempty"`      // PortSet define the ports that should be exposed on a container
+	NetworkMode          string            `json:"networkmode,omitempty"`  // container networking mode. if set to `host` the host networking will be used for this node, else bridged network
+	MgmtNet              string            `json:"mgmtnet,omitempty"`      // name of the docker network this node is connected to with its first interface
+	MgmtIntf             string            `json:"mgmtintf,omitempty"`     // can be used to be rendered by the default node template
+	MgmtIPv4Address      string            `json:"mgmtipv4address,omitempty"`
+	MgmtIPv4PrefixLength int               `json:"mgmtipv4prefixLength,omitempty"`
+	MgmtIPv6Address      string            `json:"mgmtipv6address,omitempty"`
+	MgmtIPv6PrefixLength int               `json:"mgmtipv6prefixLength,omitempty"`
+	MacAddress           string            `json:"macaddress,omitempty"`
+	ContainerID          string            `json:"containerid,omitempty"`
+	TLSCert              string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
+	TLSKey               string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
+	TLSAnchor            string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
+	NSPath               string            `json:"nspath,omitempty"`  // network namespace path for this node
+	Publish              []string          `json:"publish,omitempty"` // list of ports to publish with mysocketctl
+	ExtraHosts           []string          `json:"-"`                 // Extra /etc/hosts entries for all nodes. Do not marshal – redundant information
+	Labels               map[string]string `json:"labels,omitempty"`  // container labels
+	Endpoints            []Endpoint        `json:"-"`                 // Slice of pointers to local endpoints, do not marshal into JSON as it creates cyclical error
 	// Ignite sandbox and kernel imageNames
-	Sandbox, Kernel string
+	Sandbox, Kernel string `json:"-"` // Do not marshal into JSON - internals
 	// Configured container runtime
-	Runtime string
+	Runtime string `json:"runtime,omitempty"`
 	// Resource requirements
-	CPU    float64
-	CPUSet string
-	Memory string
+	CPU    float64 `json:"cpu,omitempty"`
+	CPUSet string  `json:"cpuset,omitempty"`
+	Memory string  `json:"memory,omitempty"`
 
-	DeploymentStatus string // status that is set by containerlab to indicate deployment stage
+	DeploymentStatus string `json:"deploymentstatus,omitempty"` // status that is set by containerlab to indicate deployment stage
 
 	// Extras
-	Extras *Extras // Extra node parameters
+	Extras *Extras `json:"-"` // Extra node parameters, do not marshal into JSON as they are kind-specific
 }
 
 // GenerateConfig generates configuration for the nodes

--- a/types/types.go
+++ b/types/types.go
@@ -43,14 +43,14 @@ type Endpoint struct {
 
 // MgmtNet struct defines the management network options
 type MgmtNet struct {
-	Network        string `yaml:"network,omitempty"` // container runtime network name
-	Bridge         string `yaml:"bridge,omitempty"`  // linux bridge backing the runtime network
-	IPv4Subnet     string `yaml:"ipv4_subnet,omitempty"`
-	IPv4Gw         string `yaml:"ipv4-gw,omitempty"`
-	IPv6Subnet     string `yaml:"ipv6_subnet,omitempty"`
-	IPv6Gw         string `yaml:"ipv6-gw,omitempty"`
-	MTU            string `yaml:"mtu,omitempty"`
-	ExternalAccess *bool  `yaml:"external-access,omitempty"`
+	Network        string `yaml:"network,omitempty" json:"network,omitempty"` // container runtime network name
+	Bridge         string `yaml:"bridge,omitempty" json:"bridge,omitempty"`   // linux bridge backing the runtime network
+	IPv4Subnet     string `yaml:"ipv4_subnet,omitempty" json:"ipv4_subnet,omitempty"`
+	IPv4Gw         string `yaml:"ipv4-gw,omitempty" json:"ipv4-gw,omitempty"`
+	IPv6Subnet     string `yaml:"ipv6_subnet,omitempty" json:"ipv6_subnet,omitempty"`
+	IPv6Gw         string `yaml:"ipv6-gw,omitempty" json:"ipv6-gw,omitempty"`
+	MTU            string `yaml:"mtu,omitempty" json:"mtu,omitempty"`
+	ExternalAccess *bool  `yaml:"external-access,omitempty" json:"external-access,omitempty"`
 }
 
 // NodeConfig is a struct that contains the information of a container element

--- a/types/types.go
+++ b/types/types.go
@@ -66,19 +66,19 @@ type NodeConfig struct {
 	StartupDelay         uint              `json:"startup-delay,omitempty"`           // optional delay (in seconds) to wait before creating this node
 	EnforceStartupConfig bool              `json:"enforce-startup-config,omitempty"`  // when set to true will enforce the use of startup-config, even when config is present in the lab directory
 	ResStartupConfig     string            `json:"startup-config-abs-path,omitempty"` // path to config file that is actually mounted to the container and is a result of templation
-	Config               *ConfigDispatcher `json:"-"`                                 // Do not marshal into JSON - internals
-	ResConfig            string            `json:"config-abs-path,omitempty"`         // path to config file that is actually mounted to the container and is a result of templation
+	Config               *ConfigDispatcher `json:"config,omitempty"`
+	ResConfig            string            `json:"config-abs-path,omitempty"` // path to config file that is actually mounted to the container and is a result of templation
 	NodeType             string            `json:"type,omitempty"`
 	Position             string            `json:"position,omitempty"`
 	License              string            `json:"license,omitempty"`
 	Image                string            `json:"image,omitempty"`
-	Sysctls              map[string]string `json:"-"` // Do not marshal into JSON - internals
+	Sysctls              map[string]string `json:"sysctls,omitempty"`
 	User                 string            `json:"user,omitempty"`
 	Entrypoint           string            `json:"entrypoint,omitempty"`
 	Cmd                  string            `json:"cmd,omitempty"`
-	Exec                 []string          `json:"-"`                      // Do not marshal into JSON - potentially high volume of low value data
-	Env                  map[string]string `json:"-"`                      // Do not marshal into JSON - potentially highly sensitive data like passwords
-	Binds                []string          `json:"-"`                      // Bind mounts strings (src:dest:options). Do not marshal into JSON - potentially sensitive data
+	Exec                 []string          `json:"exec,omitempty"`
+	Env                  map[string]string `json:"env,omitempty"`
+	Binds                []string          `json:"binds,omitempty"`        // Bind mounts strings (src:dest:options).
 	PortBindings         nat.PortMap       `json:"portbindings,omitempty"` // PortBindings define the bindings between the container ports and host ports
 	PortSet              nat.PortSet       `json:"portset,omitempty"`      // PortSet define the ports that should be exposed on a container
 	NetworkMode          string            `json:"networkmode,omitempty"`  // container networking mode. if set to `host` the host networking will be used for this node, else bridged network
@@ -90,16 +90,17 @@ type NodeConfig struct {
 	MgmtIPv6PrefixLength int               `json:"mgmtipv6prefixLength,omitempty"`
 	MacAddress           string            `json:"macaddress,omitempty"`
 	ContainerID          string            `json:"containerid,omitempty"`
-	TLSCert              string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
-	TLSKey               string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
-	TLSAnchor            string            `json:"-"`                 // Do not marshal into JSON - highly sensitive data
-	NSPath               string            `json:"nspath,omitempty"`  // network namespace path for this node
-	Publish              []string          `json:"publish,omitempty"` // list of ports to publish with mysocketctl
-	ExtraHosts           []string          `json:"-"`                 // Extra /etc/hosts entries for all nodes. Do not marshal – redundant information
-	Labels               map[string]string `json:"labels,omitempty"`  // container labels
-	Endpoints            []Endpoint        `json:"-"`                 // Slice of pointers to local endpoints, do not marshal into JSON as it creates cyclical error
+	TLSCert              string            `json:"tls-cert,omitempty"`
+	TLSKey               string            `json:"-"` // Do not marshal into JSON - highly sensitive data
+	TLSAnchor            string            `json:"tls-anchor,omitempty"`
+	NSPath               string            `json:"nspath,omitempty"`      // network namespace path for this node
+	Publish              []string          `json:"publish,omitempty"`     // list of ports to publish with mysocketctl
+	ExtraHosts           []string          `json:"extra-hosts,omitempty"` // Extra /etc/hosts entries for all nodes.
+	Labels               map[string]string `json:"labels,omitempty"`      // container labels
+	Endpoints            []Endpoint        `json:"-"`                     // Slice of pointers to local endpoints, DO NOT marshal into JSON as it creates a cyclical error
 	// Ignite sandbox and kernel imageNames
-	Sandbox, Kernel string `json:"-"` // Do not marshal into JSON - internals
+	Sandbox string `json:"sandbox,omitempty"`
+	Kernel  string `json:"kernel,omitempty"`
 	// Configured container runtime
 	Runtime string `json:"runtime,omitempty"`
 	// Resource requirements
@@ -107,10 +108,10 @@ type NodeConfig struct {
 	CPUSet string  `json:"cpuset,omitempty"`
 	Memory string  `json:"memory,omitempty"`
 
-	DeploymentStatus string `json:"deploymentstatus,omitempty"` // status that is set by containerlab to indicate deployment stage
+	DeploymentStatus string `json:"deployment-status,omitempty"` // status that is set by containerlab to indicate deployment stage
 
 	// Extras
-	Extras *Extras `json:"-"` // Extra node parameters, do not marshal into JSON as they are kind-specific
+	Extras *Extras `json:"extras,omitempty"` // Extra node parameters
 }
 
 // GenerateConfig generates configuration for the nodes

--- a/types/types.go
+++ b/types/types.go
@@ -82,13 +82,13 @@ type NodeConfig struct {
 	PortBindings         nat.PortMap       `json:"portbindings,omitempty"` // PortBindings define the bindings between the container ports and host ports
 	PortSet              nat.PortSet       `json:"portset,omitempty"`      // PortSet define the ports that should be exposed on a container
 	NetworkMode          string            `json:"networkmode,omitempty"`  // container networking mode. if set to `host` the host networking will be used for this node, else bridged network
-	MgmtNet              string            `json:"mgmtnet,omitempty"`      // name of the docker network this node is connected to with its first interface
-	MgmtIntf             string            `json:"mgmtintf,omitempty"`     // can be used to be rendered by the default node template
-	MgmtIPv4Address      string            `json:"mgmtipv4address,omitempty"`
-	MgmtIPv4PrefixLength int               `json:"mgmtipv4prefixLength,omitempty"`
-	MgmtIPv6Address      string            `json:"mgmtipv6address,omitempty"`
-	MgmtIPv6PrefixLength int               `json:"mgmtipv6prefixLength,omitempty"`
-	MacAddress           string            `json:"macaddress,omitempty"`
+	MgmtNet              string            `json:"mgmt-net,omitempty"`     // name of the docker network this node is connected to with its first interface
+	MgmtIntf             string            `json:"mgmt-intf,omitempty"`    // can be used to be rendered by the default node template
+	MgmtIPv4Address      string            `json:"mgmt-ipv4-address,omitempty"`
+	MgmtIPv4PrefixLength int               `json:"mgmt-ipv4-prefix-length,omitempty"`
+	MgmtIPv6Address      string            `json:"mgmt-ipv6-address,omitempty"`
+	MgmtIPv6PrefixLength int               `json:"mgmt-ipv6-prefix-length,omitempty"`
+	MacAddress           string            `json:"mac-address,omitempty"`
 	ContainerID          string            `json:"containerid,omitempty"`
 	TLSCert              string            `json:"tls-cert,omitempty"`
 	TLSKey               string            `json:"-"` // Do not marshal into JSON - highly sensitive data

--- a/types/types.go
+++ b/types/types.go
@@ -45,9 +45,9 @@ type Endpoint struct {
 type MgmtNet struct {
 	Network        string `yaml:"network,omitempty" json:"network,omitempty"` // container runtime network name
 	Bridge         string `yaml:"bridge,omitempty" json:"bridge,omitempty"`   // linux bridge backing the runtime network
-	IPv4Subnet     string `yaml:"ipv4_subnet,omitempty" json:"ipv4_subnet,omitempty"`
+	IPv4Subnet     string `yaml:"ipv4_subnet,omitempty" json:"ipv4-subnet,omitempty"`
 	IPv4Gw         string `yaml:"ipv4-gw,omitempty" json:"ipv4-gw,omitempty"`
-	IPv6Subnet     string `yaml:"ipv6_subnet,omitempty" json:"ipv6_subnet,omitempty"`
+	IPv6Subnet     string `yaml:"ipv6_subnet,omitempty" json:"ipv6-subnet,omitempty"`
 	IPv6Gw         string `yaml:"ipv6-gw,omitempty" json:"ipv6-gw,omitempty"`
 	MTU            string `yaml:"mtu,omitempty" json:"mtu,omitempty"`
 	ExternalAccess *bool  `yaml:"external-access,omitempty" json:"external-access,omitempty"`
@@ -62,13 +62,13 @@ type NodeConfig struct {
 	Index                int               `json:"index,omitempty"`
 	Group                string            `json:"group,omitempty"`
 	Kind                 string            `json:"kind,omitempty"`
-	StartupConfig        string            `json:"startupconfig,omitempty"`        // path to config template file that is used for startup config generation
-	StartupDelay         uint              `json:"startupdelay,omitempty"`         // optional delay (in seconds) to wait before creating this node
-	EnforceStartupConfig bool              `json:"enforcestartupconfig,omitempty"` // when set to true will enforce the use of startup-config, even when config is present in the lab directory
-	ResStartupConfig     string            `json:"resstartupconfig,omitempty"`     // path to config file that is actually mounted to the container and is a result of templation
-	Config               *ConfigDispatcher `json:"-"`                              // Do not marshal into JSON - internals
-	ResConfig            string            `json:"resconfig,omitempty"`            // path to config file that is actually mounted to the container and is a result of templation
-	NodeType             string            `json:"nodetype,omitempty"`
+	StartupConfig        string            `json:"startup-config,omitempty"`          // path to config template file that is used for startup config generation
+	StartupDelay         uint              `json:"startup-delay,omitempty"`           // optional delay (in seconds) to wait before creating this node
+	EnforceStartupConfig bool              `json:"enforce-startup-config,omitempty"`  // when set to true will enforce the use of startup-config, even when config is present in the lab directory
+	ResStartupConfig     string            `json:"startup-config-abs-path,omitempty"` // path to config file that is actually mounted to the container and is a result of templation
+	Config               *ConfigDispatcher `json:"-"`                                 // Do not marshal into JSON - internals
+	ResConfig            string            `json:"config-abs-path,omitempty"`         // path to config file that is actually mounted to the container and is a result of templation
+	NodeType             string            `json:"type,omitempty"`
 	Position             string            `json:"position,omitempty"`
 	License              string            `json:"license,omitempty"`
 	Image                string            `json:"image,omitempty"`


### PR DESCRIPTION
Similar to how clab creates `ansible-inventory.yml` file under the lab directory, this PR enables clab to export its internal knowledge of the running topology into `topology-data.json` file. It makes it possible for 3rd party software to leverage the data programmatically. One of the first applications is adding WebSSH capabilities to Graphite topology visualization tool. Automatic export of the clab data enables WebSSH connections to nodes in the topology using their dynamically assigned management IP addresses.

As part of the PR, a new special variable `__clabDir__` was added to `bind` section of a node definition yaml. It enables direct mounting of any file in the lab directory to a node in the topology without a need to refer to a topology name, and can be used to mount `topology-data.json` as well as `ansible-inventory.yml` the following way:

```yaml
    name: mylab
    topology:
      nodes:
        ansible:
          binds:
            - __clabDir__/ansible-inventory.yml:/ansible-inventory.yml:ro
        graphite:
          binds:
            - __clabDir__/topology-data.json::/var/www/localhost/htdocs/clab/topology-data.json:ro
````

High level structure on `topology-data.json` is:

```json
{
  "name": "<topology name>",
  "type": "clab",
  "clabconfig": {"<top-level information about the lab, like management network details>"},
  "nodes": {"<detailed information about every node in the topology, including dynamic information like management IP addresses>"},
  "links": ["<entries for every link between nopology nodes, including interface names and allocated MAC addresses>"]
}
````

To avoid exporting sensitive information about nodes, like TLS private keys, `type NodeConfig struct` in `types/types.go` was updated with json export tags, preventing some of the keys to be marshaled into JSON.

Finally, a special note on `links: []` section of the `topology-data.json`. The format of entries in the array is the following:

```json
        {
          "a": {
            "node": "<...A.Node.ShortName>",
            "interface": "<...A.EndpointName>",
            "mac": "<...A.MAC>"
            "peer": "z"
          },
          "z": {
            "node": "<...B.Node.ShortName>",
            "interface": "<...B.EndpointName>",
            "mac": "<...B.MAC>"
            "peer": "a"
          }
        }
````

Such format helps navigating graph data programmatically, as key names for both side of each link have identical names. This enables queries like this:

```Shell
cat clab-clos-3tier/topology-data.json | jq ".links[0,1][].node"
"node1-1"
"node2-1"
"node1-2"
"node2-1"

cat clab-clos-3tier/topology-data.json | jq ".links[0,1][].mac"
"aa:c1:ab:8e:6b:5a"
"aa:c1:ab:7f:23:6a"
"aa:c1:ab:f9:18:71"
"aa:c1:ab:74:6b:d5"
````

Also, use of a key `.peer` adds future capabilities to include more than two entries in the definition of each link, accounting for intermediate connection points like patch panels, TAPs and so on. This might not necessarily be applicable to containerlab, but has value in representing topology in systems like NSoT. The goal here is to use a flexible schema that can be re-used in multiple software projects.