### PR TITLE
runtime mtu detection for docker

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,7 +107,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        runtime: ["docker", "containerd", "podman"]
+        runtime:
+          - "docker"
+          - "podman"
+        # - "containerd"
     needs:
       - unit-test
       - build-containerlab
@@ -195,7 +198,7 @@ jobs:
       matrix:
         runtime:
           - "docker"
-          # - "containerd"
+          - "podman"
     needs:
       - unit-test
       - build-containerlab

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -212,6 +212,10 @@ jobs:
           name: containerlab
       - name: Move containerlab to usr/bin
         run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+
+      - name: Enable Podman API service
+        run: sudo systemctl start podman
+
       - uses: actions/setup-python@v2
         with:
           python-version: "3.8"

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -18,7 +18,6 @@ import (
 	"github.com/srl-labs/containerlab/runtime"
 	_ "github.com/srl-labs/containerlab/runtime/all"
 	"github.com/srl-labs/containerlab/types"
-	"github.com/srl-labs/containerlab/utils"
 )
 
 type CLab struct {
@@ -152,15 +151,6 @@ func (c *CLab) initMgmtNetwork() error {
 	if c.Config.Mgmt.ExternalAccess == nil {
 		c.Config.Mgmt.ExternalAccess = new(bool)
 		*c.Config.Mgmt.ExternalAccess = true
-	}
-
-	// init docker network mtu
-	if c.Config.Mgmt.MTU == "" {
-		m, err := utils.DefaultNetMTU()
-		if err != nil {
-			log.Warnf("Error occurred during getting the default docker MTU: %v", err)
-		}
-		c.Config.Mgmt.MTU = m
 	}
 
 	log.Debugf("New mgmt params are %+v", c.Config.Mgmt)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -287,7 +287,7 @@ func setFlags(conf *clab.Config) {
 
 func enrichNodes(containers []types.GenericContainer, nodesMap map[string]nodes.Node) {
 	for i := range containers {
-		c := &containers[i]
+		c := containers[i]
 
 		name = c.Labels[clab.NodeNameLabel]
 		if node, ok := nodesMap[name]; ok {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -241,12 +241,14 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// exec commands specified for containers with `exec` parameter
 	execJSONResult := make(map[string]map[string]map[string]interface{})
-	for _, cont := range containers {
+	for i := range containers {
+		cont := &containers[i]
+
 		name := cont.Labels[clab.NodeNameLabel]
 		if node, ok := c.Nodes[name]; ok && (len(node.Config().Exec) > 0) {
 			rt := node.GetRuntime()
 			contName := strings.TrimLeft(cont.Names[0], "/")
-			if execJSONResult[contName], err = execCmds(ctx, cont, rt, node.Config().Exec, format); err != nil {
+			if execJSONResult[contName], err = execCmds(ctx, *cont, rt, node.Config().Exec, format); err != nil {
 				log.Errorf("Failed to exec commands for node %s", name)
 			}
 		}
@@ -284,7 +286,9 @@ func setFlags(conf *clab.Config) {
 }
 
 func enrichNodes(containers []types.GenericContainer, nodesMap map[string]nodes.Node) {
-	for _, c := range containers {
+	for i := range containers {
+		c := &containers[i]
+
 		name = c.Labels[clab.NodeNameLabel]
 		if node, ok := nodesMap[name]; ok {
 			// add network information

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -242,13 +242,13 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	// exec commands specified for containers with `exec` parameter
 	execJSONResult := make(map[string]map[string]map[string]interface{})
 	for i := range containers {
-		cont := &containers[i]
+		cont := containers[i]
 
 		name := cont.Labels[clab.NodeNameLabel]
 		if node, ok := c.Nodes[name]; ok && (len(node.Config().Exec) > 0) {
 			rt := node.GetRuntime()
 			contName := strings.TrimLeft(cont.Names[0], "/")
-			if execJSONResult[contName], err = execCmds(ctx, *cont, rt, node.Config().Exec, format); err != nil {
+			if execJSONResult[contName], err = execCmds(ctx, cont, rt, node.Config().Exec, format); err != nil {
 				log.Errorf("Failed to exec commands for node %s", name)
 			}
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -70,7 +70,6 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
-		clab.WithTopoFile(topo, varsFile),
 		clab.WithRuntime(rt,
 			&runtime.RuntimeConfig{
 				Debug:            debug,
@@ -78,6 +77,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 				GracefulShutdown: graceful,
 			},
 		),
+		clab.WithTopoFile(topo, varsFile),
 	}
 	c, err := clab.NewContainerLab(opts...)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -287,7 +287,7 @@ func setFlags(conf *clab.Config) {
 
 func enrichNodes(containers []types.GenericContainer, nodesMap map[string]nodes.Node) {
 	for i := range containers {
-		c := containers[i]
+		c := &containers[i]
 
 		name = c.Labels[clab.NodeNameLabel]
 		if node, ok := nodesMap[name]; ok {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -39,6 +39,8 @@ const (
 	sysctlBase     = "/proc/sys"
 	defaultTimeout = 30 * time.Second
 	rLimitMaxValue = 1048576
+	// defaultDockerNetwork is a name of a docker network that docker uses by default when creating containers
+	defaultDockerNetwork = "bridge"
 )
 
 func init() {
@@ -88,6 +90,23 @@ func (d *DockerRuntime) WithConfig(cfg *runtime.RuntimeConfig) {
 
 func (d *DockerRuntime) WithMgmtNet(n *types.MgmtNet) {
 	d.mgmt = n
+	// return if MTU value was set by a user via config file
+	if n.MTU != "" {
+		return
+	}
+
+	// detect default MTU if this config parameter was not provided in the clab file
+	d0, err := d.Client.NetworkInspect(context.TODO(), defaultDockerNetwork, dockerTypes.NetworkInspectOptions{})
+	if err != nil {
+		d.mgmt.MTU = "1500"
+		log.Debugf("an error occured when trying to detect docker default network mtu")
+	}
+
+	if mtu, ok := d0.Options["com.docker.network.driver.mtu"]; ok {
+		log.Debugf("detected docker network mtu value - %s", mtu)
+		d.mgmt.MTU = mtu
+	}
+
 }
 
 // CreateDockerNet creates a docker network or reusing if it exists

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -22,7 +22,7 @@ Create SSH keypair
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E containerlab deploy -t ${CURDIR}/${lab-file-name}
+    ...    sudo -E containerlab --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -80,4 +80,4 @@ Ensure srl1 is reachable over ssh with public key auth
 
 *** Keywords ***
 Cleanup
-    Run    sudo containerlab destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/utils/netlink.go
+++ b/utils/netlink.go
@@ -41,16 +41,6 @@ func LinkContainerNS(nspath, containerName string) error {
 	return nil
 }
 
-// getDefaultDockerMTU gets the MTU of a docker0 bridge interface
-// if fails to get the MTU of docker0, returns "1500"
-func DefaultNetMTU() (string, error) {
-	b, err := BridgeByName("docker0")
-	if err != nil {
-		return "1500", err
-	}
-	return fmt.Sprint(b.MTU), nil
-}
-
 func CheckBrInUse(brname string) (bool, error) {
 	InUse := false
 	l, err := netlink.LinkList()


### PR DESCRIPTION
instead of relying on mtu set for `docker0` linux interface, we use runtime specific inspection functions

the problem with docker0 mtu (apart from being docker specific) is that it reports 1500 mtu when no containers are attached to the default `bridge` network, thus hiding daemon config option 