### PR TITLE
Pause / Unpause Containers

### DIFF
--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -353,8 +353,7 @@ func (c *ContainerdRuntime) StartContainer(ctx context.Context, _ string, node *
 func (c *ContainerdRuntime) PauseContainer(ctx context.Context, cID string) error {
 	ctask, err := c.getContainerTask(ctx, cID)
 	if err != nil {
-		log.Debugf("container %s: %v", cID, err)
-		return nil
+		return err
 	}
 
 	err = ctask.Pause(ctx)
@@ -364,8 +363,7 @@ func (c *ContainerdRuntime) PauseContainer(ctx context.Context, cID string) erro
 func (c *ContainerdRuntime) UnpauseContainer(ctx context.Context, cID string) error {
 	ctask, err := c.getContainerTask(ctx, cID)
 	if err != nil {
-		log.Debugf("container %s: %v", cID, err)
-		return nil
+		return err
 	}
 
 	err = ctask.Resume(ctx)
@@ -462,8 +460,7 @@ func WithSysctls(sysctls map[string]string) oci.SpecOpts {
 func (c *ContainerdRuntime) StopContainer(ctx context.Context, containername string) error {
 	ctask, err := c.getContainerTask(ctx, containername)
 	if err != nil {
-		log.Debugf("container %s: %v", containername, err)
-		return nil
+		return err
 	}
 	taskstatus, err := ctask.Status(ctx)
 	if err != nil {

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -350,6 +350,28 @@ func (c *ContainerdRuntime) StartContainer(ctx context.Context, _ string, node *
 	return nil, nil
 }
 
+func (c *ContainerdRuntime) PauseContainer(ctx context.Context, cID string) error {
+	ctask, err := c.getContainerTask(ctx, cID)
+	if err != nil {
+		log.Debugf("container %s: %v", cID, err)
+		return nil
+	}
+
+	err = ctask.Pause(ctx)
+	return err
+}
+
+func (c *ContainerdRuntime) UnpauseContainer(ctx context.Context, cID string) error {
+	ctask, err := c.getContainerTask(ctx, cID)
+	if err != nil {
+		log.Debugf("container %s: %v", cID, err)
+		return nil
+	}
+
+	err = ctask.Resume(ctx)
+	return err
+}
+
 func cniInit(cId, ifName string, mgmtNet *types.MgmtNet) (*libcni.CNIConfig, *libcni.NetworkConfigList, *libcni.RuntimeConf, error) {
 	// allow overwriting cni plugin binary path via ENV var
 

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -285,6 +285,16 @@ func (d *DockerRuntime) DeleteNet(ctx context.Context) (err error) {
 	return nil
 }
 
+// PauseContainer Pauses a container identified by its name
+func (d *DockerRuntime) PauseContainer(ctx context.Context, cID string) error {
+	return d.Client.ContainerPause(ctx, cID)
+}
+
+// UnpauseContainer UnPauses / resumes a container identified by its name
+func (d *DockerRuntime) UnpauseContainer(ctx context.Context, cID string) error {
+	return d.Client.ContainerUnpause(ctx, cID)
+}
+
 // CreateContainer creates a docker container (but does not start it)
 func (d *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeConfig) (string, error) {
 	log.Infof("Creating container: %q", node.ShortName)

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -261,12 +261,31 @@ func (c *IgniteRuntime) StartContainer(ctx context.Context, _ string, node *type
 	if err != nil {
 		return nil, err
 	}
+
 	return vmChans, utils.LinkContainerNS(node.NSPath, node.LongName)
 }
 
-func (*IgniteRuntime) CreateContainer(_ context.Context, _ *types.NodeConfig) (string, error) {
+func (*IgniteRuntime) CreateContainer(_ context.Context, node *types.NodeConfig) (string, error) {
 	// this is a no-op
-	return "", nil
+	return node.LongName, nil
+}
+
+func (i *IgniteRuntime) PauseContainer(_ context.Context, cID string) error {
+	pid, err := utils.ContainerNSToPID(cID)
+	if err != nil {
+		return err
+	}
+
+	return utils.PauseProcessGroup(pid)
+}
+
+func (i *IgniteRuntime) UnpauseContainer(_ context.Context, cID string) error {
+	pid, err := utils.ContainerNSToPID(cID)
+	if err != nil {
+		return err
+	}
+
+	return utils.UnpauseProcessGroup(pid)
 }
 
 func (*IgniteRuntime) StopContainer(_ context.Context, _ string) error {

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -177,6 +177,22 @@ func (r *PodmanRuntime) StartContainer(ctx context.Context, cID string, cfg *typ
 	return nil, nil
 }
 
+func (r *PodmanRuntime) PauseContainer(ctx context.Context, cID string) error {
+	ctx, err := r.connect(ctx)
+	if err != nil {
+		return err
+	}
+	return containers.Pause(ctx, cID, &containers.PauseOptions{})
+}
+
+func (r *PodmanRuntime) UnpauseContainer(ctx context.Context, cID string) error {
+	ctx, err := r.connect(ctx)
+	if err != nil {
+		return err
+	}
+	return containers.Unpause(ctx, cID, &containers.UnpauseOptions{})
+}
+
 func (r *PodmanRuntime) StopContainer(ctx context.Context, cID string) error {
 	ctx, err := r.connect(ctx)
 	if err != nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -40,6 +40,10 @@ type ContainerRuntime interface {
 	StartContainer(context.Context, string, *types.NodeConfig) (interface{}, error)
 	// Stop running container by its name
 	StopContainer(context.Context, string) error
+	// Pause a container identified by its name
+	PauseContainer(context.Context, string) error
+	// UnPause / resume a container identified by its name
+	UnpauseContainer(context.Context, string) error
 	// List all containers matching labels
 	ListContainers(context.Context, []*types.GenericFilter) ([]types.GenericContainer, error)
 	// Get a netns path using the pid of a container

--- a/utils/containers.go
+++ b/utils/containers.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -49,4 +52,22 @@ func GetCNIBinaryPath() string {
 		cniPath = cniBin
 	}
 	return cniPath
+}
+
+// ContainerNSToPID resolves the name of a container via
+// the "/run/netns/<CONTAINERNAME>" to its PID
+func ContainerNSToPID(cID string) (int, error) {
+	pnns, err := filepath.EvalSymlinks("/run/netns/" + cID)
+	if err != nil {
+		return 0, err
+	}
+	pathElem := strings.Split(pnns, "/")
+	if len(pathElem) != 4 {
+		return 0, fmt.Errorf("unexpected result looking up container PID")
+	}
+	pid, err := strconv.Atoi(pathElem[1])
+	if err != nil {
+		return 0, fmt.Errorf("error converting the string part of the namespace link to int")
+	}
+	return pid, nil
 }

--- a/utils/netlink.go
+++ b/utils/netlink.go
@@ -8,9 +8,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -42,24 +39,6 @@ func LinkContainerNS(nspath, containerName string) error {
 		return err
 	}
 	return nil
-}
-
-// ContainerNSToPID resolves the name of a container via
-// the "/run/netns/<CONTAINERNAME>" to its PID
-func ContainerNSToPID(cID string) (int, error) {
-	pnns, err := filepath.EvalSymlinks("/run/netns/" + cID)
-	if err != nil {
-		return 0, err
-	}
-	pathElem := strings.Split(pnns, "/")
-	if len(pathElem) != 4 {
-		return 0, fmt.Errorf("unexpected result looking up container PID")
-	}
-	pid, err := strconv.Atoi(pathElem[1])
-	if err != nil {
-		return 0, fmt.Errorf("error converting the string part of the namespace link to int")
-	}
-	return pid, nil
 }
 
 // getDefaultDockerMTU gets the MTU of a docker0 bridge interface

--- a/utils/netlink.go
+++ b/utils/netlink.go
@@ -8,6 +8,9 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -39,6 +42,24 @@ func LinkContainerNS(nspath, containerName string) error {
 		return err
 	}
 	return nil
+}
+
+// ContainerNSToPID resolves the name of a container via
+// the "/run/netns/<CONTAINERNAME>" to its PID
+func ContainerNSToPID(cID string) (int, error) {
+	pnns, err := filepath.EvalSymlinks("/run/netns/" + cID)
+	if err != nil {
+		return 0, err
+	}
+	pathElem := strings.Split(pnns, "/")
+	if len(pathElem) != 4 {
+		return 0, fmt.Errorf("unexpected result looking up container PID")
+	}
+	pid, err := strconv.Atoi(pathElem[1])
+	if err != nil {
+		return 0, fmt.Errorf("error converting the string part of the namespace link to int")
+	}
+	return pid, nil
 }
 
 // getDefaultDockerMTU gets the MTU of a docker0 bridge interface

--- a/utils/process.go
+++ b/utils/process.go
@@ -1,0 +1,17 @@
+package utils
+
+import "syscall"
+
+// PauseProcessGroup sends the SIGSTOP signal to a process group, causing all
+// the processes within the group to be Paused e.g. SRL runs multilpe processes, if the
+// container is meant to be stopped, all the related processes must be paused.
+// To me it seams like the ProcessGroupID is set correctly so we can count on that field.
+// The syscall.Kill interpretes negative ints as a PGID and not as a common PID.
+func PauseProcessGroup(pgid int) error {
+	return syscall.Kill(-pgid, syscall.SIGSTOP)
+}
+
+// UnpauseProcessGroup send the SIGCONT to the given ProcessGroup identified by its ID
+func UnpauseProcessGroup(pgid int) error {
+	return syscall.Kill(-pgid, syscall.SIGCONT)
+}


### PR DESCRIPTION
fix #772

The runtime Interface is extended with the following methods:
```golang
// Pause a container identified by its name
PauseContainer(context.Context, string) error
// UnPause / resume a container identified by its name
UnpauseContainer(context.Context, string) error
```
Docker, Podman & containerd do provide Pause and Unpause/Resume calls. So they are used.

Ignite however does not provide this functionality. Hence the implementation uses SIGSTOP and SIGCONT calls on the PGID (ProcessGroupID).

Code is just sparsely tested, and needs wiring up with the higher level functionality mentioned in #772.