### PR TITLE
check for nil in produceGenericContainerList

### DIFF
--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -365,7 +365,7 @@ func (*IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]types.Gene
 			NetworkSettings: types.GenericMgmtIPs{},
 		}
 
-		if i.Status.Runtime.ID != "" && len(i.Status.Runtime.ID) > 12 {
+		if i.Status.Runtime != nil && i.Status.Runtime.ID != "" && len(i.Status.Runtime.ID) > 12 {
 			ctr.ShortID = i.Status.Runtime.ID[:12]
 		}
 


### PR DESCRIPTION
fixes following seg violation:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x291547e]

goroutine 1 [running]:
github.com/srl-labs/containerlab/runtime/ignite.(*IgniteRuntime).produceGenericContainerList(0xc000180e60, {0xc0006a2b68, 0x1, 0xc000869318?})
        /home/iz00848/git/srl-labs/containerlab/runtime/ignite/ignite.go:368 +0x1de
github.com/srl-labs/containerlab/runtime/ignite.(*IgniteRuntime).ListContainers(0xc0008694c0?, {0xc000670000?, 0xc0005bcba0?}, {0x0, 0x0, 0x0?})
        /home/iz00848/git/srl-labs/containerlab/runtime/ignite/ignite.go:313 +0x5bc
github.com/srl-labs/containerlab/clab.(*CLab).ListContainers(0x354d580?, {0x354d5f0, 0xc0005bcba0}, {0x0, 0x0, 0x0})
        /home/iz00848/git/srl-labs/containerlab/clab/clab.go:393 +0x139

```