### PR TITLE
added push to ghcr in addition to ttl.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,14 @@ htmltest:
 	docker run --rm -v $$(pwd):/test wjdp/htmltest --conf ./site/htmltest-w-github.yml
 	rm -rf ./site
 
-# build containerlab bin and push it as an OCI artifact to ttl.sh registry
+# build containerlab bin and push it as an OCI artifact to ttl.sh and ghcr registries
 # to obtain the pushed artifact use: docker run --rm -v $(pwd):/workspace ghcr.io/deislabs/oras:v0.11.1 pull ttl.sh/<image-name>
 .PHONY: ttl-push
-ttl-push: build-with-podman
+oci-push: build-with-podman
+# push to ttl.sh
 	docker run --rm -v $$(pwd)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/clab-$$(git rev-parse --short HEAD):1d ./containerlab
 	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/clab-$$(git rev-parse --short HEAD):1d"
+# push to ghcr.io
+	@echo ""
+	docker run --rm -v $$(pwd)/bin:/workspace -v $${HOME}/.docker/config.json:/root/.docker/config.json ghcr.io/oras-project/oras:v0.12.0 push ghcr.io/srl-labs/clab-oci:$$(git rev-parse --short HEAD) ./containerlab
+	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ghcr.io/srl-labs/clab-oci:$$(git rev-parse --short HEAD)"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ htmltest:
 # to obtain the pushed artifact use: docker run --rm -v $(pwd):/workspace ghcr.io/deislabs/oras:v0.11.1 pull ttl.sh/<image-name>
 .PHONY: ttl-push
 oci-push: build-with-podman
+	@echo
+	@echo "With the following pull command you get a containerlab binary at your working directory. To use this downloaded binary - ./containerlab deploy.... Make sure not forget to add ./ prefix in order to use the downloaded binary and not the globally installed containerlab!"
+	@echo 'If https proxy is configured in your environment, pass the proxies via --env HTTPS_PROXY="<proxy-address>" flag of the docker run command.'
 # push to ttl.sh
 	docker run --rm -v $$(pwd)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/clab-$$(git rev-parse --short HEAD):1d ./containerlab
 	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/clab-$$(git rev-parse --short HEAD):1d"


### PR DESCRIPTION
non srl-labs users are able to push temp builds to ttl.sh
team member will additionally push to ghcr.io for longevity of temp builds