### PR TITLE
feat: add support to copy startup-config

### DIFF
--- a/docs/manual/kinds/vr-vqfx.md
+++ b/docs/manual/kinds/vr-vqfx.md
@@ -43,5 +43,20 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ### Node configuration
 vr-vqfx nodes come up with a basic configuration where only the control plane and line cards are provisioned, as well as the `admin` user with the provided password.
 
+#### Startup configuration
+It is possible to make vQFX nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-vqfx
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.
+
 ## Lab examples
 Coming soon.

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -118,7 +118,8 @@ func createVrvQFXFiles(node *types.NodeConfig) error {
 	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
 
 	if node.StartupConfig != "" {
-		cfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
+		// dstCfg is a path to a file on the clab host that will have rendered configuration
+		dstCfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
 
 		c, err := os.ReadFile(node.StartupConfig)
 		if err != nil {
@@ -127,7 +128,7 @@ func createVrvQFXFiles(node *types.NodeConfig) error {
 
 		cfgTemplate := string(c)
 
-		err = node.GenerateConfig(cfg, cfgTemplate)
+		err = node.GenerateConfig(dstCfg, cfgTemplate)
 		if err != nil {
 			log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
 		}

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -20,6 +20,8 @@ import (
 
 const (
 	scrapliPlatformName = "juniper_junos"
+	configDirName       = "config"
+	startupCfgFName     = "startup-config.cfg"
 )
 
 func init() {
@@ -49,7 +51,7 @@ func (s *vrVQFX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	s.cfg.Env = utils.MergeStringMaps(defEnv, s.cfg.Env)
 
-	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, "startup-config"), ":/startup-config"))
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, configDirName), ":/config"))
 
 	if s.cfg.Env["CONNECTION_MODE"] == "macvtap" {
 		// mount dev dir to enable macvtap
@@ -113,10 +115,10 @@ func (s *vrVQFX) SaveConfig(_ context.Context) error {
 
 func createVrvQFXFiles(node *types.NodeConfig) error {
 	// create config directory that will be bind mounted to vrnetlab container at / path
-	utils.CreateDirectory(path.Join(node.LabDir, "startup-config"), 0777)
+	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
 
 	if node.StartupConfig != "" {
-		cfg := filepath.Join(node.LabDir, "startup-config", "config.txt")
+		cfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
 
 		c, err := os.ReadFile(node.StartupConfig)
 		if err != nil {


### PR DESCRIPTION
Adds in the required clab support to do the bits in https://github.com/hellt/vrnetlab/pull/78. Basically we just pull in the startup config directive, copy it to the lab directory, and then bind mount it into the container. vrnetlab does the rest from a config load standpoint.