### PR TITLE
detect container env and set virt rerquirements per kind

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -608,25 +608,54 @@ func (c *CLab) verifyRootNetnsInterfaceUniqueness() error {
 	return nil
 }
 
-// verifyVirtSupport checks if virtualization supported by vcpu if vrnetlab nodes are used
+// verifyVirtSupport checks if virtualization is supported by a cpu in case topology contains VM-based nodes
+// when clab itself is being invoked as a container, this check is bypassed
 func (c *CLab) verifyVirtSupport() error {
-	virtNeeded := false
+	// check if we are being executed in a container environment
+	// in that case we skip this check as there are no convenient ways to interrogate hosts capabilities
+	// check if /proc/2 exists, and if it does, check if the name of the proc is kthreadd
+	// otherwise it is a container env
+
+	f, err := os.Open("/proc/2/status")
+	if err != nil {
+		log.Debugf("proc/2/status file was not found. This means we run in a container and no virt checks are possible")
+		return nil
+	}
+
+	defer f.Close()
+
+	// read first line of a /proc/2/status file to check if it contains kthreadd
+	// if it doesn't, we are in a container
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		if !strings.Contains(scanner.Text(), "kthreadd") {
+			log.Debugf("proc/2/status first line doesn't contain kthreadd. This means we run in a container and no virt checks are possible")
+			return nil
+		}
+
+		break
+	}
+
+	virtRequired := false
 	for _, n := range c.Nodes {
-		if strings.HasPrefix(n.Config().Kind, "vr-") {
-			virtNeeded = true
+		if n.Config().HostRequirements.VirtRequired {
+			virtRequired = true
 			break
 		}
 	}
-	if !virtNeeded {
+
+	if !virtRequired {
 		return nil
 	}
-	f, err := os.Open("/proc/cpuinfo")
+
+	f, err = os.Open("/proc/cpuinfo")
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
+	scanner = bufio.NewScanner(f)
 
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), "vmx") || strings.Contains(scanner.Text(), "svm") {
@@ -638,7 +667,7 @@ func (c *CLab) verifyVirtSupport() error {
 		return err
 	}
 
-	return fmt.Errorf("virtualization seems to be not supported and it is required for VM based nodes. Check if virtualization can be enabled")
+	return fmt.Errorf("virtualization seems to be not supported and it is required for VM-based nodes.\nEnable virtualization or, in case you're using a VM, make sure virtualization flags are propagated to a guest")
 }
 
 // checkIfSignatures ensures that users provide valid endpoint names

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -58,13 +58,20 @@ func (s *IPInfusionOcNOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) 
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
+
 func (s *IPInfusionOcNOS) Config() *types.NodeConfig { return s.cfg }
+
 func (s *IPInfusionOcNOS) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
 	return nil
 }
+
 func (s *IPInfusionOcNOS) Deploy(ctx context.Context) error {
 	cID, err := s.runtime.CreateContainer(ctx, s.cfg)
 	if err != nil {
@@ -73,6 +80,7 @@ func (s *IPInfusionOcNOS) Deploy(ctx context.Context) error {
 	_, err = s.runtime.StartContainer(ctx, cID, s.cfg)
 	return err
 }
+
 func (*IPInfusionOcNOS) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
 	return nil
 }

--- a/nodes/vr_csr/vr-csr.go
+++ b/nodes/vr_csr/vr-csr.go
@@ -63,13 +63,20 @@ func (s *vrCsr) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
+
 func (s *vrCsr) Config() *types.NodeConfig { return s.cfg }
+
 func (s *vrCsr) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
 	return nil
 }
+
 func (s *vrCsr) Deploy(ctx context.Context) error {
 	cID, err := s.runtime.CreateContainer(ctx, s.cfg)
 	if err != nil {
@@ -78,6 +85,7 @@ func (s *vrCsr) Deploy(ctx context.Context) error {
 	_, err = s.runtime.StartContainer(ctx, cID, s.cfg)
 	return err
 }
+
 func (*vrCsr) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
 	return nil
 }

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -62,13 +62,20 @@ func (s *vrFtosv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
+
 func (s *vrFtosv) Config() *types.NodeConfig { return s.cfg }
+
 func (s *vrFtosv) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
 	return nil
 }
+
 func (s *vrFtosv) Deploy(ctx context.Context) error {
 	cID, err := s.runtime.CreateContainer(ctx, s.cfg)
 	if err != nil {
@@ -77,6 +84,7 @@ func (s *vrFtosv) Deploy(ctx context.Context) error {
 	_, err = s.runtime.StartContainer(ctx, cID, s.cfg)
 	return err
 }
+
 func (*vrFtosv) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
 	return nil
 }

--- a/nodes/vr_n9kv/vr-n9kv.go
+++ b/nodes/vr_n9kv/vr-n9kv.go
@@ -62,6 +62,10 @@ func (s *vrN9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 func (s *vrN9kv) Config() *types.NodeConfig { return s.cfg }

--- a/nodes/vr_nxos/vr-nxos.go
+++ b/nodes/vr_nxos/vr-nxos.go
@@ -56,6 +56,9 @@ func (s *vrNXOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -64,13 +64,20 @@ func (s *vrPan) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
+
 func (s *vrPan) Config() *types.NodeConfig { return s.cfg }
+
 func (s *vrPan) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
 	return nil
 }
+
 func (s *vrPan) Deploy(ctx context.Context) error {
 	cID, err := s.runtime.CreateContainer(ctx, s.cfg)
 	if err != nil {
@@ -79,6 +86,7 @@ func (s *vrPan) Deploy(ctx context.Context) error {
 	_, err = s.runtime.StartContainer(ctx, cID, s.cfg)
 	return err
 }
+
 func (*vrPan) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
 	return nil
 }

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -63,6 +63,9 @@ func (s *vrRos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -76,6 +76,10 @@ func (s *vrSROS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 		s.cfg.ShortName,
 		s.cfg.NodeType,
 	)
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -60,6 +60,10 @@ func (s *vrVEOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
+
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -68,6 +68,9 @@ func (s *vrVMX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -74,6 +74,9 @@ func (s *vrVQFX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/nodes/vr_xrv/vr-xrv.go
+++ b/nodes/vr_xrv/vr-xrv.go
@@ -64,6 +64,9 @@ func (s *vrXRV) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 func (s *vrXRV) Config() *types.NodeConfig { return s.cfg }

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -66,6 +66,9 @@ func (s *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --vcpu %s --ram %s --trace",
 		s.cfg.Env["USERNAME"], s.cfg.Env["PASSWORD"], s.cfg.ShortName, s.cfg.Env["CONNECTION_MODE"], s.cfg.Env["VCPU"], s.cfg.Env["RAM"])
 
+	// set virtualization requirement
+	s.cfg.HostRequirements.VirtRequired = true
+
 	return nil
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -117,7 +117,8 @@ type NodeConfig struct {
 }
 
 type HostRequirements struct {
-	SSE3 bool `json:"sse3,omitempty"` // sse3 cpu instruction
+	SSE3         bool `json:"sse3,omitempty"`          // sse3 cpu instruction
+	VirtRequired bool `json:"virt-required,omitempty"` // indicates that KVM virtualization is required for this node to run
 }
 
 // GenerateConfig generates configuration for the nodes


### PR DESCRIPTION
This PR adds ability to skip checks for virt support in case when clab is running in a container itself. In that case we can't interrogate hosts virt parameter and just bypass this check entirely.

Additionally, every vm-based node is now has a HostRequirement flag to indicate if they need virt support to run