### PR TITLE
auto pickup of topology file name

### DIFF
--- a/clab/file.go
+++ b/clab/file.go
@@ -73,7 +73,7 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 	// create a hidden file that will contain the rendered topology
 	if !strings.HasPrefix(fileBase, ".") {
 		backupFPath := filepath.Join(topoDir,
-			fmt.Sprintf(".%s.yml", fileBase[:len(fileBase)-len(filepath.Ext(topoAbsPath))]))
+			fmt.Sprintf(".%s.yml.bak", fileBase[:len(fileBase)-len(filepath.Ext(topoAbsPath))]))
 
 		err = utils.CreateFile(backupFPath, buf.String())
 		if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -73,6 +73,7 @@ func init() {
 	deployCmd.Flags().StringVarP(&exportTemplate, "export-template", "", defaultExportTemplateFPath, "template file for topology data export")
 }
 
+// deployFn function runs deploy sub command
 func deployFn(_ *cobra.Command, _ []string) error {
 	var err error
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,7 @@ func sudoCheck(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func preRunFn(cmd *cobra.Command, args []string) error {
+func preRunFn(cmd *cobra.Command, _ []string) error {
 
 	// set debug level when required
 	debug = debugCount > 0

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,12 +61,18 @@ func sudoCheck(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func preRunFn(_ *cobra.Command, _ []string) error {
+func preRunFn(cmd *cobra.Command, args []string) error {
 
 	// set debug level when required
 	debug = debugCount > 0
 	if debug {
 		log.SetLevel(log.DebugLevel)
+	}
+
+	// for inspect --all command we don't proceed with topo files search process/
+	// as it is not required
+	if cmd.Name() == "inspect" && cmd.Flag("all").Value.String() == "true" {
+		return nil
 	}
 
 	return getTopoFilePath()
@@ -75,7 +81,7 @@ func preRunFn(_ *cobra.Command, _ []string) error {
 // getTopoFilePath finds *.clab.y*ml file in the current working directory if the files was note specified using flags
 // errors if more than one file is found by the glob path
 func getTopoFilePath() error {
-	if topo != "" {
+	if topo != "" || name != "" {
 		return nil
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,9 +69,9 @@ func preRunFn(cmd *cobra.Command, args []string) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// for inspect --all command we don't proceed with topo files search process/
+	// for inspect/destroy --all command we don't proceed with topo files search process/
 	// as it is not required
-	if cmd.Name() == "inspect" && cmd.Flag("all").Value.String() == "true" {
+	if (cmd.Name() == "inspect" || cmd.Name() == "destroy") && cmd.Flag("all").Value.String() == "true" {
 		return nil
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -28,14 +29,9 @@ var name string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "containerlab",
-	Short: "deploy container based lab environments with a user-defined interconnections",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		debug = debugCount > 0
-		if debug {
-			log.SetLevel(log.DebugLevel)
-		}
-	},
+	Use:               "containerlab",
+	Short:             "deploy container based lab environments with a user-defined interconnections",
+	PersistentPreRunE: preRunFn,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -49,8 +45,8 @@ func Execute() {
 func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().CountVarP(&debugCount, "debug", "d", "enable debug mode")
-	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "", "path to the file with topology information")
-	rootCmd.PersistentFlags().StringVarP(&varsFile, "vars", "", "", "path to the file with topology template variables")
+	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "", "path to the topology file")
+	rootCmd.PersistentFlags().StringVarP(&varsFile, "vars", "", "", "path to the topology template variables file")
 	_ = rootCmd.MarkPersistentFlagFilename("topo", "*.yaml", "*.yml")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "lab name")
 	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 120*time.Second, "timeout for external API requests (e.g. container runtimes), e.g: 30s, 1m, 2m30s")
@@ -63,4 +59,40 @@ func sudoCheck(_ *cobra.Command, _ []string) error {
 		return errors.New("containerlab requires sudo privileges to run")
 	}
 	return nil
+}
+
+func preRunFn(_ *cobra.Command, _ []string) error {
+
+	// set debug level when required
+	debug = debugCount > 0
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	return getTopoFilePath()
+}
+
+// getTopoFilePath finds *.clab.y*ml file in the current working directory if the files was note specified using flags
+// errors if more than one file is found by the glob path
+func getTopoFilePath() error {
+	if topo != "" {
+		return nil
+	}
+
+	var err error
+
+	log.Debugf("trying to find topology files automatically")
+
+	files, err := filepath.Glob("*.clab.y*ml")
+
+	if len(files) != 1 {
+		return errors.New("none or more than one topology files found, can't auto select one")
+	}
+
+	topo = files[0]
+
+	log.Debugf("topology file found: %s", files[0])
+
+	return err
+
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,18 +69,23 @@ func preRunFn(cmd *cobra.Command, args []string) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// for inspect/destroy --all command we don't proceed with topo files search process/
-	// as it is not required
-	if (cmd.Name() == "inspect" || cmd.Name() == "destroy") && cmd.Flag("all").Value.String() == "true" {
-		return nil
-	}
-
-	return getTopoFilePath()
+	return getTopoFilePath(cmd)
 }
 
 // getTopoFilePath finds *.clab.y*ml file in the current working directory if the files was note specified using flags
 // errors if more than one file is found by the glob path
-func getTopoFilePath() error {
+func getTopoFilePath(cmd *cobra.Command) error {
+	// set commands which may use topo file find functionality, the rest don't need it
+	if !(cmd.Name() == "deploy" || cmd.Name() == "destroy" || cmd.Name() == "inspect" || cmd.Name() == "save" || cmd.Name() == "graph" || cmd.Name() == "exec") {
+		return nil
+	}
+
+	// inspect and destroy commands with --all flag don't use file find functionality
+	if (cmd.Name() == "inspect" || cmd.Name() == "destroy") && cmd.Flag("all").Value.String() == "true" {
+		return nil
+	}
+
+	// if topo or name flags have been provided, don't try to derive the topo file
 	if topo != "" || name != "" {
 		return nil
 	}

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -16,6 +16,8 @@ The `deploy` command spins up a lab using the topology expressed via [topology d
 
 With the global `--topo | -t` flag a user sets the path to the topology definition file that will be used to spin up a lab.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 #### name
 
 With the global `--name | -n` flag a user sets a lab name. This value will override the lab name value passed in the topology definition file.

--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -16,6 +16,8 @@ The `destroy` command destroys a lab referenced by its [topology definition file
 
 With the global `--topo | -t` flag a user sets the path to the topology definition file that will be used get the elements of a lab that will be destroyed.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 #### cleanup
 
 The local `--cleanup` flag instructs containerlab to remove the lab directory and all its content.

--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -16,6 +16,8 @@ This command does exactly the same thing as `docker exec` does, but it allows to
 
 With the global `--topo | -t` flag a user specifies from which lab to take the containers and perform the exec command.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 #### cmd
 The command to be executed on the nodes is provided with `--cmd` flag. The command is provided as a string, thus it needs to be quoted to accommodate for spaces or special characters.
 

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -79,6 +79,8 @@ If `--offline` flag was not provided and no containers were found matching the l
 
 With the global `--topo | -t` flag a user sets the path to the topology file that will be used to get the nodes of a lab.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 #### srv
 
 The `--srv` flag allows a user to customize the HTTP address and port for the web server. Default value is `:50080`.

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -19,6 +19,8 @@ The lab name and path values will be set for the first node of such lab, to redu
 
 With the global `--topo | -t` or `--name | -n` flag a user specifies which particular lab they want to get the information about.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 #### format
 
 The local `--format` flag enables different output stylings. By default the table view will be used.

--- a/docs/cmd/save.md
+++ b/docs/cmd/save.md
@@ -23,6 +23,8 @@ The exact command that performs configuration save depends on a given kind. The 
 
 With the global `--topo | -t` or `--name | -n` flag a user specifies from which lab to take the containers and perform the save configuration task.
 
+When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
+
 ### Examples
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,6 +66,11 @@ The image name follows the same rules as the images you use with, for example, D
 
     For example: `docker tag srlinux:20.6.1-286 srlinux:latest`
 
+!!!warning "Images availability"
+    Quickstart lab includes Nokia SR Linux and Arista cEOS images. While Nokia SR Linux is a publicly available image and can be pulled by anyone, its counterpart Arista cEOS images needs to be downloaded by the users first.
+
+    This means that you have to login with Arista website and download the image, then import it to docker image store before proceeding with this lab. Or you can swap the ceos image with another SR Linux image and enjoy the freedom of labbing.
+
 ## Deploying a lab
 Now when we know what a basic topology file consists of and sorted out the container image name and node's license file, we can proceed with deploying this lab. To keep things easy and guessable, the command to deploy a lab is called [`deploy`](cmd/deploy.md).
 
@@ -80,9 +85,12 @@ REPOSITORY             TAG                 IMAGE ID            CREATED          
 ghcr.io/nokia/srlinux  latest              79019d14cfc7        3 months ago        1.32GB
 ceos                   4.25.0F             15a5f97fe8e8        3 months ago        1.76GB
 
-# start the lab deployment by referencing the topology file
-containerlab deploy --topo srlceos01.clab.yml
+# start the lab deployment
+containerlab deploy # (1)!
 ```
+
+1. `deploy` command will automatically lookup a file matching the `*.clab.y*ml` patter to select it.  
+  If you have several files and want to pick a specific one, use `--topo <path>` flag.
 
 After a couple of seconds you will see the summary of the deployed nodes:
 


### PR DESCRIPTION
This PR adds ability for clab to auto sense presence of a topo file in the CWD.
If a single file matches `*.clab.y*ml` patter it will be used in all clab commands as a topo file. 

close #898