### PR TITLE
Fix typo in kind name

### DIFF
--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	kindnames = []string{"crdp", "juniper_crpd"}
+	kindnames = []string{"crpd", "juniper_crpd"}
 	//go:embed crpd.cfg
 	cfgTemplate string
 


### PR DESCRIPTION
kind was erroneously named 'crdp', while the product and node type are 'crpd'