### PR TITLE
swapped custom location for default one

### DIFF
--- a/docs/cmd/generate.md
+++ b/docs/cmd/generate.md
@@ -25,7 +25,7 @@ The user configures the CLOS fabric topology by using the `--nodes` flag. The fl
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:12,&quot;zoom&quot;:1.4,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 For example, the following flag value will define a 2-tier CLOS fabric with tier1 (leafs) consists of 4x SR Linux containers of IXR-D3 type and the 2x Arista cEOS spines:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,4 +89,4 @@ This short clip briefly demonstrates containerlab features and explains its purp
 ## Join us
 Have questions, ideas, bug reports or just want to chat? Come join [our discord server](https://discord.gg/vAyddtaEV9).
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/cfg-clos.md
+++ b/docs/lab-examples/cfg-clos.md
@@ -182,4 +182,4 @@ Containerlab will render the templates and use SSH client to connect to the node
 
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/cvx01.md
+++ b/docs/lab-examples/cvx01.md
@@ -1,6 +1,6 @@
 |                               |                                                                      |
 | ----------------------------- | -------------------------------------------------------------------- |
-| **Description**               | Cumulus Linux connected back-to-back with FRR                          |
+| **Description**               | Cumulus Linux connected back-to-back with FRR                        |
 | **Components**                | [Cumulus Linux][cvx]                                                 |
 | **Resource requirements**[^1] | :fontawesome-solid-microchip: 1 <br/>:fontawesome-solid-memory: 1 GB |
 | **Topology file**             | [topo.clab.yml][topofile]                                            |
@@ -44,4 +44,4 @@ rtt min/avg/max/mdev = 0.400/0.400/0.400/0.000 ms
 
 
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/cvx02.md
+++ b/docs/lab-examples/cvx02.md
@@ -45,4 +45,4 @@ root@sw1:mgmt:~#
 
 
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/ext-bridge.md
+++ b/docs/lab-examples/ext-bridge.md
@@ -29,4 +29,4 @@ By introducing a link of `bridge` type to the containerlab topology, we are open
 
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/ixiacone-srl.md
+++ b/docs/lab-examples/ixiacone-srl.md
@@ -107,4 +107,4 @@ flow_metrics:
 [^3]: Replace `add` with `del` to undo.
 [^4]: The docker commands above shall not be required for upcoming releases of ixia-c-one with added ARP/ND capability.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/lab-examples.md
+++ b/docs/lab-examples/lab-examples.md
@@ -1,5 +1,5 @@
 # About lab examples
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:4,&quot;zoom&quot;:1,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
 

--- a/docs/lab-examples/min-5clos.md
+++ b/docs/lab-examples/min-5clos.md
@@ -122,4 +122,4 @@ Configuration snippets that are used to provision the nodes are contained within
 
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/min-clos.md
+++ b/docs/lab-examples/min-clos.md
@@ -24,4 +24,4 @@ With this lightweight CLOS topology a user can exhibit the following scenarios:
 
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/multinode.md
+++ b/docs/lab-examples/multinode.md
@@ -15,7 +15,7 @@ With such approach users are allowed to spread the load between multiple VMs and
 For the sake of the demonstration the topology used in this lab consists of just two virtualized routers [packaged in a container format](../manual/vrnetlab.md) - Nokia SR OS and Juniper vMX. Although the routers are running on different VMs, they logically form a back-to-back connection over a pair of interfaces aggregated in a logical bundle.
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:7,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/multinode.drawio&quot;}"></div>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 Upon succesful lab deployment and configuration, the routers will be able to exchange LACP frames, thus proving a transparent L2 connectivity and will be able to ping each other.
 

--- a/docs/lab-examples/single-srl.md
+++ b/docs/lab-examples/single-srl.md
@@ -28,4 +28,4 @@ This lightweight lab enables the users to perform the following exercises:
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 [^2]: Check out [gnmic](https://gnmic.kmrd.dev) gNMI client to interact with SR Linux gNMI server.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/srl-ceos.md
+++ b/docs/lab-examples/srl-ceos.md
@@ -131,4 +131,4 @@ PING 10.10.10.2 (10.10.10.2) 56(84) bytes of data.
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/srl-crpd.md
+++ b/docs/lab-examples/srl-crpd.md
@@ -179,4 +179,4 @@ Once the lab is deployed with containerlab, use the following configuration inst
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/srl-frr.md
+++ b/docs/lab-examples/srl-frr.md
@@ -30,4 +30,4 @@ The lab directory [contains](https://github.com/srl-labs/containerlab/tree/maste
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/srl-sonic.md
+++ b/docs/lab-examples/srl-sonic.md
@@ -139,4 +139,4 @@ PING 10.10.10.1 (10.10.10.1) 56(84) bytes of data.
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/templated01.md
+++ b/docs/lab-examples/templated01.md
@@ -55,4 +55,4 @@ The `configure.sh` script relies on [gomplate](https://docs.gomplate.ca) and [gn
 [topovarfile]: https://github.com/srl-labs/containerlab/tree/main/lab-examples/templated01/templated01.clab_vars.yaml
 
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/templated02.md
+++ b/docs/lab-examples/templated02.md
@@ -62,4 +62,4 @@ bash configure.sh
 [topovarfile]: https://github.com/srl-labs/containerlab/tree/main/lab-examples/templated01/templated01.clab_vars.yaml
 
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/two-srls.md
+++ b/docs/lab-examples/two-srls.md
@@ -45,4 +45,4 @@ This lab, besides having the same objectives as [srl01](single-srl.md) lab, also
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 [^2]: versions of respective container images or software that was used to create the lab.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/vr-sros.md
+++ b/docs/lab-examples/vr-sros.md
@@ -26,4 +26,4 @@ The lab directory [contains](https://github.com/srl-labs/containerlab/tree/maste
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/vr-vmx.md
+++ b/docs/lab-examples/vr-vmx.md
@@ -26,4 +26,4 @@ The lab directory [contains](https://github.com/srl-labs/containerlab/tree/maste
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/vr-xrv.md
+++ b/docs/lab-examples/vr-xrv.md
@@ -25,4 +25,4 @@ The lab directory [contains](https://github.com/srl-labs/containerlab/tree/maste
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/vr-xrv9k.md
+++ b/docs/lab-examples/vr-xrv9k.md
@@ -25,4 +25,4 @@ The lab directory [contains](https://github.com/srl-labs/containerlab/tree/maste
 [^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
 [^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/lab-examples/wan.md
+++ b/docs/lab-examples/wan.md
@@ -22,4 +22,4 @@ The WAN-centric scenarios can be tested with this lab:
 
 [^1]: Resource requirements are provisional. Consult with SR Linux Software Installation guide for additional information.
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/manual/kinds/bridge.md
+++ b/docs/manual/kinds/bridge.md
@@ -2,7 +2,7 @@
 search:
   boost: 4
 ---
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 # Linux bridge
 Containerlab can connect its nodes to a Linux bridge instead of interconnecting the nodes directly. This connectivity option is enabled with `bridge` kind and opens a variety of integrations that containerlab labs can have with workloads of other types.
 

--- a/docs/manual/kinds/linux.md
+++ b/docs/manual/kinds/linux.md
@@ -2,7 +2,7 @@
 search:
   boost: 4
 ---
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 # Linux container
 Labs deployed with containerlab are endlessly flexible, mostly because containerlab can spin up and wire regular containers as part of the lab topology.

--- a/docs/manual/multi-node.md
+++ b/docs/manual/multi-node.md
@@ -41,7 +41,7 @@ In this scenario you wouldn't get far with exposing services via host-ports, as 
 For integration tasks like this containerlab users can leverage static routing towards [containerlab management network](network.md#management-network). Consider the following diagram:
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:0,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/multinode.drawio&quot;}"></div>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 This solution requires to set up routing between the host which runs the NMS and the container host that has containerlab nodes inside. Since containers are always attached to a common management network, we can make this network reachable by installing, for example, a static route on the NMS host. This will provision the datapath between the NMS and the containerlab management network.
 

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 One of the most important tasks in the process of building container based labs is to create a virtual wiring between the containers and the host. That is one of the problems that containerlab was designed to solve.
 
 In this document we will discuss the networking concepts that containerlab employs to provide the following connectivity scenarios:

--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -3,7 +3,7 @@ Containerlab builds labs based on the topology information that users pass to it
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:4,&quot;zoom&quot;:1,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 ## Topology definition components
 The topology definition file is a configuration file expressed in YAML and has a name pattern of `*.clab.yml`[^1]. In this document, we take a pre-packaged [Nokia SR Linux and Arista cEOS](../lab-examples/srl-ceos.md) lab and explain the topology definition structure using its definition file [srlceos01.clab.yml](https://github.com/srl-labs/containerlab/tree/master/lab-examples/srlceos01/srlceos01.clab.yml) which is pasted below:

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -4,7 +4,7 @@ Keeping this requirement in mind from the very beginning, we added [`bridge`](..
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:0,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/vrnetlab.drawio&quot;}"></div>
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 With this approach, you could bridge VM-based routing systems by attaching interfaces to the bridge you define in your topology. However, it doesn't allow users to define the VM-based nodes in the same topology file. With [`vrnetlab`](https://github.com/hellt/vrnetlab) integration, containerlab is now capable of launching topologies with VM-based routers defined in the same topology file.
 

--- a/docs/manual/wireshark.md
+++ b/docs/manual/wireshark.md
@@ -10,7 +10,7 @@ Consider the following lab topology which highlights the typical points of packe
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:13,&quot;zoom&quot;:2,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
 
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 Since containerlab leverages linux network devices, users are free to use whatever tool of choice to sniff from any of them. This article will provide examples for `tcpdump` and `wireshark` tools.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 hide:
   - navigation
 ---
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 ## Installation
 Getting containerlab is as easy as it gets. Thanks to the trivial [installation](install.md) procedure it can be set up in a matter of a few seconds on any RHEL or Debian based OS[^1].

--- a/docs/rn/0.11.0.md
+++ b/docs/rn/0.11.0.md
@@ -17,7 +17,7 @@ To help you navigate these options we've created a [multi-node labs](../manual/m
 With 0.11.0 specifically, we add the last option in that list, which is most flexible and far-reaching - [VxLAN Tunneling](../manual/multi-node.md#vxlan-tunneling).
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:9,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/multinode.drawio&quot;}"></div>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/hellt/drawio-js@main/embed2.js" async></script>
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 
 To help containerlab users to provision VxLAN tunnels the helper commands have been created - [vxlan create](../cmd/tools/vxlan/create.md), [vxlan delete](../cmd/tools/vxlan/delete.md).
 


### PR DESCRIPTION
the reason we had a custom location for diagrams JS files was that it seemed it was not using CDN when delivering the embed2.js used to render diagrams on our site.

But last time I checked load times were quite ok, so swapping back to original script location to ensure that we got updates as soon as they are published by diagrams team.

<img width="940" alt="image" src="https://user-images.githubusercontent.com/5679861/176642898-300f6344-57e9-4ae2-b910-3d44f06fa3b7.png">
