### PR TITLE
Writing rendered topology should be optional

### DIFF
--- a/clab/file.go
+++ b/clab/file.go
@@ -77,7 +77,7 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 
 		err = utils.CreateFile(backupFPath, buf.String())
 		if err != nil {
-			return err
+			log.Warnf("Could not write rendered topology: %v", err)
 		}
 	}
 	log.Debugf("topology:\n%s\n", buf.String())


### PR DESCRIPTION
On initial run the correct topology backup backup is created and saved with all the rendered values, this usually happens with root privileges. So the `.bak` file belongs to root

Any subsequent containerlab command that does not require root privileges but uses the topology fails, since writing this file fails.

The PR only issues a warning when the file cannot be created.