### PR TITLE
expose IPv6 gateway and add to cEOS config

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -325,6 +325,7 @@ func enrichNodes(containers []types.GenericContainer, nodesMap map[string]nodes.
 				node.Config().MgmtIPv6Address = c.NetworkSettings.IPv6addr
 				node.Config().MgmtIPv6PrefixLength = c.NetworkSettings.IPv6pLen
 				node.Config().MgmtIPv4Gateway = c.NetworkSettings.IPv4Gw
+				node.Config().MgmtIPv6Gateway = c.NetworkSettings.IPv6Gw
 			}
 			node.Config().ContainerID = c.ID
 		}

--- a/nodes/ceos/ceos.cfg
+++ b/nodes/ceos/ceos.cfg
@@ -8,6 +8,7 @@ username admin privilege 15 secret admin
 service routing protocols model multi-agent
 !
 {{ if .MgmtIPv4Gateway }}ip route 0.0.0.0/0 {{ .MgmtIPv4Gateway }}{{end}}
+{{ if .MgmtIPv6Gateway }}ipv6 route ::0/0 {{ .MgmtIPv6Gateway }}{{end}}
 !
 interface {{ .MgmtIntf }}
 {{ if .MgmtIPv4Address }}ip address {{ .MgmtIPv4Address }}/{{.MgmtIPv4PrefixLength}}{{end}}

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -147,6 +147,7 @@ func (n *ceos) createCEOSFiles() error {
 	// since the container network has been created before we launch nodes
 	// and mgmt gateway can be used in ceos.cfg template to configure default route for mgmt
 	nodeCfg.MgmtIPv4Gateway = n.runtime.Mgmt().IPv4Gw
+	nodeCfg.MgmtIPv6Gateway = n.runtime.Mgmt().IPv6Gw
 
 	// set the mgmt interface name for the node
 	err := setMgmtInterface(nodeCfg)

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -671,7 +671,7 @@ func extractIPInfoFromLabels(labels map[string]string) (types.GenericMgmtIPs, er
 			return types.GenericMgmtIPs{}, err
 		}
 	}
-	return types.GenericMgmtIPs{IPv4addr: labels["clab.ipv4.addr"], IPv4pLen: ipv4mask, IPv6addr: labels["clab.ipv6.addr"], IPv6pLen: ipv6mask, IPv4Gw: labels["clab.ipv4.gateway"]}, nil
+	return types.GenericMgmtIPs{IPv4addr: labels["clab.ipv4.addr"], IPv4pLen: ipv4mask, IPv6addr: labels["clab.ipv6.addr"], IPv6pLen: ipv6mask, IPv4Gw: labels["clab.ipv4.gateway"], IPv6Gw: labels["clab.ipv6.gateway"]}, nil
 }
 
 func timeSinceInHuman(since time.Time) string {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -230,12 +230,13 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	// get management bridge v4/6 addresses and save it under mgmt struct
 	// so that nodes can use this information prior to being deployed
 	// this was added to allow mgmt network gw ip to be available in a startup config templation step (ceos)
-	var v4 string
-	if v4, _, err = utils.FirstLinkIPs(bridgeName); err != nil {
+	var v4, v6 string
+	if v4, v6, err = utils.FirstLinkIPs(bridgeName); err != nil {
 		return err
 	}
 
 	d.mgmt.IPv4Gw = v4
+	d.mgmt.IPv6Gw = v6
 
 	log.Debugf("Docker network %q, bridge name %q", d.mgmt.Network, bridgeName)
 

--- a/tests/03-basic-ceos/01-two-ceos.robot
+++ b/tests/03-basic-ceos/01-two-ceos.robot
@@ -41,6 +41,11 @@ Ensure n2 mgmt IPv4 is in the config file
     Log    ${f}
     Should Contain    ${f}    ${n2-mgmt-ip}
 
+Ensure IPv6 default route is in the config file
+    ${f} =    OperatingSystem.Get File    ${EXECDIR}/clab-${lab-name}/${node1-name}/flash/startup-config
+    Log    ${f}
+    Should Contain    ${f}    ipv6 route
+
 Ensure n1 is reachable over ssh
     Common.Login via SSH with username and password
     ...    address=${n1-mgmt-ip}

--- a/types/types.go
+++ b/types/types.go
@@ -89,6 +89,7 @@ type NodeConfig struct {
 	MgmtIPv6Address      string            `json:"mgmt-ipv6-address,omitempty"`
 	MgmtIPv6PrefixLength int               `json:"mgmt-ipv6-prefix-length,omitempty"`
 	MgmtIPv4Gateway      string            `json:"mgmt-ipv4-gateway,omitempty"`
+	MgmtIPv6Gateway      string            `json:"mgmt-ipv6-gateway,omitempty"`
 	MacAddress           string            `json:"mac-address,omitempty"`
 	ContainerID          string            `json:"containerid,omitempty"`
 	TLSCert              string            `json:"tls-cert,omitempty"`
@@ -210,6 +211,7 @@ type GenericMgmtIPs struct {
 	IPv4Gw   string
 	IPv6addr string
 	IPv6pLen int
+	IPv6Gw   string
 }
 
 type GenericFilter struct {


### PR DESCRIPTION
Add MgmtmIPv6Gateway to NodeConfig and use to configure default IPv6
route for cEOS devices.