### PR TITLE
Add Pseudo randomness to SRL chassis mac addresses

### DIFF
--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -444,11 +444,8 @@ func generateSRLTopologyFile(cfg *types.NodeConfig) error {
 		return errors.Wrap(err, "failed to get srl topology file")
 	}
 
-	// bit 0     : strictly 0 (indicating unicast address)
-	// bit 01-11 : pseudo-random (avoid mac clashes when interconnecting projects)
-	// bit 12-24 : index of the node (for labs up to 4096 nodes)
-	// bit 25-47 : used by SRL: FF:00:<port>
 	// this ensures that different srl nodes will have different macs for their ports
+	// see macPrefix variable for full explanation of bits in mac address
 	m := fmt.Sprintf("%s%1x:%02x:00:00:00", macPrefix, cfg.Index/256, cfg.Index%256)
 	mac := mac{
 		MAC: m,


### PR DESCRIPTION
In Pull request #713 , deterministic MAC address for SRL nodes were introduced. This might give problems when interconnecting different containerlab projects, as the n-th nodes of each containerlab projects have the same chassis mac address. Specifically, FSS will refuse adding two nodes with the same MAC addresses.

This PR adds a pseudo-random, project-specific prefix to the mac address, while ensuring all previous requirements:
- bit 0 : strictly 0 (indicating unicast address)
- bit 1-11 : pseudo-random (avoid mac clashes when interconnecting projects)
- bit 12-24 : index of the node (for labs up to 4096 nodes)
- bit 25-47 : used by SRL: FF:00:<port> (ensures unique port mac addresses)