### PR TITLE
Restore the slice template function

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -70,7 +70,6 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 
 	// gomplate overrides the built-in *slice* function. Rename it to *list*
 	gfuncs := gomplate.CreateFuncs(context.Background(), new(data.Data))
-	gfuncs["list"] = gfuncs["slice"]
 	delete(gfuncs, "slice")
 
 	tmpl := template.New("").Funcs(gfuncs).Funcs(jT.Funcs)

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -68,7 +68,7 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 		log.Infof("No template names specified (-l) using: %s", strings.Join(TemplateNames, ", "))
 	}
 
-	// gomplate overrides the built-in *slice* function. Rename it to *list*
+	// gomplate overrides the built-in *slice* function. You can still use *coll.Slice*
 	gfuncs := gomplate.CreateFuncs(context.Background(), new(data.Data))
 	delete(gfuncs, "slice")
 

--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -68,9 +68,12 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 		log.Infof("No template names specified (-l) using: %s", strings.Join(TemplateNames, ", "))
 	}
 
-	tmpl := template.New("").
-		Funcs(jT.Funcs).
-		Funcs(gomplate.CreateFuncs(context.Background(), new(data.Data)))
+	// gomplate overrides the built-in *slice* function. Rename it to *list*
+	gfuncs := gomplate.CreateFuncs(context.Background(), new(data.Data))
+	gfuncs["list"] = gfuncs["slice"]
+	delete(gfuncs, "slice")
+
+	tmpl := template.New("").Funcs(gfuncs).Funcs(jT.Funcs)
 
 	for _, nc := range allnodes {
 		for _, baseN := range TemplateNames {


### PR DESCRIPTION
Gomplate override the built-in slice function from text/template.

This PR deletes the `slice` shortcut provided by gomplate. Use `coll.Slice`

Built-in
```
slice
	slice returns the result of slicing its first argument by the
	remaining arguments. Thus "slice x 1 2" is, in Go syntax, x[1:2],
	while "slice x" is x[:], "slice x 1" is x[1:], and "slice x 1 2 3"
	is x[1:2:3]. The first argument must be a string, slice, or array.
```

gomplate's [slice](https://docs.gomplate.ca/functions/coll/#coll-slice)
```
Creates a slice (like an array or list). Useful when needing to range over a bunch of variables
```