### PR TITLE
introducing env var CLAB_VERSION_CHECK

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -103,7 +103,16 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// latest version channel
 	vCh := make(chan string)
-	go getLatestVersion(vCh)
+
+	// check if new_version_notification is meant to be disabled
+	versionCheckStatus := os.Getenv("CLAB_VERSION_CHECK")
+	log.Debugf("Env: CLAB_VERSION_CHECK=%s", versionCheckStatus)
+
+	if strings.Contains(strings.ToLower(versionCheckStatus), "disable") {
+		close(vCh)
+	} else {
+		go getLatestVersion(vCh)
+	}
 
 	if reconfigure {
 		if err != nil {

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -55,6 +55,15 @@ The local `--export-template` flag allows a user to specify a custom Go template
 
 To export full topology data instead of a subset of fields exported by default, use `--export-template /etc/containerlab/templates/export/full.tmpl`. Note, some fields exported via `full.tmpl` might contain sensitive information like TLS private keys. To customize export data, it is recommended to start with a copy of `auto.tmpl` and change it according to your needs.
 
+### Environment variables
+
+#### CLAB_VERSION_CHECK
+
+Can be set to "disable" value to prevent deploy command making a network request to check new version to report if one is available.
+
+Useful when running in an automated environments with restricted network access.
+
+Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 
 ### Examples
 


### PR DESCRIPTION
CLAB_VERSION_CHECK can be set to 'disable' to prevent the version checks from running and printing a new version notification