### PR TITLE
Enable Unix domain socket in the default SRL configuration

### DIFF
--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -45,6 +45,7 @@ set / system tls server-profile clab-profile trust-anchor "{{ .TLSAnchor }}"
 set / system tls server-profile clab-profile authenticate-client false
 {{- end }}
 set / system gnmi-server admin-state enable network-instance mgmt admin-state enable tls-profile clab-profile
+set / system gnmi-server unix-socket admin-state enable
 set / system json-rpc-server admin-state enable network-instance mgmt http admin-state enable
 set / system json-rpc-server admin-state enable network-instance mgmt https admin-state enable tls-profile clab-profile
 set / system lldp admin-state enable


### PR DESCRIPTION
This is a pull request to enable Unix domain socket in the default SRL configuration. 
I built containerlab on my dev VM and tested it.