### PR TITLE
#973 startup config

### DIFF
--- a/docs/manual/kinds/vr-csr.md
+++ b/docs/manual/kinds/vr-csr.md
@@ -50,3 +50,19 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ## Features and options
 ### Node configuration
 vr-csr nodes come up with a basic configuration where only `admin` user and management interfaces such as NETCONF provisioned.
+
+
+#### Startup configuration
+It is possible to make CSR1000V nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-csr
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.

--- a/docs/manual/kinds/vr-ftosv.md
+++ b/docs/manual/kinds/vr-ftosv.md
@@ -45,3 +45,18 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ## Features and options
 ### Node configuration
 vr-ftosv nodes come up with a basic configuration where only `admin` user and management interfaces such as SSH provisioned.
+
+#### Startup configuration
+It is possible to make vMX nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-ftosv
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.

--- a/docs/manual/kinds/vr-n9kv.md
+++ b/docs/manual/kinds/vr-n9kv.md
@@ -52,3 +52,19 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ## Features and options
 ### Node configuration
 vr-n9kv nodes come up with a basic configuration where only `admin` user and management interfaces such as NETCONF, NXAPI and GRPC provisioned.
+
+
+#### Startup configuration
+It is possible to make n9kv nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-n9kv
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.

--- a/docs/manual/kinds/vr-nxos.md
+++ b/docs/manual/kinds/vr-nxos.md
@@ -45,3 +45,18 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ### Node configuration
 vr-nxos nodes come up with a basic configuration where only the control plane and line cards are provisioned, as well as the `clab` user.
 
+
+#### Startup configuration
+It is possible to make NXOS nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-nxos
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.

--- a/docs/manual/kinds/vr-veos.md
+++ b/docs/manual/kinds/vr-veos.md
@@ -58,3 +58,19 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ## Features and options
 ### Node configuration
 vr-veos nodes come up with a basic configuration where only the control plane and line cards are provisioned, as well as the `admin` user and management interfaces such as NETCONF, SNMP, gNMI.
+
+
+#### Startup configuration
+It is possible to make vEOS nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-veos
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.

--- a/docs/manual/kinds/vr-xrv.md
+++ b/docs/manual/kinds/vr-xrv.md
@@ -61,6 +61,21 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ### Node configuration
 vr-xrv nodes come up with a basic configuration where only the control plane and line cards are provisioned, as well as the `clab` user and management interfaces such as NETCONF, SNMP, gNMI.
 
+#### Startup configuration
+It is possible to make XRv nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-xrv
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.
+
 ## Lab examples
 The following labs feature vr-xrv node:
 

--- a/docs/manual/kinds/vr-xrv9k.md
+++ b/docs/manual/kinds/vr-xrv9k.md
@@ -57,6 +57,21 @@ Data interfaces `eth1+` needs to be configured with IP addressing manually using
 ### Node configuration
 vr-xrv9k nodes come up with a basic configuration where only the control plane and line cards are provisioned, as well as the `clab` user and management interfaces such as NETCONF, SNMP, gNMI.
 
+#### Startup configuration
+It is possible to make XRv9k nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-xrv9k
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.
+
 ## Lab examples
 The following labs feature vr-xrv9k node:
 

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -7,6 +7,9 @@ package vr_ftosv
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
@@ -18,6 +21,8 @@ import (
 var kindnames = []string{"vr-ftosv", "vr-dell_ftosv"}
 
 const (
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
 	defaultUser     = "admin"
 	defaultPassword = "admin"
 )
@@ -53,6 +58,9 @@ func (s *vrFtosv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	s.cfg.Env = utils.MergeStringMaps(defEnv, s.cfg.Env)
 
+	// mount config dir to support startup-config functionality
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, configDirName), ":/config"))
+
 	if s.cfg.Env["CONNECTION_MODE"] == "macvtap" {
 		// mount dev dir to enable macvtap
 		s.cfg.Binds = append(s.cfg.Binds, "/dev:/dev")
@@ -71,7 +79,7 @@ func (s *vrFtosv) Config() *types.NodeConfig { return s.cfg }
 
 func (s *vrFtosv) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
-	return nil
+	return loadStartupConfigFile(s.cfg)
 }
 
 func (s *vrFtosv) Deploy(ctx context.Context) error {
@@ -103,5 +111,28 @@ func (s *vrFtosv) Delete(ctx context.Context) error {
 }
 
 func (*vrFtosv) SaveConfig(_ context.Context) error {
+	return nil
+}
+
+func loadStartupConfigFile(node *types.NodeConfig) error {
+	// create config directory that will be bind mounted to vrnetlab container at / path
+	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
+
+	if node.StartupConfig != "" {
+		// dstCfg is a path to a file on the clab host that will have rendered configuration
+		dstCfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
+
+		c, err := os.ReadFile(node.StartupConfig)
+		if err != nil {
+			return err
+		}
+
+		cfgTemplate := string(c)
+
+		err = node.GenerateConfig(dstCfg, cfgTemplate)
+		if err != nil {
+			log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
+		}
+	}
 	return nil
 }

--- a/nodes/vr_n9kv/vr-n9kv.go
+++ b/nodes/vr_n9kv/vr-n9kv.go
@@ -7,6 +7,9 @@ package vr_n9kv
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/srl-labs/containerlab/nodes"
@@ -18,6 +21,9 @@ import (
 var kindnames = []string{"vr-n9kv", "vr-cisco_n9kv"}
 
 const (
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+
 	defaultUser     = "admin"
 	defaultPassword = "admin"
 )
@@ -53,6 +59,9 @@ func (s *vrN9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	s.cfg.Env = utils.MergeStringMaps(defEnv, s.cfg.Env)
 
+	// mount config dir to support startup-config functionality
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, configDirName), ":/config"))
+
 	if s.cfg.Env["CONNECTION_MODE"] == "macvtap" {
 		// mount dev dir to enable macvtap
 		s.cfg.Binds = append(s.cfg.Binds, "/dev:/dev")
@@ -69,7 +78,7 @@ func (s *vrN9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 func (s *vrN9kv) Config() *types.NodeConfig { return s.cfg }
 func (s *vrN9kv) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
-	return nil
+	return loadStartupConfigFile(s.cfg)
 }
 
 func (s *vrN9kv) Deploy(ctx context.Context) error {
@@ -101,5 +110,28 @@ func (s *vrN9kv) Delete(ctx context.Context) error {
 }
 
 func (*vrN9kv) SaveConfig(_ context.Context) error {
+	return nil
+}
+
+func loadStartupConfigFile(node *types.NodeConfig) error {
+	// create config directory that will be bind mounted to vrnetlab container at / path
+	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
+
+	if node.StartupConfig != "" {
+		// dstCfg is a path to a file on the clab host that will have rendered configuration
+		dstCfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
+
+		c, err := os.ReadFile(node.StartupConfig)
+		if err != nil {
+			return err
+		}
+
+		cfgTemplate := string(c)
+
+		err = node.GenerateConfig(dstCfg, cfgTemplate)
+		if err != nil {
+			log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
+		}
+	}
 	return nil
 }

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -7,6 +7,9 @@ package vr_veos
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/netconf"
@@ -20,8 +23,12 @@ var kindnames = []string{"vr-veos", "vr-arista_veos"}
 
 const (
 	scrapliPlatformName = "arista_eos"
-	defaultUser         = "admin"
-	defaultPassword     = "admin"
+
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+
+	defaultUser     = "admin"
+	defaultPassword = "admin"
 )
 
 func init() {
@@ -52,6 +59,9 @@ func (s *vrVEOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	s.cfg.Env = utils.MergeStringMaps(defEnv, s.cfg.Env)
 
+	// mount config dir to support startup-config functionality
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, configDirName), ":/config"))
+
 	if s.cfg.Env["CONNECTION_MODE"] == "macvtap" {
 		// mount dev dir to enable macvtap
 		s.cfg.Binds = append(s.cfg.Binds, "/dev:/dev")
@@ -68,7 +78,10 @@ func (s *vrVEOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 func (s *vrVEOS) Config() *types.NodeConfig { return s.cfg }
 
-func (*vrVEOS) PreDeploy(_, _, _ string) error { return nil }
+func (s *vrVEOS) PreDeploy(_, _, _ string) error {
+	utils.CreateDirectory(s.cfg.LabDir, 0777)
+	return loadStartupConfigFile(s.cfg)
+}
 
 func (s *vrVEOS) Deploy(ctx context.Context) error {
 	cID, err := s.runtime.CreateContainer(ctx, s.cfg)
@@ -108,5 +121,28 @@ func (s *vrVEOS) SaveConfig(_ context.Context) error {
 	}
 
 	log.Infof("saved %s running configuration to startup configuration file\n", s.cfg.ShortName)
+	return nil
+}
+
+func loadStartupConfigFile(node *types.NodeConfig) error {
+	// create config directory that will be bind mounted to vrnetlab container at / path
+	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
+
+	if node.StartupConfig != "" {
+		// dstCfg is a path to a file on the clab host that will have rendered configuration
+		dstCfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
+
+		c, err := os.ReadFile(node.StartupConfig)
+		if err != nil {
+			return err
+		}
+
+		cfgTemplate := string(c)
+
+		err = node.GenerateConfig(dstCfg, cfgTemplate)
+		if err != nil {
+			log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
+		}
+	}
 	return nil
 }

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -77,7 +77,7 @@ func (s *vrVMX) Config() *types.NodeConfig { return s.cfg }
 
 func (s *vrVMX) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
-	return createVrvMXFiles(s.cfg)
+	return loadStartupConfigFile(s.cfg)
 }
 
 func (s *vrVMX) Deploy(ctx context.Context) error {
@@ -121,7 +121,7 @@ func (s *vrVMX) SaveConfig(_ context.Context) error {
 	return nil
 }
 
-func createVrvMXFiles(node *types.NodeConfig) error {
+func loadStartupConfigFile(node *types.NodeConfig) error {
 	// create config directory that will be bind mounted to vrnetlab container at / path
 	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
 

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -83,7 +83,7 @@ func (s *vrVQFX) Config() *types.NodeConfig { return s.cfg }
 
 func (s *vrVQFX) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
-	return createVrvQFXFiles(s.cfg)
+	return loadStartupConfigFile(s.cfg)
 }
 
 func (s *vrVQFX) Deploy(ctx context.Context) error {
@@ -127,7 +127,7 @@ func (s *vrVQFX) SaveConfig(_ context.Context) error {
 	return nil
 }
 
-func createVrvQFXFiles(node *types.NodeConfig) error {
+func loadStartupConfigFile(node *types.NodeConfig) error {
 	// create config directory that will be bind mounted to vrnetlab container at / path
 	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
 

--- a/nodes/vr_xrv/vr-xrv.go
+++ b/nodes/vr_xrv/vr-xrv.go
@@ -7,6 +7,9 @@ package vr_xrv
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/netconf"
@@ -20,8 +23,12 @@ var kindnames = []string{"vr-xrv", "vr-cisco_xrv"}
 
 const (
 	scrapliPlatformName = "cisco_iosxr"
-	defaultUser         = "clab"
-	defaultPassword     = "clab@123"
+
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+
+	defaultUser     = "clab"
+	defaultPassword = "clab@123"
 )
 
 func init() {
@@ -55,6 +62,9 @@ func (s *vrXRV) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	s.cfg.Env = utils.MergeStringMaps(defEnv, s.cfg.Env)
 
+	// mount config dir to support startup-config functionality
+	s.cfg.Binds = append(s.cfg.Binds, fmt.Sprint(path.Join(s.cfg.LabDir, configDirName), ":/config"))
+
 	if s.cfg.Env["CONNECTION_MODE"] == "macvtap" {
 		// mount dev dir to enable macvtap
 		s.cfg.Binds = append(s.cfg.Binds, "/dev:/dev")
@@ -72,7 +82,7 @@ func (s *vrXRV) Config() *types.NodeConfig { return s.cfg }
 
 func (s *vrXRV) PreDeploy(_, _, _ string) error {
 	utils.CreateDirectory(s.cfg.LabDir, 0777)
-	return nil
+	return loadStartupConfigFile(s.cfg)
 }
 
 func (s *vrXRV) Deploy(ctx context.Context) error {
@@ -113,5 +123,28 @@ func (s *vrXRV) SaveConfig(_ context.Context) error {
 	}
 
 	log.Infof("saved %s running configuration to startup configuration file\n", s.cfg.ShortName)
+	return nil
+}
+
+func loadStartupConfigFile(node *types.NodeConfig) error {
+	// create config directory that will be bind mounted to vrnetlab container at / path
+	utils.CreateDirectory(path.Join(node.LabDir, configDirName), 0777)
+
+	if node.StartupConfig != "" {
+		// dstCfg is a path to a file on the clab host that will have rendered configuration
+		dstCfg := filepath.Join(node.LabDir, configDirName, startupCfgFName)
+
+		c, err := os.ReadFile(node.StartupConfig)
+		if err != nil {
+			return err
+		}
+
+		cfgTemplate := string(c)
+
+		err = node.GenerateConfig(dstCfg, cfgTemplate)
+		if err != nil {
+			log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes most of the nodes in #973 

I don't have access to all the node images, so I don't want to inadvertently break something without being able to test.

This adds support for CSR, NXOS, N9KV, VEOS, XRV, and XRV9K to use and run the startup-config option.