### PR TITLE
fix iptables removal issue for external bridges

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -304,9 +304,7 @@ func (d *DockerRuntime) DeleteNet(ctx context.Context) (err error) {
 		return err
 	}
 
-	// bridge name associated with the network
-	br := "br-" + nres.ID[:12]
-	err = d.deleteIPTablesFwdRule(br)
+	err = d.deleteIPTablesFwdRule()
 	if err != nil {
 		log.Warnf("errors during iptables rules removal: %v", err)
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -96,15 +96,20 @@ func (d *DockerRuntime) WithMgmtNet(n *types.MgmtNet) {
 	}
 
 	// detect default MTU if this config parameter was not provided in the clab file
-	d0, err := d.Client.NetworkInspect(context.TODO(), defaultDockerNetwork, dockerTypes.NetworkInspectOptions{})
+	netRes, err := d.Client.NetworkInspect(context.TODO(), defaultDockerNetwork, dockerTypes.NetworkInspectOptions{})
 	if err != nil {
 		d.mgmt.MTU = "1500"
 		log.Debugf("an error occurred when trying to detect docker default network mtu")
 	}
 
-	if mtu, ok := d0.Options["com.docker.network.driver.mtu"]; ok {
+	if mtu, ok := netRes.Options["com.docker.network.driver.mtu"]; ok {
 		log.Debugf("detected docker network mtu value - %s", mtu)
 		d.mgmt.MTU = mtu
+	}
+
+	// if bridge was not set in the topo file, we default to
+	if d.mgmt.Bridge == "" {
+		d.mgmt.Bridge = "br-" + netRes.ID[:12]
 	}
 }
 

--- a/runtime/docker/iptables.go
+++ b/runtime/docker/iptables.go
@@ -6,14 +6,15 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/utils"
 )
 
 const (
 	iptCheckCmd = "-vL DOCKER-USER"
-	iptAllowCmd = "-I DOCKER-USER -o %s -j ACCEPT"
-	iptDelCmd   = "-D DOCKER-USER -o %s -j ACCEPT"
+	iptAllowCmd = "-I DOCKER-USER -o %s -j ACCEPT -m comment --comment \"set by containerlab\""
+	iptDelCmd   = "-D DOCKER-USER -o %s -j ACCEPT -m comment --comment \"set by containerlab\""
 )
 
 // installIPTablesFwdRule calls iptables to install `allow` rule for traffic destined nodes on the clab management network.
@@ -39,23 +40,28 @@ func (d *DockerRuntime) installIPTablesFwdRule() (err error) {
 		return fmt.Errorf("missing DOCKER-USER iptables chain. See http://containerlab.dev/manual/network/#external-access")
 	}
 
-	cmd := fmt.Sprintf(iptAllowCmd, d.mgmt.Bridge)
+	cmd, err := shlex.Split(fmt.Sprintf(iptAllowCmd, d.mgmt.Bridge))
+	if err != nil {
+		return err
+	}
 
 	log.Debugf("Installing iptables rules for bridge %q", d.mgmt.Bridge)
 
-	stdOutErr, err := exec.Command("iptables", strings.Split(cmd, " ")...).CombinedOutput()
+	stdOutErr, err := exec.Command("iptables", cmd...).CombinedOutput()
 	if err != nil {
 		log.Warnf("Iptables install stdout/stderr result is: %s", stdOutErr)
-		return fmt.Errorf("unable to install iptables rules: %w", err)
+		return fmt.Errorf("unable to install iptables rule using '%s' command: %w", cmd, err)
 	}
 	return nil
 }
 
 // deleteIPTablesFwdRule deletes `allow` rule installed with InstallIPTablesFwdRule when the bridge interface doesn't exist anymore.
-func (d *DockerRuntime) deleteIPTablesFwdRule(br string) (err error) {
+func (d *DockerRuntime) deleteIPTablesFwdRule() (err error) {
 	if !*d.mgmt.ExternalAccess {
 		return
 	}
+
+	br := d.mgmt.Bridge
 
 	if br == "" || br == "docker0" {
 		log.Debug("skipping deletion of iptables forwarding rule for non-bridged or default management network")
@@ -64,28 +70,36 @@ func (d *DockerRuntime) deleteIPTablesFwdRule(br string) (err error) {
 
 	// first check if a rule exists before trying to delete it
 	res, err := exec.Command("iptables", strings.Split(iptCheckCmd, " ")...).Output()
-	if !bytes.Contains(res, []byte(d.mgmt.Bridge)) {
-		log.Debug("external access iptables rule doesn't exist. Skipping deletion")
-		return nil
-	}
 	if err != nil {
 		// non nil error typically means that DOCKER-USER chain doesn't exist
 		// this happens with old docker installations (centos7 hello) from default repos
 		return fmt.Errorf("missing DOCKER-USER iptables chain. See http://containerlab.dev/manual/network/#external-access")
 	}
 
+	if !bytes.Contains(res, []byte(br)) {
+		log.Debug("external access iptables rule doesn't exist. Skipping deletion")
+		return nil
+	}
+
+	// we are not deleting the rule if the bridge still exists
+	// it happens when bridge is either still in use by docker network
+	// or it is managed externally (created manually)
 	_, err = utils.BridgeByName(br)
 	if err == nil {
-		// nil error means the bridge interface was found, hence we don't need to delete the fwd rule, as the bridge is still in use
+		log.Debugf("bridge %s is still in use, not removing the forwarding rule", br)
 		return nil
 	}
 
 	cmd := fmt.Sprintf(iptDelCmd, br)
-	log.Debugf("Removing clab iptables rules for bridge %q", br)
+
+	log.Debugf("removing clab iptables rules for bridge %q", br)
+	log.Debugf("trying to delete the forwarding rule with cmd: iptables %s", cmd)
+
 	stdOutErr, err := exec.Command("iptables", strings.Split(cmd, " ")...).CombinedOutput()
 	if err != nil {
 		log.Warnf("Iptables delete stdout/stderr result is: %s", stdOutErr)
 		return fmt.Errorf("unable to delete iptables rules: %w", err)
 	}
+
 	return nil
 }

--- a/runtime/docker/iptables.go
+++ b/runtime/docker/iptables.go
@@ -90,12 +90,15 @@ func (d *DockerRuntime) deleteIPTablesFwdRule() (err error) {
 		return nil
 	}
 
-	cmd := fmt.Sprintf(iptDelCmd, br)
+	cmd, err := shlex.Split(fmt.Sprintf(iptDelCmd, br))
+	if err != nil {
+		return err
+	}
 
 	log.Debugf("removing clab iptables rules for bridge %q", br)
 	log.Debugf("trying to delete the forwarding rule with cmd: iptables %s", cmd)
 
-	stdOutErr, err := exec.Command("iptables", strings.Split(cmd, " ")...).CombinedOutput()
+	stdOutErr, err := exec.Command("iptables", cmd...).CombinedOutput()
 	if err != nil {
 		log.Warnf("Iptables delete stdout/stderr result is: %s", stdOutErr)
 		return fmt.Errorf("unable to delete iptables rules: %w", err)

--- a/runtime/docker/iptables.go
+++ b/runtime/docker/iptables.go
@@ -63,7 +63,7 @@ func (d *DockerRuntime) deleteIPTablesFwdRule() (err error) {
 
 	br := d.mgmt.Bridge
 
-	if br == "" || br == "docker0" {
+	if br == "docker0" {
 		log.Debug("skipping deletion of iptables forwarding rule for non-bridged or default management network")
 		return
 	}


### PR DESCRIPTION
when using external bridges, the iptables removal logic was not using the bridge name.