### PR TITLE
Document CLAB_RUNTIME environment variable for deply command

### DIFF
--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -57,6 +57,15 @@ To export full topology data instead of a subset of fields exported by default, 
 
 ### Environment variables
 
+#### CLAB_RUNTIME
+
+Default value of "runtime" key for nodes, same as global `--runtime | -r` flag described above.
+Affects all containerlab commands in the same way, not just `deploy`.
+
+Intended to be set in environments where non-default container runtime should be used, to avoid needing to specify it for every command invocation or in every configuration file.
+
+Example command-line usage: `CLAB_RUNTIME=podman containerlab deploy`
+
 #### CLAB_VERSION_CHECK
 
 Can be set to "disable" value to prevent deploy command making a network request to check new version to report if one is available.


### PR DESCRIPTION
I've randomly noticed that CLAB_RUNTIME environemnt variable wasn't mentioned as an tunable for any of the containerlab command descriptions, and thought to propose adding it to deploy.md similar to how it was done with CLAB_VERSION_CHECK here: https://github.com/srl-labs/containerlab/pull/959#issuecomment-1200869163

One quirk is that afaiu it is env var affecting all subcommands, not just `deploy`, but `deploy` is first and arguably most notable one by far, so maybe it's ok just to dump such description there, in a similar fashion as its global `--runtime` option counterpart.

More proper alternative solution that I can think of, is to add some kind of "Overview" page to "Command reference" section of the documentation, with short listing of all global options and env vars, followed by listing of all supported commands with their short descriptions, similar to what you'd get in manpages or by running similar compound tools, e.g. `git` or `ip` without any subcommands.

EDIT: "... variable for deplOy command" is fixed in the commit msg