### PR TITLE
Wait for external container dependencies on deploy

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -337,7 +337,7 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 	timeout := time.After(time.Second * 3600)
 
 	// repeat retryCounter for log display
-	var retryCounter = 0
+	retryCounter := 0
 
 	// enter the ticker loop
 TIMEOUT_LOOP:
@@ -352,11 +352,13 @@ TIMEOUT_LOOP:
 				break TIMEOUT_LOOP
 			}
 			// if not, log and loop again
-			log.Infof("node %q depends on external container %q, which is not running yet. waited %d seconds. continue to wait", nodename, contName, tickFrequencySec*retryCounter)
+			log.Infof("node %q depends on external container %q, which is not running yet. waited %d seconds. continue to wait",
+				nodename, contName, tickFrequencySec*retryCounter)
 
 		case <-timeout:
 			// timeout reached, break with error log message
-			log.Errorf("node %q waited %d seconds for external dependency container %q to come up, which did not happen. Giving up now", nodename, waitTimeoutSec*tickFrequencySec, contName)
+			log.Errorf("node %q waited %d seconds for external dependency container %q to come up, which did not happen. Giving up now",
+				nodename, waitTimeoutSec*tickFrequencySec, contName)
 			break TIMEOUT_LOOP
 		}
 		// increment counter

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -346,7 +346,7 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 		if counter >= waitTimeoutCounter {
 			log.Errorf("container %q waited %d seconds for external dependency container %q to come up, which did not happen. Giving up now", nodename, waitTimeout*waitTimeoutCounter, contName)
 		}
-		log.Infof("container %q depends on external container %q, which is not running yet. waited %d seconds. will continue to wait", nodename, contName, waitTimeout)
+		log.Infof("container %q depends on external container %q, which is not running yet. waited %d seconds. continue to wait", nodename, contName, waitTimeout*counter)
 		// sleep until next try
 		time.Sleep(time.Second * time.Duration(waitTimeout))
 	}

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -340,6 +340,7 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 	var retryCounter = 0
 
 	// enter the ticker loop
+TIMEOUT_LOOP:
 	for {
 		select {
 		case <-ticker.C:
@@ -348,7 +349,7 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 			// check if dependency is running, if so break the loop
 			if runtimeStatus == runtime.Running {
 				log.Infof("node %q starts since external container %q is running now", nodename, contName)
-				break
+				break TIMEOUT_LOOP
 			}
 			// if not, log and loop again
 			log.Infof("node %q depends on external container %q, which is not running yet. waited %d seconds. continue to wait", nodename, contName, tickFrequencySec*retryCounter)
@@ -356,7 +357,7 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 		case <-timeout:
 			// timeout reached, break with error log message
 			log.Errorf("node %q waited %d seconds for external dependency container %q to come up, which did not happen. Giving up now", nodename, waitTimeoutSec*tickFrequencySec, contName)
-			break
+			break TIMEOUT_LOOP
 		}
 		// increment counter
 		retryCounter++

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -350,7 +350,6 @@ func (c *CLab) WaitForExternalNodeDependencies(ctx context.Context, nodename str
 		// sleep until next try
 		time.Sleep(time.Second * time.Duration(waitTimeout))
 	}
-	return
 }
 
 // CreateLinks creates links using the specified number of workers.

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -351,7 +351,7 @@ TIMEOUT_LOOP:
 
 			// if not, log and retry
 			log.Infof("node %q depends on external container %q, which is not running yet. Waited %s. Retrying...",
-				nodeName, contName, time.Since(startTime))
+				nodeName, contName, time.Since(startTime).Truncate(time.Second))
 
 		case <-timeout:
 			log.Errorf("node %q waited %s for external dependency container %q to come up, which did not happen. Giving up now",

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -829,3 +829,20 @@ func (c *ContainerdRuntime) DeleteContainer(ctx context.Context, containerID str
 func (c *ContainerdRuntime) GetHostsPath(context.Context, string) (string, error) {
 	return "", nil
 }
+
+// GetContainerStatus retrieves the ContainerStatus of the named container
+func (c *ContainerdRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+	task, err := c.getContainerTask(ctx, cID)
+	if err != nil {
+		return runtime.NotFound, err
+	}
+
+	status, err := task.Status(ctx)
+	switch status.Status {
+	case containerd.Running:
+		return runtime.Running, nil
+	case containerd.Created, containerd.Paused, containerd.Pausing, containerd.Stopped, containerd.Unknown:
+		return runtime.Stopped, nil
+	}
+	return runtime.NotFound, nil
+}

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -831,18 +831,22 @@ func (c *ContainerdRuntime) GetHostsPath(context.Context, string) (string, error
 }
 
 // GetContainerStatus retrieves the ContainerStatus of the named container
-func (c *ContainerdRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+func (c *ContainerdRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	task, err := c.getContainerTask(ctx, cID)
 	if err != nil {
-		return runtime.NotFound, err
+		return runtime.NotFound
 	}
 
 	status, err := task.Status(ctx)
+	if err != nil {
+		return runtime.NotFound
+	}
+
 	switch status.Status {
 	case containerd.Running:
-		return runtime.Running, nil
+		return runtime.Running
 	case containerd.Created, containerd.Paused, containerd.Pausing, containerd.Stopped, containerd.Unknown:
-		return runtime.Stopped, nil
+		return runtime.Stopped
 	}
-	return runtime.NotFound, nil
+	return runtime.NotFound
 }

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -549,7 +549,7 @@ func (c *ContainerdRuntime) ListContainers(ctx context.Context, filter []*types.
 	return c.produceGenericContainerList(ctx, containerlist)
 }
 
-// TODO this will probably not work. need to work out the exact filter format.
+// GetContainer: TODO this will probably not work. need to work out the exact filter format.
 func (c *ContainerdRuntime) GetContainer(ctx context.Context, containerID string) (*types.GenericContainer, error) {
 	var ctr *types.GenericContainer
 	gFilter := types.GenericFilter{

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -830,7 +830,7 @@ func (c *ContainerdRuntime) GetHostsPath(context.Context, string) (string, error
 	return "", nil
 }
 
-// GetContainerStatus retrieves the ContainerStatus of the named container
+// GetContainerStatus retrieves the ContainerStatus of the named container.
 func (c *ContainerdRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	task, err := c.getContainerTask(ctx, cID)
 	if err != nil {

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -549,7 +549,7 @@ func (c *ContainerdRuntime) ListContainers(ctx context.Context, filter []*types.
 	return c.produceGenericContainerList(ctx, containerlist)
 }
 
-// GetContainer: TODO this will probably not work. need to work out the exact filter format.
+// GetContainer TODO this will probably not work. need to work out the exact filter format.
 func (c *ContainerdRuntime) GetContainer(ctx context.Context, containerID string) (*types.GenericContainer, error) {
 	var ctr *types.GenericContainer
 	gFilter := types.GenericFilter{

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -113,7 +113,7 @@ func (d *DockerRuntime) WithMgmtNet(n *types.MgmtNet) {
 	}
 }
 
-// CreateDockerNet creates a docker network or reusing if it exists.
+// CreateNet creates a docker network or reusing if it exists.
 func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, d.config.Timeout)
 	defer cancel()

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -844,16 +844,16 @@ func (d *DockerRuntime) processNetworkMode(
 }
 
 // GetContainerStatus retrieves the ContainerStatus of the named container
-func (d *DockerRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+func (d *DockerRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	inspect, err := d.Client.ContainerInspect(ctx, cID)
 	if err != nil {
-		return runtime.NotFound, err
+		return runtime.NotFound
 	}
 	switch inspect.State.Status {
 	case "running":
-		return runtime.Running, nil
+		return runtime.Running
 	case "created", "paused", "restarting", "removing", "exited", "dead":
-		return runtime.Stopped, nil
+		return runtime.Stopped
 	}
-	return runtime.NotFound, nil
+	return runtime.NotFound
 }

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -842,3 +842,18 @@ func (d *DockerRuntime) processNetworkMode(
 
 	return nil
 }
+
+// GetContainerStatus retrieves the ContainerStatus of the named container
+func (d *DockerRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+	inspect, err := d.Client.ContainerInspect(ctx, cID)
+	if err != nil {
+		return runtime.NotFound, err
+	}
+	switch inspect.State.Status {
+	case "running":
+		return runtime.Running, nil
+	case "created", "paused", "restarting", "removing", "exited", "dead":
+		return runtime.Stopped, nil
+	}
+	return runtime.NotFound, nil
+}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -843,7 +843,7 @@ func (d *DockerRuntime) processNetworkMode(
 	return nil
 }
 
-// GetContainerStatus retrieves the ContainerStatus of the named container
+// GetContainerStatus retrieves the ContainerStatus of the named container.
 func (d *DockerRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	inspect, err := d.Client.ContainerInspect(ctx, cID)
 	if err != nil {

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -441,3 +441,15 @@ func (c *IgniteRuntime) DeleteContainer(ctx context.Context, containerID string)
 func (c *IgniteRuntime) GetHostsPath(context.Context, string) (string, error) {
 	return "", nil
 }
+
+// GetContainerStatus retrieves the ContainerStatus of the named container
+func (c *IgniteRuntime) GetContainerStatus(ctx context.Context, containerID string) (runtime.ContainerStatus, error) {
+	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(containerID))
+	if err != nil {
+		return runtime.NotFound, err
+	}
+	if vm.Status.Running {
+		return runtime.Running, nil
+	}
+	return runtime.Stopped, nil
+}

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -443,13 +443,13 @@ func (c *IgniteRuntime) GetHostsPath(context.Context, string) (string, error) {
 }
 
 // GetContainerStatus retrieves the ContainerStatus of the named container
-func (c *IgniteRuntime) GetContainerStatus(ctx context.Context, containerID string) (runtime.ContainerStatus, error) {
+func (c *IgniteRuntime) GetContainerStatus(ctx context.Context, containerID string) runtime.ContainerStatus {
 	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(containerID))
 	if err != nil {
-		return runtime.NotFound, err
+		return runtime.NotFound
 	}
 	if vm.Status.Running {
-		return runtime.Running, nil
+		return runtime.Running
 	}
-	return runtime.Stopped, nil
+	return runtime.Stopped
 }

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -443,7 +443,7 @@ func (c *IgniteRuntime) GetHostsPath(context.Context, string) (string, error) {
 }
 
 // GetContainerStatus retrieves the ContainerStatus of the named container
-func (c *IgniteRuntime) GetContainerStatus(ctx context.Context, containerID string) runtime.ContainerStatus {
+func (c *IgniteRuntime) GetContainerStatus(_ context.Context, containerID string) runtime.ContainerStatus {
 	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(containerID))
 	if err != nil {
 		return runtime.NotFound

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -442,7 +442,7 @@ func (c *IgniteRuntime) GetHostsPath(context.Context, string) (string, error) {
 	return "", nil
 }
 
-// GetContainerStatus retrieves the ContainerStatus of the named container
+// GetContainerStatus retrieves the ContainerStatus of the named container.
 func (c *IgniteRuntime) GetContainerStatus(_ context.Context, containerID string) runtime.ContainerStatus {
 	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(containerID))
 	if err != nil {

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -323,17 +323,17 @@ func (r *PodmanRuntime) GetHostsPath(ctx context.Context, cID string) (string, e
 }
 
 // GetContainerStatus retrieves the ContainerStatus of the named container
-func (r *PodmanRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+func (r *PodmanRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	ctx, err := r.connect(ctx)
 	if err != nil {
-		return runtime.NotFound, err
+		return runtime.NotFound
 	}
 	icd, err := containers.Inspect(ctx, cID, nil)
 	if err != nil {
-		return runtime.NotFound, nil
+		return runtime.NotFound
 	}
 	if icd.State.Running {
-		return runtime.Running, nil
+		return runtime.Running
 	}
-	return runtime.Stopped, nil
+	return runtime.Stopped
 }

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -322,7 +322,7 @@ func (r *PodmanRuntime) GetHostsPath(ctx context.Context, cID string) (string, e
 	return hostsPath, nil
 }
 
-// GetContainerStatus retrieves the ContainerStatus of the named container
+// GetContainerStatus retrieves the ContainerStatus of the named container.
 func (r *PodmanRuntime) GetContainerStatus(ctx context.Context, cID string) runtime.ContainerStatus {
 	ctx, err := r.connect(ctx)
 	if err != nil {

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -321,3 +321,19 @@ func (r *PodmanRuntime) GetHostsPath(ctx context.Context, cID string) (string, e
 	log.Debugf("Method GetHostsPath was called with a resulting path %q", hostsPath)
 	return hostsPath, nil
 }
+
+// GetContainerStatus retrieves the ContainerStatus of the named container
+func (r *PodmanRuntime) GetContainerStatus(ctx context.Context, cID string) (runtime.ContainerStatus, error) {
+	ctx, err := r.connect(ctx)
+	if err != nil {
+		return runtime.NotFound, err
+	}
+	icd, err := containers.Inspect(ctx, cID, nil)
+	if err != nil {
+		return runtime.NotFound, nil
+	}
+	if icd.State.Running {
+		return runtime.Running, nil
+	}
+	return runtime.Stopped, nil
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -59,7 +59,17 @@ type ContainerRuntime interface {
 	GetName() string
 	// GetHostsPath returns fs path to a file which is mounted as /etc/hosts into a given container
 	GetHostsPath(context.Context, string) (string, error)
+	// GetContainerStatus retrieves the ContainerStatus of the named container
+	GetContainerStatus(ctx context.Context, cID string) (ContainerStatus, error)
 }
+
+type ContainerStatus string
+
+const (
+	NotFound = "NotFound"
+	Running  = "Running"
+	Stopped  = "Stopped"
+)
 
 type Initializer func() ContainerRuntime
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -60,7 +60,7 @@ type ContainerRuntime interface {
 	// GetHostsPath returns fs path to a file which is mounted as /etc/hosts into a given container
 	GetHostsPath(context.Context, string) (string, error)
 	// GetContainerStatus retrieves the ContainerStatus of the named container
-	GetContainerStatus(ctx context.Context, cID string) (ContainerStatus, error)
+	GetContainerStatus(ctx context.Context, cID string) ContainerStatus
 }
 
 type ContainerStatus string


### PR DESCRIPTION
By querying the runtime I want to figure out if the external containers that denpending containers rely up on are already running and only then start to actually deploy the dependent container.