### PR TITLE
Docs - Include examples in the table of content (and add examples)

### DIFF
--- a/docs/cmd/completion.md
+++ b/docs/cmd/completion.md
@@ -43,10 +43,10 @@ Start a new shell for this setup to take effect.
 
 #### Fish completions
 ```bash
-containerlab completion fish | source
+❯ containerlab completion fish | source
 ```
 
 To load completions for each session, execute once:
 ```
-containerlab completion fish > ~/.config/fish/completions/containerlab.fish
+❯ containerlab completion fish > ~/.config/fish/completions/containerlab.fish
 ```

--- a/docs/cmd/completion.md
+++ b/docs/cmd/completion.md
@@ -43,10 +43,10 @@ Start a new shell for this setup to take effect.
 
 #### Fish completions
 ```bash
-❯ containerlab completion fish | source
+containerlab completion fish | source
 ```
 
 To load completions for each session, execute once:
 ```
-❯ containerlab completion fish > ~/.config/fish/completions/containerlab.fish
+containerlab completion fish > ~/.config/fish/completions/containerlab.fish
 ```

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -70,13 +70,13 @@ Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 #### Deploy a lab using the given topology file
 
 ```bash
-containerlab deploy -t mylab.clab.yml
+❯ containerlab deploy -t mylab.clab.yml
 ```
 
 #### Deploy a lab and regenerate all configuration artifacts
 
 ```bash
-containerlab deploy -t mylab.clab.yml --reconfigure
+❯ containerlab deploy -t mylab.clab.yml --reconfigure
 ```
 
 #### Deploy a lab without specifying topology file
@@ -84,11 +84,11 @@ containerlab deploy -t mylab.clab.yml --reconfigure
 Given that a single topology file is present in the current directory.
 
 ```bash
-containerlab deploy
+❯ containerlab deploy
 ```
 
 #### Deploy a lab using shortcut names
 ```bash
-clab dep -t mylab.clab.yml
+❯ clab dep -t mylab.clab.yml
 ```
 

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -67,10 +67,28 @@ Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 
 ### Examples
 
-```bash
-# deploy a lab from mylab.clab.yml file located in the same dir
-containerlab deploy -t mylab.clab.yml
+#### Deploy a lab using the given topology file
 
-# deploy a lab from mylab.clab.yml file and regenerate all configuration artifacts
+```bash
+containerlab deploy -t mylab.clab.yml
+```
+
+#### Deploy a lab and regenerate all configuration artifacts
+
+```bash
 containerlab deploy -t mylab.clab.yml --reconfigure
 ```
+
+#### Deploy a lab without specifying topology file
+
+Given that a single topology file is present in the current directory.
+
+```bash
+containerlab deploy
+```
+
+#### Deploy a lab using shortcut names
+```bash
+clab dep -t mylab.clab.yml
+```
+

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -70,13 +70,13 @@ Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 #### Deploy a lab using the given topology file
 
 ```bash
-❯ containerlab deploy -t mylab.clab.yml
+containerlab deploy -t mylab.clab.yml
 ```
 
 #### Deploy a lab and regenerate all configuration artifacts
 
 ```bash
-❯ containerlab deploy -t mylab.clab.yml --reconfigure
+containerlab deploy -t mylab.clab.yml --reconfigure
 ```
 
 #### Deploy a lab without specifying topology file
@@ -84,11 +84,11 @@ Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 Given that a single topology file is present in the current directory.
 
 ```bash
-❯ containerlab deploy
+containerlab deploy
 ```
 
-#### Deploy a lab using shortcut names
+#### Deploy a lab using short flag names
 ```bash
-❯ clab dep -t mylab.clab.yml
+clab dep -t mylab.clab.yml
 ```
 

--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -40,13 +40,13 @@ Destroy command provided with `--all | -a` flag will perform the deletion of all
 #### Destroy a lab described in the given topology file
 
 ```bash
-containerlab destroy -t mylab.clab.yml
+❯ containerlab destroy -t mylab.clab.yml
 ```
 
 #### Destroy a lab and remove the Lab directory
 
 ```bash
-containerlab destroy -t mylab.clab.yml --cleanup
+❯ containerlab destroy -t mylab.clab.yml --cleanup
 ```
 
 #### Destroy a lab without specifying topology file
@@ -54,18 +54,18 @@ containerlab destroy -t mylab.clab.yml --cleanup
 Given that a single topology file is present in the current directory.
 
 ```bash
-containerlab destroy
+❯ containerlab destroy
 ```
 
 #### Destroy all labs on the container host
 
 ```bash
-containerlab destroy -a
+❯ containerlab destroy -a
 ```
 
 
 #### Destroy a lab using shortcut names
 
 ```bash
-clab des
+❯ clab des
 ```

--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -40,13 +40,13 @@ Destroy command provided with `--all | -a` flag will perform the deletion of all
 #### Destroy a lab described in the given topology file
 
 ```bash
-❯ containerlab destroy -t mylab.clab.yml
+containerlab destroy -t mylab.clab.yml
 ```
 
 #### Destroy a lab and remove the Lab directory
 
 ```bash
-❯ containerlab destroy -t mylab.clab.yml --cleanup
+containerlab destroy -t mylab.clab.yml --cleanup
 ```
 
 #### Destroy a lab without specifying topology file
@@ -54,18 +54,18 @@ Destroy command provided with `--all | -a` flag will perform the deletion of all
 Given that a single topology file is present in the current directory.
 
 ```bash
-❯ containerlab destroy
+containerlab destroy
 ```
 
 #### Destroy all labs on the container host
 
 ```bash
-❯ containerlab destroy -a
+containerlab destroy -a
 ```
 
 
-#### Destroy a lab using shortcut names
+#### Destroy a lab using short flag names
 
 ```bash
-❯ clab des
+clab des
 ```

--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -37,14 +37,35 @@ Destroy command provided with `--all | -a` flag will perform the deletion of all
 
 ### Examples
 
+#### Destroy a lab described in the given topology file
+
 ```bash
-# destroy a lab based on mylab.clab.yml topology file located in the same dir
 containerlab destroy -t mylab.clab.yml
+```
 
-# destroy a lab and also remove the Lab Directory
+#### Destroy a lab and remove the Lab directory
+
+```bash
 containerlab destroy -t mylab.clab.yml --cleanup
+```
 
-# destroy all labs deployed with containerlab
-# using shortcut names
-clab des -a
+#### Destroy a lab without specifying topology file
+
+Given that a single topology file is present in the current directory.
+
+```bash
+containerlab destroy
+```
+
+#### Destroy all labs on the container host
+
+```bash
+containerlab destroy -a
+```
+
+
+#### Destroy a lab using shortcut names
+
+```bash
+clab des
 ```

--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -46,7 +46,7 @@ INFO[0000] clab-srl02-srl2: stdout:
     inet 172.20.20.2/24 brd 172.20.20.255 scope global dummy-mgmt0
        valid_lft forever preferred_lft forever
 ```
-#### Execute a command on one node by name
+#### Execute a command on a node referenced by its name
 
 Show ipv4 information from a specific node of the lab with a plain text output
 
@@ -59,7 +59,7 @@ INFO[0000] Executed command 'ip -4 a show dummy-mgmt0' on clab-srl02-srl2. stdou
        valid_lft forever preferred_lft forever 
 ```
 
-#### Execute a SR Linux CLI Command
+#### Execute a CLI Command
 
 ```bash
 ❯ containerlab exec -t srl02.yml --cmd 'sr_cli  "show version"'
@@ -93,7 +93,7 @@ Free Memory       : 21911914 kB
 ----------------------------------------------------
 ```
 
-#### Execute a SR Linux CLI Command with json formatted output
+#### Execute a Command with json formatted output
 
 ```bash
 ❯ containerlab exec -t srl02.yml --cmd 'sr_cli  "show version | as json"' -f json | jq

--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -44,6 +44,14 @@ INFO[0000] clab-srl02-srl2: stdout:
     inet 172.20.20.2/24 brd 172.20.20.255 scope global dummy-mgmt0
        valid_lft forever preferred_lft forever
 
+# show ipv4 information from a specific node of the lab
+# with a plain text output
+❯ containerlab exec -t srl02.yml --label clab-node-name\=srl2 --cmd 'ip -4 a show dummy-mgmt0'
+INFO[0000] Parsing & checking topology file: srl02.yml  
+INFO[0000] Executed command 'ip -4 a show dummy-mgmt0' on clab-srl02-srl2. stdout:
+6: dummy-mgmt0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    inet 172.20.20.5/24 brd 172.20.20.255 scope global dummy-mgmt0
+       valid_lft forever preferred_lft forever 
 
 # execute a CLI command with a plain text output
 ❯ containerlab exec -t srl02.yml --cmd 'sr_cli  "show version"'

--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -31,9 +31,11 @@ By default `exec` command will attempt to execute the command across all the nod
 
 ### Examples
 
+#### Execute a command on all nodes of the lab
+
+Show ipv4 information from all the nodes of the lab with a plain text output
+
 ```bash
-# show ipv4 information from all the nodes of the lab
-# with a plain text output
 ❯ containerlab exec -t srl02.yml --cmd 'ip -4 a show dummy-mgmt0'
 INFO[0000] clab-srl02-srl1: stdout:
 6: dummy-mgmt0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
@@ -43,17 +45,23 @@ INFO[0000] clab-srl02-srl2: stdout:
 6: dummy-mgmt0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
     inet 172.20.20.2/24 brd 172.20.20.255 scope global dummy-mgmt0
        valid_lft forever preferred_lft forever
+```
+#### Execute a command on one node by name
 
-# show ipv4 information from a specific node of the lab
-# with a plain text output
+Show ipv4 information from a specific node of the lab with a plain text output
+
+```bash
 ❯ containerlab exec -t srl02.yml --label clab-node-name\=srl2 --cmd 'ip -4 a show dummy-mgmt0'
 INFO[0000] Parsing & checking topology file: srl02.yml  
 INFO[0000] Executed command 'ip -4 a show dummy-mgmt0' on clab-srl02-srl2. stdout:
 6: dummy-mgmt0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
     inet 172.20.20.5/24 brd 172.20.20.255 scope global dummy-mgmt0
        valid_lft forever preferred_lft forever 
+```
 
-# execute a CLI command with a plain text output
+#### Execute a SR Linux CLI Command
+
+```bash
 ❯ containerlab exec -t srl02.yml --cmd 'sr_cli  "show version"'
 INFO[0001] clab-srl02-srl1: stdout:
 ----------------------------------------------------
@@ -83,9 +91,11 @@ Last Booted       : 2021-06-24T10:25:26.904Z
 Total Memory      : 24052875 kB
 Free Memory       : 21911914 kB
 ----------------------------------------------------
+```
 
+#### Execute a SR Linux CLI Command with json formatted output
 
-# execute a CLI command with a json output
+```bash
 ❯ containerlab exec -t srl02.yml --cmd 'sr_cli  "show version | as json"' -f json | jq
 {
   "clab-srl02-srl1": {

--- a/docs/cmd/generate.md
+++ b/docs/cmd/generate.md
@@ -105,7 +105,7 @@ Generate and deploy a lab topology for 3-tier CLOS network with 8 leafs, 4 spine
     The `srl` kind in the image and license flags can be omitted, as it is implied by default
 
 ```bash
-containerlab generate --name 3tier --image srl=srlinux:latest \
+❯ containerlab generate --name 3tier --image srl=srlinux:latest \
                       --license srl=license.key \
                       --nodes 8,4,2 --deploy
 ```

--- a/docs/cmd/generate.md
+++ b/docs/cmd/generate.md
@@ -105,7 +105,7 @@ Generate and deploy a lab topology for 3-tier CLOS network with 8 leafs, 4 spine
     The `srl` kind in the image and license flags can be omitted, as it is implied by default
 
 ```bash
-❯ containerlab generate --name 3tier --image srl=srlinux:latest \
+containerlab generate --name 3tier --image srl=srlinux:latest \
                       --license srl=license.key \
                       --nodes 8,4,2 --deploy
 ```

--- a/docs/cmd/generate.md
+++ b/docs/cmd/generate.md
@@ -98,13 +98,13 @@ With `--ipv4-subnet` and `ipv6-subnet` its possible to change the address ranges
 
 ### Examples
 
-```bash
-# generate and deploy a lab topology for 3-tier CLOS network
-# with 8 leafs, 4 spines and 2 superspines
-# all using Nokia SR Linux nodes with license and image provided.
-# Note that `srl` kind in the image and license flags might be omitted,
-# as it is implied by default)
+#### Generate topology for a 3-tier CLOS network
+Generate and deploy a lab topology for 3-tier CLOS network with 8 leafs, 4 spines and 2 superspines. All using Nokia SR Linux nodes with license and image provided.
 
+!!! note
+    The `srl` kind in the image and license flags can be omitted, as it is implied by default
+
+```bash
 containerlab generate --name 3tier --image srl=srlinux:latest \
                       --license srl=license.key \
                       --nodes 8,4,2 --deploy

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -102,17 +102,30 @@ With `--dot` flag provided containerlab will generate the `dot` file instead of 
 
 ### Examples
 
+#### Render graph of topology on HTML server
+
+This will render the running lab if the lab is running and the topology file if it isn't. Default options will be used (HTML server running on port `50080`).
+
 ```bash
+containerlab graph -t /path/to/topo1.clab.yml
+```
 
-# render a graph from running lab or topo file if lab is not running#
-# using HTML graph option with default server address :50080
-containerlab graph --topo /path/to/topo1.clab.yml
+#### Render graph on specified http server port
 
-# start an http server on :3002 where topo1 graph will be rendered using a custom template my_template.html
-containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002" --template my_template.html
+```bash
+containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002"
+```
 
-# start an http server on default port :50080 
-# using a custom template that links to local files located at /path/to/static_files directory
+#### Render graph using a custom html template
+
+```bash
+containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html
+```
+
+#### Render graph using a custom template that links to local files
+
+The HTML server will use a custom template that links to local files located at /path/to/static_files directory
+```bash
 containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html --static-dir /path/to/static_files
 ```
 

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -107,26 +107,26 @@ With `--dot` flag provided containerlab will generate the `dot` file instead of 
 This will render the running lab if the lab is running and the topology file if it isn't. Default options will be used (HTML server running on port `50080`).
 
 ```bash
-containerlab graph -t /path/to/topo1.clab.yml
+❯ containerlab graph -t /path/to/topo1.clab.yml
 ```
 
 #### Render graph on specified http server port
 
 ```bash
-containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002"
+❯ containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002"
 ```
 
 #### Render graph using a custom html template
 
 ```bash
-containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html
+❯ containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html
 ```
 
 #### Render graph using a custom template that links to local files
 
 The HTML server will use a custom template that links to local files located at /path/to/static_files directory
 ```bash
-containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html --static-dir /path/to/static_files
+❯ containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html --static-dir /path/to/static_files
 ```
 
 [^1]: This method is prone to errors when node names contain dashes and special symbols. Use with caution, and prefer the HTML server alternative.

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -107,7 +107,7 @@ With `--dot` flag provided containerlab will generate the `dot` file instead of 
 This will render the running lab if the lab is running and the topology file if it isn't. Default options will be used (HTML server running on port `50080`).
 
 ```bash
-❯ containerlab graph -t /path/to/topo1.clab.yml
+containerlab graph -t /path/to/topo1.clab.yml
 ```
 
 #### Render graph on specified http server port

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -113,20 +113,20 @@ This will render the running lab if the lab is running and the topology file if 
 #### Render graph on specified http server port
 
 ```bash
-❯ containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002"
+containerlab graph --topo /path/to/topo1.clab.yml --srv ":3002"
 ```
 
 #### Render graph using a custom html template
 
 ```bash
-❯ containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html
+containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html
 ```
 
 #### Render graph using a custom template that links to local files
 
 The HTML server will use a custom template that links to local files located at /path/to/static_files directory
 ```bash
-❯ containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html --static-dir /path/to/static_files
+containerlab graph --topo /path/to/topo1.clab.yml --template my_template.html --static-dir /path/to/static_files
 ```
 
 [^1]: This method is prone to errors when node names contain dashes and special symbols. Use with caution, and prefer the HTML server alternative.

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -34,8 +34,9 @@ With this flag inspect command will output every bit of information about the ru
 
 ### Examples
 
+#### List all running labs on the host
+
 ```bash
-# list all running labs on the host
 containerlab inspect --all
 +---+------------+----------+-----------------+--------------+--------------------+------+-------+---------+----------------+----------------------+
 | # | Topo Path  | Lab Name |      Name       | Container ID |       Image        | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
@@ -45,7 +46,11 @@ containerlab inspect --all
 | 3 | srl02.yml  | srl01    | clab-srl01-srl  | 13c9e7543771 | srlinux:20.6.3-145 | srl  |       | running | 172.20.20.2/24 | 2001:172:20:20::2/80 |
 | 4 |            |          | clab-srl01-srl2 | 8cfca93b7b6f | srlinux:20.6.3-145 | srl  |       | running | 172.20.20.3/24 | 2001:172:20:20::3/80 |
 +---+------------+----------+-----------------+--------------+--------------------+------+-------+---------+----------------+----------------------+
+```
 
+#### Provide information about a specific running lab
+
+```bash
 # provide information about the running lab named srl02
 containerlab inspect --name srlceos01
 +---+---------------------+--------------+---------+------+-------+---------+----------------+----------------------+
@@ -55,8 +60,11 @@ containerlab inspect --name srlceos01
 | 2 | clab-srlceos01-srl  | 82e9aa3c7e6b | srlinux | srl  |       | running | 172.20.20.3/24 | 2001:172:20:20::3/80 |
 +---+---------------------+--------------+---------+------+-------+---------+----------------+----------------------+
 
+```
 
-# now in json format
+#### Provide information about a specific running lab in json format
+
+```bash
 containerlab inspect --name srlceos01 -f json
 [
   {

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -48,9 +48,9 @@ With this flag inspect command will output every bit of information about the ru
 +---+------------+----------+-----------------+--------------+--------------------+------+-------+---------+----------------+----------------------+
 ```
 
-#### Provide information about a specific running lab
+#### Provide information about a specific running lab by its name
 
-Provide information about the running lab named `srl02`
+Provide information about the running lab named `srlceos01`
 
 ```bash
 ❯ containerlab inspect --name srlceos01
@@ -60,7 +60,19 @@ Provide information about the running lab named `srl02`
 | 1 | clab-srlceos01-ceos | 90bebb1e2c5f | ceos    | ceos |       | running | 172.20.20.4/24 | 2001:172:20:20::4/80 |
 | 2 | clab-srlceos01-srl  | 82e9aa3c7e6b | srlinux | srl  |       | running | 172.20.20.3/24 | 2001:172:20:20::3/80 |
 +---+---------------------+--------------+---------+------+-------+---------+----------------+----------------------+
+```
 
+#### Provide information about a specific running lab by its topology file
+
+```bash
+clab inspect -t srl02.clab.yml 
+INFO[0000] Parsing & checking topology file: srl02.clab.yml 
++---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
+| # |      Name       | Container ID |         Image         | Kind |  State  |  IPv4 Address  |     IPv6 Address     |
++---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
+| 1 | clab-srl02-srl1 | 7a7c101be7d8 | ghcr.io/nokia/srlinux | srl  | running | 172.20.20.4/24 | 2001:172:20:20::4/64 |
+| 2 | clab-srl02-srl2 | 5e3737621753 | ghcr.io/nokia/srlinux | srl  | running | 172.20.20.5/24 | 2001:172:20:20::5/64 |
++---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
 ```
 
 #### Provide information about a specific running lab in json format
@@ -90,3 +102,4 @@ Provide information about the running lab named `srl02`
   }
 ]
 ```
+

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -37,7 +37,7 @@ With this flag inspect command will output every bit of information about the ru
 #### List all running labs on the host
 
 ```bash
-containerlab inspect --all
+❯ containerlab inspect --all
 +---+------------+----------+-----------------+--------------+--------------------+------+-------+---------+----------------+----------------------+
 | # | Topo Path  | Lab Name |      Name       | Container ID |       Image        | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+------------+----------+-----------------+--------------+--------------------+------+-------+---------+----------------+----------------------+
@@ -50,9 +50,10 @@ containerlab inspect --all
 
 #### Provide information about a specific running lab
 
+Provide information about the running lab named `srl02`
+
 ```bash
-# provide information about the running lab named srl02
-containerlab inspect --name srlceos01
+❯ containerlab inspect --name srlceos01
 +---+---------------------+--------------+---------+------+-------+---------+----------------+----------------------+
 | # |        Name         | Container ID |  Image  | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+---------------------+--------------+---------+------+-------+---------+----------------+----------------------+
@@ -65,7 +66,7 @@ containerlab inspect --name srlceos01
 #### Provide information about a specific running lab in json format
 
 ```bash
-containerlab inspect --name srlceos01 -f json
+❯ containerlab inspect --name srlceos01 -f json
 [
   {
     "lab_name": "srlceos01",

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -65,7 +65,7 @@ Provide information about the running lab named `srlceos01`
 #### Provide information about a specific running lab by its topology file
 
 ```bash
-clab inspect -t srl02.clab.yml 
+❯ clab inspect -t srl02.clab.yml 
 INFO[0000] Parsing & checking topology file: srl02.clab.yml 
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
 | # |      Name       | Container ID |         Image         | Kind |  State  |  IPv4 Address  |     IPv6 Address     |

--- a/docs/cmd/save.md
+++ b/docs/cmd/save.md
@@ -27,8 +27,11 @@ When the topology file flag is omitted, containerlab will try to find the matchi
 
 ### Examples
 
+#### Save the configuration of the containers in a specific lab
+
+Save the configuration of the containers running in lab named srl02
+
 ```bash
-# save the configuration of the containers running in lab named srl02
 ❯ containerlab save -n srl02
 INFO[0001] clab-srl02-srl1: stdout: /system:
     Generated checkpoint '/etc/opt/srlinux/checkpoint/checkpoint-0.json' with name 'checkpoint-2020-11-18T09:00:54.998Z' and comment ''


### PR DESCRIPTION
Being able to quickly navigate to a certain example or send a link for an example is really useful. 
- Adds the examples to a command's table of content (similar to [gnmic docs](https://gnmic.kmrd.dev/cmd/capabilities/#single-host))
- Split examples and a couple for certain commands (includes PR #1029)
- All commands typed into terminal start with `❯ ` to distinguish them from the output (following the format on the `exec` page)