### PR TITLE
changed cvx default runtime to docker

### DIFF
--- a/docs/manual/kinds/cvx.md
+++ b/docs/manual/kinds/cvx.md
@@ -6,20 +6,23 @@ search:
 
 [Cumulus VX](https://docs.nvidia.com/networking-ethernet-software/cumulus-vx/) is identified with `cvx` or `cumulus_cvx` kind in the [topology file](../topo-def-file.md). The `cvx` kind defines a supported feature set and a startup procedure of a `cvx` node.
 
-CVX nodes launched with containerlab comes up with:
+CVX nodes launched with containerlab come up with:
 
-* the management interface `eth0` configured with IPv4/6 addresses as assigned by either the container runtime or DHCP
+* the management interface `eth0` is configured with IPv4/6 addresses as assigned by either the container runtime or DHCP
 * `root` user created with password `root`
 
 ## Mode of operation
 
 CVX supports two modes of operation:
 
-* Using Firecracker micro-VMs -- this mode runs Cumulus VX inside a micro-VM on top of the native Cumulus kernel. This is mode uses `ignite` runtime and is the default way of running CVX nodes.
-* Using only the container runtime -- this mode runs Cumulus VX container image directly inside the container runtime (e.g. Docker). Due to the lack of Cumulus VX kernel modules, some features are not supported, most notable one being MLAG. In order to use this mode add `runtime: docker` under the cvx node definition (see also [this example](https://github.com/srl-labs/containerlab/blob/main/lab-examples/cvx02/topo.clab.yml)).
+* Using only the container runtime -- this mode runs Cumulus VX container image directly inside the container runtime (e.g. Docker). Due to the lack of Cumulus VX kernel modules, some features are not supported, most notable one being MLAG. In order to use this mode, add `runtime: docker` under the cvx node definition (see also [this example](https://github.com/srl-labs/containerlab/blob/main/lab-examples/cvx02/topo.clab.yml)).
+* Using Firecracker micro-VMs -- this mode runs Cumulus VX inside a micro-VM on top of the native Cumulus kernel. This mode uses `ignite` runtime and is the default way of running CVX nodes.
+
+    !!!warning
+        This mode doesn't work with containerlab > v0.27.1 due to dependencies issues in ignite[^2]. Install containerlab v0.27.1 or older to get ignite-based cvx nodes.
 
 !!! note
-    When running in the default `ignite` runtime mode, the only host OS dependency is `/dev/kvm`[^1] required to support harware-assisted virtualisation. Firecracker VMs are spun up inside a special "sandbox" container that has all the right tools and dependencies required to run micro-VMs.
+    When running in the default `ignite` runtime mode, the only host OS dependency is `/dev/kvm`[^1] required to support hardware-assisted virtualisation. Firecracker VMs are spun up inside a special "sandbox" container that has all the right tools and dependencies required to run micro-VMs.
 
     Additionally, containerlab creates a number of directories under `/var/lib/firecracker` for nodes running in `ignite` runtime to store runtime metadata; these directories are managed by containerlab.
 
@@ -45,7 +48,7 @@ Cumulus VX node launched with containerlab can be managed via the following inte
 !!!info
     Default user credentials: `root:root`
 
-#### User defined config
+### User-defined config
 
 It is possible to make cvx nodes to boot up with a user-defined config by passing any number of files along with their desired mount path:
 
@@ -61,7 +64,7 @@ topology:
         - cvx/frr.conf:/etc/frr/frr.conf
 ```
 
-### Note on configuration persistency
+### Configuration persistency
 
 When running inside the `ignite` runtime, all mount binds work one way -- from host OS to the cvx node, but not the other way around. Currently, it's up to a user to manually update individual files if configuration updates need to be persisted.
 This will be addressed in the future releases.
@@ -80,3 +83,4 @@ The following labs feature CVX node:
 * CVX in Ignite is always attached to the default docker bridge network
 
 [^1]: this device is already part of the linux kernel, therefore this can be read as "no external dependencies are needed for running cvx with `ignite` runtime".
+[^2]: see <https://github.com/srl-labs/containerlab/pull/1037> and <https://github.com/srl-labs/containerlab/issues/1039>

--- a/nodes/cvx/cvx.go
+++ b/nodes/cvx/cvx.go
@@ -27,7 +27,6 @@ func init() {
 	nodes.Register(kindnames, func() nodes.Node {
 		return new(cvx)
 	})
-	nodes.SetNonDefaultRuntimePerKind(kindnames, runtime.IgniteRuntime)
 }
 
 type cvx struct {


### PR DESCRIPTION
ignite support is broken with k8s.io/apimachinery >0.22
for that reason we sunset ignite support