### PR TITLE
Config Engine: Skip template-paths without templates for a role & expose clab_type

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -42,7 +42,7 @@ func LoadTemplates(tmpl *template.Template, role string) error {
 		if err != nil {
 			if strings.Contains(err.Error(), "pattern matches no file") {
 				log.Debug(err)
-				return nil
+				continue
 			}
 			return fmt.Errorf("could not load templates from %s: %w", fn, err)
 		}

--- a/clab/config/utils.go
+++ b/clab/config/utils.go
@@ -22,6 +22,7 @@ const (
 	vkManagementIPv4 = "clab_management_ipv4" // reserved, management IPv4 of the node
 	vkManagementIPv6 = "clab_management_ipv6" // reserved, management IPv6 of the node
 	vkKind           = "clab_kind"            // reserved, will contain the node kind
+	vkType           = "clab_type"            // reserved, will contain the node type
 
 	vkSystemIP = "clab_system_ip" // optional, system IP if present could be used to calc link IPs
 	vkLinkIP   = "clab_link_ip"   // optional, link IP
@@ -44,6 +45,7 @@ func PrepareVars(nodes map[string]nodes.Node, links map[int]*types.Link) map[str
 		vars[vkKind] = nodeCfg.Kind
 		vars[vkManagementIPv4] = nodeCfg.MgmtIPv4Address
 		vars[vkManagementIPv6] = nodeCfg.MgmtIPv6Address
+		vars[vkType] = nodeCfg.NodeType
 
 		// Init array for this node
 		for key, val := range nodeCfg.Config.Vars {


### PR DESCRIPTION
When we search for templates in a list of template-paths the current implementation (incorrectly) stops searching when there are no templates available for a role in a path.

This PR allows the code to continue searching through the remainder of the template-paths (the code already prints a debug message)

Today, the workaround is to create empty/dummy templates

The second part of the PR exposes the node type as `clab_type` in the config engine variables