### PR TITLE
fix default bridge use

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -84,6 +84,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
+		clab.WithTopoFile(topo, varsFile),
 		clab.WithRuntime(rt,
 			&runtime.RuntimeConfig{
 				Debug:            debug,
@@ -91,7 +92,6 @@ func deployFn(_ *cobra.Command, _ []string) error {
 				GracefulShutdown: graceful,
 			},
 		),
-		clab.WithTopoFile(topo, varsFile),
 	}
 	c, err := clab.NewContainerLab(opts...)
 	if err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -51,13 +51,6 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
-		clab.WithRuntime(rt,
-			&runtime.RuntimeConfig{
-				Debug:            debug,
-				Timeout:          timeout,
-				GracefulShutdown: graceful,
-			},
-		),
 	}
 
 	if keepMgmtNet {
@@ -70,7 +63,19 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 	case !all:
 		topos[topo] = struct{}{}
 	case all:
-		c, err := clab.NewContainerLab(opts...)
+		// only WithRuntime option is needed to list all containers of a lab
+		inspectAllOpts := []clab.ClabOption{
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
+			clab.WithTimeout(timeout),
+		}
+
+		c, err := clab.NewContainerLab(inspectAllOpts...)
 		if err != nil {
 			return err
 		}
@@ -97,6 +102,13 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 	for topo := range topos {
 		opts := append(opts,
 			clab.WithTopoFile(topo, varsFile),
+			clab.WithRuntime(rt,
+				&runtime.RuntimeConfig{
+					Debug:            debug,
+					Timeout:          timeout,
+					GracefulShutdown: graceful,
+				},
+			),
 		)
 		log.Debugf("going through extracted topos for destroy, got a topo file %v and generated opts list %+v", topo, opts)
 		nc, err := clab.NewContainerLab(opts...)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -49,10 +49,6 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opts := []clab.ClabOption{
-		clab.WithTimeout(timeout),
-	}
-
 	topos := map[string]struct{}{}
 
 	switch {
@@ -96,7 +92,8 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 
 	log.Debugf("We got the following topos struct for destroy: %+v", topos)
 	for topo := range topos {
-		opts = append(opts,
+		opts := []clab.ClabOption{
+			clab.WithTimeout(timeout),
 			clab.WithTopoFile(topo, varsFile),
 			clab.WithRuntime(rt,
 				&runtime.RuntimeConfig{
@@ -105,7 +102,7 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 					GracefulShutdown: graceful,
 				},
 			),
-		)
+		}
 
 		if keepMgmtNet {
 			opts = append(opts, clab.WithKeepMgmtNet())

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -53,10 +53,6 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 		clab.WithTimeout(timeout),
 	}
 
-	if keepMgmtNet {
-		opts = append(opts, clab.WithKeepMgmtNet())
-	}
-
 	topos := map[string]struct{}{}
 
 	switch {
@@ -100,7 +96,7 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 
 	log.Debugf("We got the following topos struct for destroy: %+v", topos)
 	for topo := range topos {
-		opts := append(opts,
+		opts = append(opts,
 			clab.WithTopoFile(topo, varsFile),
 			clab.WithRuntime(rt,
 				&runtime.RuntimeConfig{
@@ -110,6 +106,11 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 				},
 			),
 		)
+
+		if keepMgmtNet {
+			opts = append(opts, clab.WithKeepMgmtNet())
+		}
+
 		log.Debugf("going through extracted topos for destroy, got a topo file %v and generated opts list %+v", topo, opts)
 		nc, err := clab.NewContainerLab(opts...)
 		if err != nil {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -109,10 +109,10 @@ func (d *DockerRuntime) WithMgmtNet(n *types.MgmtNet) {
 
 	// if bridge was not set in the topo file, find out the bridge name
 	// used by the network used in the topology
-	log.Debugf("bridge %s, network %s", d.mgmt.Bridge, d.mgmt.Network)
 	if d.mgmt.Bridge == "" && d.mgmt.Network != "" {
 		// fetch the network by the name set in the topo and populate the bridge name used by this network
 		netRes, err := d.Client.NetworkInspect(context.TODO(), d.mgmt.Network, dockerTypes.NetworkInspectOptions{})
+		// if the network is succesfully found, set the bridge used by it
 		if err == nil {
 			d.mgmt.Bridge = "br-" + netRes.ID[:12]
 			log.Debugf("detected network name in use: %s, backed by a bridge %s", d.mgmt.Network, d.mgmt.Bridge)

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -107,9 +107,17 @@ func (d *DockerRuntime) WithMgmtNet(n *types.MgmtNet) {
 		d.mgmt.MTU = mtu
 	}
 
-	// if bridge was not set in the topo file, we default to
-	if d.mgmt.Bridge == "" {
-		d.mgmt.Bridge = "br-" + netRes.ID[:12]
+	// if bridge was not set in the topo file, find out the bridge name
+	// used by the network used in the topology
+	log.Debugf("bridge %s, network %s", d.mgmt.Bridge, d.mgmt.Network)
+	if d.mgmt.Bridge == "" && d.mgmt.Network != "" {
+		// fetch the network by the name set in the topo and populate the bridge name used by this network
+		netRes, err := d.Client.NetworkInspect(context.TODO(), d.mgmt.Network, dockerTypes.NetworkInspectOptions{})
+		if err == nil {
+			d.mgmt.Bridge = "br-" + netRes.ID[:12]
+			log.Debugf("detected network name in use: %s, backed by a bridge %s", d.mgmt.Network, d.mgmt.Bridge)
+		}
+
 	}
 }
 


### PR DESCRIPTION
a bridge backing default `bridge` docker network was used for any network referenced in clab topo