### PR TITLE
Fix nextui node tooltip without image field

### DIFF
--- a/templates/graph/nextui/static/js/script.js
+++ b/templates/graph/nextui/static/js/script.js
@@ -11,6 +11,15 @@
             data.nodes[key]["group"] = 'N/A';
         }
     }
+    // for non container nodes, no image filed is set
+    // we set it to N/A to indicate no image property
+    // without this, the nx graph node tooltip image value 
+    // will be skipped, cause the filed name and value mismatch
+    for (var key in data.nodes) {
+        if (!("image" in data.nodes[key])) {
+            data.nodes[key]["image"] = 'N/A';
+        }
+    }
 
     nx.define('CustomLinkLabel', nx.graphic.Topology.Link, {
         properties: {


### PR DESCRIPTION
For non container nodes, image filed is not set.
Without this, the nx graph node tooltip image field in value colume will be skipped. Cause the filed name and value mismatch.
I set the image field to  N/A to indicate no image property to fix this problem.


Before fix:
![image](https://user-images.githubusercontent.com/32395144/202283333-ff47f6bf-9d52-485d-b04b-83be67bb437e.png)

After fix:
![image](https://user-images.githubusercontent.com/32395144/202283242-edad7096-91d9-4d0c-958e-3e1e3c0f5037.png)
