### PR TITLE
Adding BOF change through on-boot script example

### DIFF
--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -191,13 +191,15 @@ cat clab-cert01/sr/tftpboot/config.txt
 
 #### Boot Options File
 
-By default vr-sros nodes boot up with a pre-defined "boot options file" (BOF). This file includes settings such as:
-- license file location
-- config file location
+By default `vr_nokia_sros` nodes boot up with a pre-defined "Boot Options File" (BOF). This file includes boot settings including:
 
-When the node is up and running you can make changes to this BOF. One popular example of such changes is the addition of static-routes to reach external networks from within the vs-sros node. Although you can save the BOF from within the SROS system, the location the file is written to is not persistent across container restarts. It is also not possible to define a BOF target location. A workaround for this is to automatically execute a CLI script after successful boot making the needed BOF changes:
+* license file location
+* config file location
 
-SROS has an option to automatically execute a "script" upon successful boot. This option is accessible in SROS via:
+When the node is up and running you can make changes to this BOF. One popular example of such changes is the addition of static-routes to reach external networks from within the SR OS node. Although you can save the BOF from within the SROS system, the location the file is written to is not persistent across container restarts. It is also not possible to define a BOF target location.  
+A workaround for this limitation is to automatically execute a CLI script that configures BOF once the system boots.
+
+SR OS has an option (introduced in SR OS 16.0.R1) to automatically execute a script upon successful boot. This option is accessible in SR OS by the `/configure system boot-good-exec` MD-CLI path:
 
 ```bash
 [pr:/configure]
@@ -207,14 +209,11 @@ A:admin@sros1# system boot-good-exec ?
  <string>  - <1..180 characters>
 
     CLI script file to execute following successful boot-up
-
-[pr:/configure]
-A:admin@sros1# system boot-good-exec
 ```
 
-This option was introduced already in SROS 16.0.R1. Using this option and the ability to mount basically any file into the default tftp location used by the containerized SROS boxes it is very easy to automatically apply any config including BOF changes after startup. 
+By mounting a script to SR OS container node and using the `boot-good-exec` option, users can make changes to the BOF the second the node boots and thus complete the task of having a *somewhat* persistent BOF.
 
-As an example the following SROS MD-CLI script was created:
+As an example the following SR OS MD-CLI script was created to persist custom static routes to the BOF:
 
 ```bash
 ########################################
@@ -229,7 +228,7 @@ commit
 exit all
 ```
 
-This script is placed in the containerlab's topology root directory and bound to the vr-sros containers tftpboot location using containerlab's "binds" variable:
+This script is then placed somewhere on the disk, for example in the containerlab's topology root directory, and mounted to `vr-nokia_sros` node tftpboot directory using [binds](../nodes.md#binds) property:
 
 ```yaml
   nodes:
@@ -240,20 +239,22 @@ This script is placed in the containerlab's topology root directory and bound to
       type: sr-1s
       license: license-sros.txt
       binds:
-        - post-boot-exec.cfg:/tftpboot/post-boot-exec.cfg
+        - post-boot-exec.cfg:/tftpboot/post-boot-exec.cfg #(1)!
 ```
 
-Note: You still need to apply the following configuration line to your SROS devices to enable the automatic CLI script execution after successful boot. The tftpboot location is always at "tftp://172.31.255.29/".
+1. `post-boot-exec.cfg` file contains the script referenced above and it is mounted to `/tftpboot` directory that is available in SR OS node.
+
+Once the script is mounted to the node, users need to instruct SR OS to execute the script upon successful boot. This is done by adding the following configuration line on SR OS MD-CLI:
 
 ```bash
 [pr:/configure system]
 A:admin@sros1# info | match boot-goo
-    boot-good-exec "tftp://172.31.255.29/post-boot-exec.cfg"
-
-[pr:/configure system]
+    boot-good-exec "tftp://172.31.255.29/post-boot-exec.cfg" #(1)!
 ```
 
-By combining file bindings available in containerlab and the automatic script execution of SROS it is possible to reach some kind of BOF persistency. 
+1. The tftpboot location is always at `tftp://172.31.255.29/` address and the name of the file needs to match the file you used in the binds instruction.
+
+By combining file bindings and the automatic script execution of SROS it is possible to create a workaround for persistent BOF settings.
 
 ### License
 

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -195,7 +195,7 @@ By default vr-sros nodes boot up with a pre-defined "boot options file" (BOF). T
 - license file location
 - config file location
 
-When the node is up and running you can make changes to this BOF. One popular example of such changes is the addition of static-routes to reach external networks from within the vs-sros node. Although you can save the BOF from within the SROS system, the location the file is written to is not persistent across container restarts. It is also not possible to define a BOF target location. Hence we had to come with an idea to apply BOF changes upon startup automatically. 
+When the node is up and running you can make changes to this BOF. One popular example of such changes is the addition of static-routes to reach external networks from within the vs-sros node. Although you can save the BOF from within the SROS system, the location the file is written to is not persistent across container restarts. It is also not possible to define a BOF target location. A workaround for this is to automatically execute a CLI script after successful boot making the needed BOF changes:
 
 SROS has an option to automatically execute a "script" upon successful boot. This option is accessible in SROS via:
 


### PR DESCRIPTION
Added brief description on how to reach some kind of BOF persistency by using a combination of file-mount and SROS on-boot script execution.  