### PR TITLE
Rate-limit polling for node status at link creation time

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -501,7 +501,9 @@ func (c *CLab) CreateLinks(ctx context.Context, workers uint) {
 			}
 			c.m.Unlock()
 		}
-		time.Sleep(time.Duration(500) * time.Millisecond)
+
+		// prevent clab from throttle CPU when nodes take considerable time to start
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	// close channel to terminate the workers

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -501,6 +501,7 @@ func (c *CLab) CreateLinks(ctx context.Context, workers uint) {
 			}
 			c.m.Unlock()
 		}
+		time.Sleep(time.Duration(500) * time.Millisecond)
 	}
 
 	// close channel to terminate the workers


### PR DESCRIPTION
Creating for links busy-waits until the nodes on both sides of a link are created.
This is just to introduce some sleep time.

Idealy we woudl integrate this into the DependencyManager as well. That would need some rework to use general interfaces instead of just working with node names...

Maybe we open a new issue for that!? But go with this workaround for now,