### PR TITLE
Refactor exec node interface part 1

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -16,13 +16,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// templates to execute.
+// TemplateNames is templates to execute.
 var TemplateNames []string
 
-// path to additional templates.
+// TemplatePaths is path to additional templates.
 var TemplatePaths []string
 
-// debug count.
+// DebugCount is a debug verbosity counter.
 var DebugCount int
 
 type NodeConfig struct {
@@ -34,7 +34,7 @@ type NodeConfig struct {
 	Info []string
 }
 
-// Load templates from all paths for the specific role/kind.
+// LoadTemplates loads templates from all paths for the specific role/kind.
 func LoadTemplates(tmpl *template.Template, role string) error {
 	for _, p := range TemplatePaths {
 		fn := filepath.Join(p, fmt.Sprintf("*__%s.tmpl", role))
@@ -107,7 +107,7 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 	return nil
 }
 
-// Implement stringer for NodeConfig.
+// String implements stringer interface for NodeConfig.
 func (c *NodeConfig) String() string {
 	s := fmt.Sprintf("%s: %v", c.TargetNode.ShortName, c.Info)
 	return s

--- a/clab/config/transport/ssh.go
+++ b/clab/config/transport/ssh.go
@@ -21,7 +21,7 @@ type SSHSession struct {
 
 type SSHTransportOption func(*SSHTransport) error
 
-// The SSH reply, executed command and the prompt.
+// SSHReply is SSH reply, executed command and the prompt.
 type SSHReply struct{ result, prompt, command string }
 
 // SSHTransport setting needs to be set before calling Connect()
@@ -52,7 +52,7 @@ type SSHTransport struct {
 	K SSHKind
 }
 
-// Add username & password authentication.
+// WithUserNamePassword adds username & password authentication.
 func WithUserNamePassword(username, password string) SSHTransportOption {
 	return func(tx *SSHTransport) error {
 		tx.SSHConfig.User = username
@@ -64,7 +64,7 @@ func WithUserNamePassword(username, password string) SSHTransportOption {
 	}
 }
 
-// Add a basic username & password to a config
+// HostKeyCallback adds a basic username & password to a config.
 // Will initialize the config if required.
 func HostKeyCallback(callback ...ssh.HostKeyCallback) SSHTransportOption {
 	return func(tx *SSHTransport) error {
@@ -311,7 +311,7 @@ func (t *SSHTransport) Close() {
 	t.ses.Close()
 }
 
-// Create a new SSH session (Dial, open in/out pipes and start the shell)
+// NewSSHSession creates a new SSH session (Dial, open in/out pipes and start the shell)
 // pass the authentication details in sshConfig.
 func NewSSHSession(host string, sshConfig *ssh.ClientConfig) (*SSHSession, error) {
 	if !strings.Contains(host, ":") {
@@ -369,7 +369,7 @@ func (ses *SSHSession) Close() {
 	ses.Session.Close()
 }
 
-// The LogString will include the entire SSHReply
+// LogString will include the entire SSHReply
 //   Each field will be prefixed by a character.
 //   # - command sent
 //   | - result received

--- a/clab/config/transport/ssh.go
+++ b/clab/config/transport/ssh.go
@@ -109,7 +109,7 @@ func NewSSHTransport(node *types.NodeConfig, options ...SSHTransportOption) (*SS
 	return nil, fmt.Errorf("no transport implemented for kind: %s", node.Kind)
 }
 
-// Creates the channel reading the SSH connection
+// InChannel creates the channel reading the SSH connection.
 //
 // The first prompt is saved in LoginMessages
 //

--- a/clab/config/transport/sshkind.go
+++ b/clab/config/transport/sshkind.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// An interface to implement kind specific methods for transactions and prompt checking.
+// SSHKind is an interface to implement kind specific methods for transactions and prompt checking.
 type SSHKind interface {
 	// Start a config transaction
 	ConfigStart(s *SSHTransport, transaction bool) error
@@ -23,7 +23,7 @@ type SSHKind interface {
 	PromptParse(s *SSHTransport, in *string) *SSHReply
 }
 
-// implements SShKind.
+// VrSrosSSHKind implements SShKind.
 type VrSrosSSHKind struct{}
 
 func (*VrSrosSSHKind) ConfigStart(s *SSHTransport, transaction bool) error { // skipcq: RVV-A0005
@@ -61,7 +61,7 @@ func (*VrSrosSSHKind) PromptParse(s *SSHTransport, in *string) *SSHReply {
 	return nil
 }
 
-// implements SShKind.
+// SrlSSHKind implements SShKind.
 type SrlSSHKind struct{}
 
 func (*SrlSSHKind) ConfigStart(s *SSHTransport, transaction bool) error { // skipcq: RVV-A0005

--- a/clab/config/transport/transport.go
+++ b/clab/config/transport/transport.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Debug count.
+// DebugCount is a debug verbosity counter.
 var DebugCount int
 
 type TransportOption func(*Transport)

--- a/clab/config/utils.go
+++ b/clab/config/utils.go
@@ -32,7 +32,7 @@ const (
 
 type Dict map[string]interface{}
 
-// Prepare variables for all nodes. This will also prepare all variables for the links.
+// PrepareVars variables for all nodes. This will also prepare all variables for the links.
 func PrepareVars(nodes map[string]nodes.Node, links map[int]*types.Link) map[string]*NodeConfig {
 	res := make(map[string]*NodeConfig)
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -256,7 +256,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	for _, n := range c.Nodes {
 		execResult, err := n.RunExecs(ctx, n.Config().Exec)
 		if err != nil {
-			log.Errorf("Failed to exec commands for node %s", name)
+			log.Warnf("Failed to exec commands for node %q", n.Config().ShortName)
 		}
 		execCollection.AddAll(n.Config().ShortName, execResult)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -251,11 +251,10 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		log.Errorf("failed to create hosts file: %v", err)
 	}
 
-	// exec commands specified for containers with `exec` parameter
-
+	// execute commands specified for nodes with `exec` node parameter
 	execCollection := types.NewExecCollection()
 	for _, n := range c.Nodes {
-		execResult, err := n.RunExecConfig(ctx)
+		execResult, err := n.RunExecs(ctx, n.Config().Exec)
 		if err != nil {
 			log.Errorf("Failed to exec commands for node %s", name)
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cloudflare/cfssl/log"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
 	"github.com/srl-labs/containerlab/runtime"
@@ -58,11 +59,13 @@ var execCmd = &cobra.Command{
 		resultCollection := types.NewExecCollection()
 
 		for _, node := range c.Nodes {
-			exec, err := types.NewExec(execCommand)
+			execCmd, err := types.NewExecCmdFromString(execCommand)
 			if err != nil {
-				return err
+				// do not stop exec for other nodes if some failed
+				log.Error(err)
 			}
-			execResult, err := node.RunExecType(ctx, exec)
+
+			execResult, err := node.RunExec(ctx, execCmd)
 			if err != nil {
 				// skip nodes that do not support exec
 				if err == types.ErrRunExecTypeNotSupported {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cloudflare/cfssl/log"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
 	"github.com/srl-labs/containerlab/runtime"

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -308,7 +308,11 @@ func saveTopoFile(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
 	_, err = f.Write(data)
-	return err
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
 }

--- a/mocks/default_node.go
+++ b/mocks/default_node.go
@@ -78,7 +78,7 @@ func (mr *MockNodeOverwritesMockRecorder) PullImage(ctx interface{}) *gomock.Cal
 }
 
 // RunExecType mocks base method.
-func (m *MockNodeOverwrites) RunExecType(ctx context.Context, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (m *MockNodeOverwrites) RunExecType(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunExecType", ctx, exec)
 	ret0, _ := ret[0].(types.ExecResultHolder)

--- a/mocks/default_node.go
+++ b/mocks/default_node.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	types "github.com/srl-labs/containerlab/types"
 )
 
 // MockNodeOverwrites is a mock of NodeOverwrites interface.
@@ -75,21 +74,6 @@ func (m *MockNodeOverwrites) PullImage(ctx context.Context) error {
 func (mr *MockNodeOverwritesMockRecorder) PullImage(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockNodeOverwrites)(nil).PullImage), ctx)
-}
-
-// RunExecType mocks base method.
-func (m *MockNodeOverwrites) RunExecType(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunExecType", ctx, exec)
-	ret0, _ := ret[0].(types.ExecResultHolder)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunExecType indicates an expected call of RunExecType.
-func (mr *MockNodeOverwritesMockRecorder) RunExecType(ctx, exec interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecType", reflect.TypeOf((*MockNodeOverwrites)(nil).RunExecType), ctx, exec)
 }
 
 // VerifyHostRequirements mocks base method.

--- a/mocks/exec.go
+++ b/mocks/exec.go
@@ -11,31 +11,31 @@ import (
 	types "github.com/srl-labs/containerlab/types"
 )
 
-// MockExecOperation is a mock of ExecOperation interface.
-type MockExecOperation struct {
+// MockExecCmd is a mock of ExecCmd interface.
+type MockExecCmd struct {
 	ctrl     *gomock.Controller
-	recorder *MockExecOperationMockRecorder
+	recorder *MockExecCmdMockRecorder
 }
 
-// MockExecOperationMockRecorder is the mock recorder for MockExecOperation.
-type MockExecOperationMockRecorder struct {
-	mock *MockExecOperation
+// MockExecCmdMockRecorder is the mock recorder for MockExecCmd.
+type MockExecCmdMockRecorder struct {
+	mock *MockExecCmd
 }
 
-// NewMockExecOperation creates a new mock instance.
-func NewMockExecOperation(ctrl *gomock.Controller) *MockExecOperation {
-	mock := &MockExecOperation{ctrl: ctrl}
-	mock.recorder = &MockExecOperationMockRecorder{mock}
+// NewMockExecCmd creates a new mock instance.
+func NewMockExecCmd(ctrl *gomock.Controller) *MockExecCmd {
+	mock := &MockExecCmd{ctrl: ctrl}
+	mock.recorder = &MockExecCmdMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockExecOperation) EXPECT() *MockExecOperationMockRecorder {
+func (m *MockExecCmd) EXPECT() *MockExecCmdMockRecorder {
 	return m.recorder
 }
 
 // GetCmd mocks base method.
-func (m *MockExecOperation) GetCmd() []string {
+func (m *MockExecCmd) GetCmd() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCmd")
 	ret0, _ := ret[0].([]string)
@@ -43,13 +43,13 @@ func (m *MockExecOperation) GetCmd() []string {
 }
 
 // GetCmd indicates an expected call of GetCmd.
-func (mr *MockExecOperationMockRecorder) GetCmd() *gomock.Call {
+func (mr *MockExecCmdMockRecorder) GetCmd() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCmd", reflect.TypeOf((*MockExecOperation)(nil).GetCmd))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCmd", reflect.TypeOf((*MockExecCmd)(nil).GetCmd))
 }
 
 // GetCmdString mocks base method.
-func (m *MockExecOperation) GetCmdString() string {
+func (m *MockExecCmd) GetCmdString() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCmdString")
 	ret0, _ := ret[0].(string)
@@ -57,9 +57,9 @@ func (m *MockExecOperation) GetCmdString() string {
 }
 
 // GetCmdString indicates an expected call of GetCmdString.
-func (mr *MockExecOperationMockRecorder) GetCmdString() *gomock.Call {
+func (mr *MockExecCmdMockRecorder) GetCmdString() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCmdString", reflect.TypeOf((*MockExecOperation)(nil).GetCmdString))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCmdString", reflect.TypeOf((*MockExecCmd)(nil).GetCmdString))
 }
 
 // MockExecResultHolder is a mock of ExecResultHolder interface.

--- a/mocks/node.go
+++ b/mocks/node.go
@@ -241,7 +241,7 @@ func (mr *MockNodeMockRecorder) RunExecConfig(ctx interface{}) *gomock.Call {
 }
 
 // RunExecType mocks base method.
-func (m *MockNode) RunExecType(ctx context.Context, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (m *MockNode) RunExecType(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunExecType", ctx, exec)
 	ret0, _ := ret[0].(types.ExecResultHolder)

--- a/mocks/node.go
+++ b/mocks/node.go
@@ -225,34 +225,34 @@ func (mr *MockNodeMockRecorder) PreDeploy(ctx, configName, labCADir, labCARoot i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreDeploy", reflect.TypeOf((*MockNode)(nil).PreDeploy), ctx, configName, labCADir, labCARoot)
 }
 
-// RunExecConfig mocks base method.
-func (m *MockNode) RunExecConfig(ctx context.Context) ([]types.ExecResultHolder, error) {
+// RunExec mocks base method.
+func (m *MockNode) RunExec(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunExecConfig", ctx)
-	ret0, _ := ret[0].([]types.ExecResultHolder)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunExecConfig indicates an expected call of RunExecConfig.
-func (mr *MockNodeMockRecorder) RunExecConfig(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecConfig", reflect.TypeOf((*MockNode)(nil).RunExecConfig), ctx)
-}
-
-// RunExecType mocks base method.
-func (m *MockNode) RunExecType(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunExecType", ctx, exec)
+	ret := m.ctrl.Call(m, "RunExec", ctx, exec)
 	ret0, _ := ret[0].(types.ExecResultHolder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RunExecType indicates an expected call of RunExecType.
-func (mr *MockNodeMockRecorder) RunExecType(ctx, exec interface{}) *gomock.Call {
+// RunExec indicates an expected call of RunExec.
+func (mr *MockNodeMockRecorder) RunExec(ctx, exec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecType", reflect.TypeOf((*MockNode)(nil).RunExecType), ctx, exec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExec", reflect.TypeOf((*MockNode)(nil).RunExec), ctx, exec)
+}
+
+// RunExecs mocks base method.
+func (m *MockNode) RunExecs(ctx context.Context, cmds []string) ([]types.ExecResultHolder, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunExecs", ctx, cmds)
+	ret0, _ := ret[0].([]types.ExecResultHolder)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunExecs indicates an expected call of RunExecs.
+func (mr *MockNodeMockRecorder) RunExecs(ctx, cmds interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecs", reflect.TypeOf((*MockNode)(nil).RunExecs), ctx, cmds)
 }
 
 // SaveConfig mocks base method.

--- a/mocks/runtime.go
+++ b/mocks/runtime.go
@@ -108,7 +108,7 @@ func (mr *MockContainerRuntimeMockRecorder) DeleteNet(arg0 interface{}) *gomock.
 }
 
 // Exec mocks base method.
-func (m *MockContainerRuntime) Exec(ctx context.Context, cID string, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (m *MockContainerRuntime) Exec(ctx context.Context, cID string, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exec", ctx, cID, exec)
 	ret0, _ := ret[0].(types.ExecResultHolder)
@@ -123,7 +123,7 @@ func (mr *MockContainerRuntimeMockRecorder) Exec(ctx, cID, exec interface{}) *go
 }
 
 // ExecNotWait mocks base method.
-func (m *MockContainerRuntime) ExecNotWait(ctx context.Context, cID string, exec types.ExecOperation) error {
+func (m *MockContainerRuntime) ExecNotWait(ctx context.Context, cID string, exec types.ExecCmd) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecNotWait", ctx, cID, exec)
 	ret0, _ := ret[0].(error)

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -110,13 +110,6 @@ func (b *bridge) UpdateConfigWithRuntimeInfo(_ context.Context) error { return n
 // GetContainers is a noop for bridges.
 func (b *bridge) GetContainers(_ context.Context) ([]types.GenericContainer, error) { return nil, nil }
 
-func (b *bridge) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error) {
-	if b.Cfg.Exec != nil && len(b.Cfg.Exec) > 0 {
-		log.Error("exec not supported on kind 'bridge' -> noop; continuing")
-	}
-	return []types.ExecResultHolder{}, nil
-}
-
 func (b *bridge) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", b.Config().Kind)
 

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -117,7 +117,7 @@ func (b *bridge) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, err
 	return []types.ExecResultHolder{}, nil
 }
 
-func (b *bridge) RunExecType(_ context.Context, _ types.ExecOperation) (types.ExecResultHolder, error) {
+func (b *bridge) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
 	log.Error("exec not supported on kind 'bridge' -> noop; continuing")
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -118,6 +118,7 @@ func (b *bridge) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, err
 }
 
 func (b *bridge) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
-	log.Error("exec not supported on kind 'bridge' -> noop; continuing")
+	log.Warnf("Exec operation is not implemented for kind %q", b.Config().Kind)
+
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -43,7 +43,7 @@ var (
 	//go:embed ceos.cfg
 	cfgTemplate string
 
-	saveCmd = []string{"Cli", "-p", "15", "-c", "wr"}
+	saveCmd = "Cli -p 15 -c wr"
 )
 
 func init() {
@@ -106,8 +106,8 @@ func (n *ceos) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 }
 
 func (n *ceos) SaveConfig(ctx context.Context) error {
-	saveCmdExec := types.NewExecOperationSlice(saveCmd)
-	execResult, err := n.RunExecType(ctx, saveCmdExec)
+	cmd, _ := types.NewExecCmdFromString(saveCmd)
+	execResult, err := n.RunExec(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("%s: failed to execute cmd: %v", n.Cfg.ShortName, err)
 	}

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -29,8 +29,8 @@ var (
 	//go:embed sshd_config
 	sshdCfg string
 
-	saveCmd       = []string{"cli", "show", "conf"}
-	sshRestartCmd = []string{"service", "ssh", "restart"}
+	saveCmd       = "cli show conf"
+	sshRestartCmd = "service ssh restart"
 )
 
 func init() {
@@ -71,8 +71,8 @@ func (s *crpd) PreDeploy(_ context.Context, _, _, _ string) error {
 func (s *crpd) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 	log.Debugf("Running postdeploy actions for CRPD %q node", s.Cfg.ShortName)
 
-	sshRestartExec := types.NewExecOperationSlice(sshRestartCmd)
-	execResult, err := s.RunExecType(ctx, sshRestartExec)
+	cmd, _ := types.NewExecCmdFromString(sshRestartCmd)
+	execResult, err := s.RunExec(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -85,8 +85,8 @@ func (s *crpd) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 }
 
 func (s *crpd) SaveConfig(ctx context.Context) error {
-	saveExec := types.NewExecOperationSlice(saveCmd)
-	execResult, err := s.RunExecType(ctx, saveExec)
+	cmd, _ := types.NewExecCmdFromString(saveCmd)
+	execResult, err := s.RunExec(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -64,7 +64,7 @@ func (e *extcont) PullImage(_ context.Context) error             { return nil }
 
 // RunExecType is the final function that calls the runtime to execute a type.Exec on a container
 // This is to be overriden if the nodes implementation differs
-func (e *extcont) RunExecType(ctx context.Context, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (e *extcont) RunExecType(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	execResult, err := e.GetRuntime().Exec(ctx, e.Cfg.ShortName, exec)
 	if err != nil {
 		// On Ext-container we have to use the shortname, whilst default is to use longname
@@ -76,7 +76,7 @@ func (e *extcont) RunExecType(ctx context.Context, exec types.ExecOperation) (ty
 
 // RunExecType is the final function that calls the runtime to execute a type.Exec on a container
 // This is to be overriden if the nodes implementation differs
-func (e *extcont) RunExecTypeWoWait(ctx context.Context, exec types.ExecOperation) error {
+func (e *extcont) RunExecTypeWoWait(ctx context.Context, exec types.ExecCmd) error {
 	err := e.GetRuntime().ExecNotWait(ctx, e.Cfg.ShortName, exec)
 	if err != nil {
 		// On Ext-container we have to use the shortname, whilst default is to use longname

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -73,7 +73,8 @@ func (h *host) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error
 	return []types.ExecResultHolder{}, nil
 }
 
-func (h *host) RunExecType(_ context.Context, _ types.ExecCmd) (types.ExecResultHolder, error) {
-	log.Error("exec not supported on kind 'host' -> noop; continuing")
+func (h *host) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
+	log.Warnf("Exec operation is not implemented for kind %q", h.Config().Kind)
+
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -73,7 +73,7 @@ func (h *host) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error
 	return []types.ExecResultHolder{}, nil
 }
 
-func (h *host) RunExecType(_ context.Context, _ types.ExecOperation) (types.ExecResultHolder, error) {
+func (h *host) RunExecType(_ context.Context, _ types.ExecCmd) (types.ExecResultHolder, error) {
 	log.Error("exec not supported on kind 'host' -> noop; continuing")
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -66,13 +66,6 @@ func (*host) GetContainers(_ context.Context) ([]types.GenericContainer, error) 
 	}, nil
 }
 
-func (h *host) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error) {
-	if h.Cfg.Exec != nil && len(h.Cfg.Exec) > 0 {
-		log.Error("exec not supported on kind 'host' -> noop; continuing")
-	}
-	return []types.ExecResultHolder{}, nil
-}
-
 func (h *host) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", h.Config().Kind)
 

--- a/nodes/keysight_ixiacone/ixiac-one.go
+++ b/nodes/keysight_ixiacone/ixiac-one.go
@@ -54,11 +54,11 @@ func (l *ixiacOne) PostDeploy(ctx context.Context, _ map[string]nodes.Node) erro
 
 // ixiacPostDeploy runs postdeploy actions which are required for keysight_ixia-c-one node.
 func (l *ixiacOne) ixiacPostDeploy(ctx context.Context) error {
-	ixiacOneCmd := fmt.Sprintf("ls %s", ixiacStatusConfig.readyFileName)
+	ixiacOneCmd := fmt.Sprintf("bash -c 'ls %s'", ixiacStatusConfig.readyFileName)
 	statusInProgressMsg := fmt.Sprintf("ls: %s: No such file or directory", ixiacStatusConfig.readyFileName)
 	for {
-		exec := types.NewExecOperationSlice([]string{"bash", "-c", ixiacOneCmd})
-		execResult, err := l.RunExecType(ctx, exec)
+		cmd, _ := types.NewExecCmdFromString(ixiacOneCmd)
+		execResult, err := l.RunExec(ctx, cmd)
 		if err != nil {
 			return err
 		}

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -81,9 +81,8 @@ type Node interface {
 	GenerateConfig(dst, templ string) error      // Generate the nodes configuration
 	// UpdateConfigWithRuntimeInfo updates node config with runtime info like IP addresses assgined by runtime
 	UpdateConfigWithRuntimeInfo(context.Context) error
-	RunExecConfig(ctx context.Context) ([]types.ExecResultHolder, error)
-	// RunExecType will return a types.ErrRunExecTypeNotSupported if the Kind does not support the execution of commands. This error must be handled.
-	RunExecType(ctx context.Context, exec types.ExecOperation) (types.ExecResultHolder, error)
+	RunExecs(ctx context.Context, cmds []string) ([]types.ExecResultHolder, error)
+	RunExec(ctx context.Context, exec types.ExecCmd) (types.ExecResultHolder, error)
 }
 
 type Initializer func() Node

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -61,7 +61,7 @@ func (o *ovs) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error)
 	return []types.ExecResultHolder{}, nil
 }
 
-func (*ovs) RunExecType(_ context.Context, _ types.ExecOperation) (types.ExecResultHolder, error) {
+func (*ovs) RunExecType(_ context.Context, _ types.ExecCmd) (types.ExecResultHolder, error) {
 	log.Error("exec not supported on kind 'ovs' -> noop; continuing")
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -61,7 +61,8 @@ func (o *ovs) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error)
 	return []types.ExecResultHolder{}, nil
 }
 
-func (*ovs) RunExecType(_ context.Context, _ types.ExecCmd) (types.ExecResultHolder, error) {
-	log.Error("exec not supported on kind 'ovs' -> noop; continuing")
+func (o *ovs) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
+	log.Warnf("Exec operation is not implemented for kind %q", o.Config().Kind)
+
 	return nil, types.ErrRunExecTypeNotSupported
 }

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -54,13 +54,6 @@ func (*ovs) PullImage(_ context.Context) error             { return nil }
 func (*ovs) GetImages(_ context.Context) map[string]string { return map[string]string{} }
 func (*ovs) Delete(_ context.Context) error                { return nil }
 
-func (o *ovs) RunExecConfig(_ context.Context) ([]types.ExecResultHolder, error) {
-	if o.Cfg.Exec != nil && len(o.Cfg.Exec) > 0 {
-		log.Error("exec not supported on kind 'ovs' -> noop; continuing")
-	}
-	return []types.ExecResultHolder{}, nil
-}
-
 func (o *ovs) RunExecs(_ context.Context, _ []string) ([]types.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", o.Config().Kind)
 

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -48,14 +48,14 @@ func (s *sonic) PreDeploy(_ context.Context, _, _, _ string) error {
 func (s *sonic) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 	log.Debugf("Running postdeploy actions for sonic-vs '%s' node", s.Cfg.ShortName)
 
-	exec := types.NewExecOperationSlice([]string{"supervisord"})
-	err := s.RunExecTypeWoWait(ctx, exec)
+	cmd, _ := types.NewExecCmdFromString("supervisord")
+	err := s.RunExecTypeWoWait(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed post-deploy node %q: %w", s.Cfg.ShortName, err)
 	}
 
-	exec = types.NewExecOperationSlice([]string{"supervisorctl", "start", "bgpd"})
-	err = s.RunExecTypeWoWait(ctx, exec)
+	cmd, _ = types.NewExecCmdFromString("supervisorctl start bgpd")
+	err = s.RunExecTypeWoWait(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed post-deploy node %q: %w", s.Cfg.ShortName, err)
 	}

--- a/nodes/srl/banner.go
+++ b/nodes/srl/banner.go
@@ -28,11 +28,9 @@ const banner = `................................................................
 // banner returns a banner string with a docs version filled in based on the version information queried from the node.
 func (s *srl) banner(ctx context.Context) (string, error) {
 
-	exec := types.NewExecOperationSlice([]string{
-		"sr_cli", "-d", "info from state /system information version | grep version",
-	})
+	cmd, _ := types.NewExecCmdFromString(`sr_cli -d "info from state /system information version | grep version"`)
 
-	execResult, err := s.RunExecType(ctx, exec)
+	execResult, err := s.RunExec(ctx, cmd)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -699,16 +699,16 @@ func (c *ContainerdRuntime) GetNSPath(ctx context.Context, containername string)
 	return "/proc/" + strconv.Itoa(int(task.Pid())) + "/ns/net", nil
 }
 
-func (c *ContainerdRuntime) Exec(ctx context.Context, containername string, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (c *ContainerdRuntime) Exec(ctx context.Context, containername string, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	return c.internalExec(ctx, containername, exec, false)
 }
 
-func (c *ContainerdRuntime) ExecNotWait(ctx context.Context, containername string, exec types.ExecOperation) error {
+func (c *ContainerdRuntime) ExecNotWait(ctx context.Context, containername string, exec types.ExecCmd) error {
 	_, err := c.internalExec(ctx, containername, exec, true)
 	return err
 }
 
-func (c *ContainerdRuntime) internalExec(ctx context.Context, containername string, exec types.ExecOperation, detach bool) (types.ExecResultHolder, error) { // skipcq: RVV-A0005
+func (c *ContainerdRuntime) internalExec(ctx context.Context, containername string, exec types.ExecCmd, detach bool) (types.ExecResultHolder, error) { // skipcq: RVV-A0005
 
 	clabExecId := "clabexec"
 	ctx = namespaces.WithNamespace(ctx, containerdNamespace)

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -682,7 +682,7 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 }
 
 // Exec executes cmd on container identified with id and returns stdout, stderr bytes and an error.
-func (d *DockerRuntime) Exec(ctx context.Context, cID string, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (d *DockerRuntime) Exec(ctx context.Context, cID string, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	cont, err := d.Client.ContainerInspect(ctx, cID)
 	if err != nil {
 		return nil, err
@@ -740,7 +740,7 @@ func (d *DockerRuntime) Exec(ctx context.Context, cID string, exec types.ExecOpe
 }
 
 // ExecNotWait executes cmd on container identified with id but doesn't wait for output nor attaches stdout/err.
-func (d *DockerRuntime) ExecNotWait(_ context.Context, cID string, exec types.ExecOperation) error {
+func (d *DockerRuntime) ExecNotWait(_ context.Context, cID string, exec types.ExecCmd) error {
 	execConfig := dockerTypes.ExecConfig{Tty: false, AttachStdout: false, AttachStderr: false, Cmd: exec.GetCmd()}
 	respID, err := d.Client.ContainerExecCreate(context.Background(), cID, execConfig)
 	if err != nil {

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -398,12 +398,12 @@ func (c *IgniteRuntime) GetNSPath(ctx context.Context, ctrId string) (string, er
 	return result, nil
 }
 
-func (*IgniteRuntime) Exec(_ context.Context, _ string, _ types.ExecOperation) (types.ExecResultHolder, error) {
+func (*IgniteRuntime) Exec(_ context.Context, _ string, _ types.ExecCmd) (types.ExecResultHolder, error) {
 	log.Infof("Exec is not yet implemented for Ignite runtime")
 	return nil, nil
 }
 
-func (*IgniteRuntime) ExecNotWait(_ context.Context, _ string, _ types.ExecOperation) error {
+func (*IgniteRuntime) ExecNotWait(_ context.Context, _ string, _ types.ExecCmd) error {
 	log.Infof("ExecNotWait is not yet implemented for Ignite runtime")
 	return nil
 }

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -234,7 +234,7 @@ func (r *PodmanRuntime) GetNSPath(ctx context.Context, cID string) (string, erro
 	return nspath, nil
 }
 
-func (r *PodmanRuntime) Exec(ctx context.Context, cID string, exec types.ExecOperation) (types.ExecResultHolder, error) {
+func (r *PodmanRuntime) Exec(ctx context.Context, cID string, exec types.ExecCmd) (types.ExecResultHolder, error) {
 	ctx, err := r.connect(ctx)
 	if err != nil {
 		return nil, err
@@ -277,7 +277,7 @@ func (r *PodmanRuntime) Exec(ctx context.Context, cID string, exec types.ExecOpe
 	return execResult, nil
 }
 
-func (r *PodmanRuntime) ExecNotWait(ctx context.Context, cID string, exec types.ExecOperation) error {
+func (r *PodmanRuntime) ExecNotWait(ctx context.Context, cID string, exec types.ExecCmd) error {
 	ctx, err := r.connect(ctx)
 	if err != nil {
 		return err

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -46,9 +46,9 @@ type ContainerRuntime interface {
 	// Get a netns path using the pid of a container
 	GetNSPath(context.Context, string) (string, error)
 	// Executes cmd on container identified with id and returns stdout, stderr bytes and an error
-	Exec(ctx context.Context, cID string, exec types.ExecOperation) (types.ExecResultHolder, error)
+	Exec(ctx context.Context, cID string, exec types.ExecCmd) (types.ExecResultHolder, error)
 	// ExecNotWait executes cmd on container identified with id but doesn't wait for output nor attaches stdout/err
-	ExecNotWait(ctx context.Context, cID string, exec types.ExecOperation) error
+	ExecNotWait(ctx context.Context, cID string, exec types.ExecCmd) error
 	// Delete container by its name
 	DeleteContainer(context.Context, string) error
 	// Getter for runtime config options

--- a/types/exec.go
+++ b/types/exec.go
@@ -32,7 +32,7 @@ func ParseExecOutputFormat(s string) (ExecOutputFormat, error) {
 	return "", fmt.Errorf("cannot parse %q as 'ExecOutputFormat'", s)
 }
 
-type ExecOperation interface {
+type ExecCmd interface {
 	GetCmd() []string
 	GetCmdString() string
 }
@@ -41,7 +41,7 @@ type ExecOp struct {
 	Cmd []string `json:"cmd"`
 }
 
-func NewExec(cmd string) (ExecOperation, error) {
+func NewExecCmdFromString(cmd string) (ExecCmd, error) {
 	result := &ExecOp{}
 	if err := result.SetCmd(cmd); err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func NewExec(cmd string) (ExecOperation, error) {
 	return result, nil
 }
 
-func NewExecOperationSlice(cmd []string) ExecOperation {
+func NewExecCmdFromSlice(cmd []string) ExecCmd {
 	return &ExecOp{
 		Cmd: cmd,
 	}
@@ -73,7 +73,7 @@ type ExecResult struct {
 	Stderr     string   `json:"stderr"`
 }
 
-func NewExecResult(op ExecOperation) *ExecResult {
+func NewExecResult(op ExecCmd) *ExecResult {
 	er := &ExecResult{Cmd: op.GetCmd()}
 	return er
 }

--- a/utils/env.go
+++ b/utils/env.go
@@ -14,7 +14,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// convertEnvs convert env variables passed as a map to a list of them.
+// ConvertEnvs converts env variables passed as a map to a list of them.
 func ConvertEnvs(m map[string]string) []string {
 	s := make([]string, 0, len(m))
 	for k, v := range m {
@@ -35,7 +35,7 @@ func mapify(i interface{}) (map[string]interface{}, bool) {
 	return map[string]interface{}{}, false
 }
 
-// merge all dictionaries and return a new dictionary
+// MergeMaps merges all dictionaries and return a new dictionary
 // recursively if matching keys are both dictionaries.
 func MergeMaps(dicts ...map[string]interface{}) map[string]interface{} {
 	res := make(map[string]interface{})
@@ -63,7 +63,7 @@ func MergeMaps(dicts ...map[string]interface{}) map[string]interface{} {
 	return res
 }
 
-// merge all string maps and return a new map
+// MergeStringMaps merges all string maps and return a new map
 // maps that are passed for merging will not be changed
 // merging to empty maps return an empty map
 // merging nils return nil.
@@ -91,7 +91,7 @@ func MergeStringMaps(maps ...map[string]string) map[string]string {
 	return res
 }
 
-// does a slice contain a string.
+// StringInSlice checks if a slice contains `val` string and returns slice index if true.
 func StringInSlice(slice []string, val string) (int, bool) {
 	for i, item := range slice {
 		if item == val {

--- a/utils/ethtool.go
+++ b/utils/ethtool.go
@@ -17,13 +17,13 @@ const (
 	IFNAMSIZ        = 16         // linux/if.h
 )
 
-// linux/if.h 'struct ifreq'.
+// IFReqData linux/if.h 'struct ifreq'.
 type IFReqData struct {
 	Name [IFNAMSIZ]byte
 	Data uintptr
 }
 
-// linux/ethtool.h 'struct ethtool_value'.
+// EthtoolValue linux/ethtool.h 'struct ethtool_value'.
 type EthtoolValue struct {
 	Cmd  uint32
 	Data uint32

--- a/utils/file.go
+++ b/utils/file.go
@@ -91,7 +91,7 @@ func CopyFileContents(src, dst string, mode os.FileMode) (err error) {
 			return err
 		}
 	}
-	defer in.Close()
+	defer in.Close() // skipcq: GO-S2307
 
 	out, err := os.Create(dst)
 	if err != nil {

--- a/utils/file.go
+++ b/utils/file.go
@@ -124,12 +124,16 @@ func CreateFile(file, content string) (err error) {
 	var f *os.File
 
 	f, err = os.Create(file)
-	if err == nil {
-		defer f.Close()
-		_, err = f.WriteString(content + "\n")
+	if err != nil {
+		return err
 	}
 
-	return err
+	_, err = f.WriteString(content + "\n")
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
 }
 
 // CreateDirectory creates a directory by a path with a mode/permission specified by perm.


### PR DESCRIPTION
Hi @steiler 

I propose to make the following changes in the part1 of the review.

Here I rename the Node interface methods to `RunExecs` and `RunExec`

`RunExecs` take a list of string commands to work on, whereas `RunExec` take an `ExecCmd` (renamed).

I have changed the commands used for different kinds from `slice` to `string` type, as it is easier for humans to check what the command is about visually.

PS. I plan to do more renaming in the following PRs, but before I wanted to clear this major change with you first