### PR TITLE
Implementing xrd kind

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,7 +13,7 @@ on:
 env:
   GOVER: 1.18.4
   CGO_ENABLED: 0
-  MKDOCS_INS_VER: 8.5.6-insiders-4.25.4-hellt-hellt
+  MKDOCS_INS_VER: 8.5.11-insiders-4.27.0-hellt
   GORELEASER_VER: v1.11.4
   PODMAN_VER: v4.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY = $$(pwd)/bin/containerlab
 MKDOCS_VER = 8.3.9
 # insiders version/tag https://github.com/srl-labs/mkdocs-material-insiders/pkgs/container/mkdocs-material-insiders
 # make sure to also change the mkdocs version in actions' cicd.yml and force-build.yml files
-MKDOCS_INS_VER = 8.5.6-insiders-4.25.4-hellt-hellt
+MKDOCS_INS_VER = 8.5.11-insiders-4.27.0-hellt
 
 include .mk/lint.mk
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -31,8 +31,9 @@ var interfaceFormat = map[string]string{
 	"vr-vqfx":  "eth%d",
 	"vr-xrv9k": "eth%d",
 	"vr-veos":  "eth%d",
+	"xrd":      "eth%d",
 }
-var supportedKinds = []string{"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros", "vr-vmx", "vr-vqfx", "vr-xrv9k"}
+var supportedKinds = []string{"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros", "vr-vmx", "vr-vqfx", "vr-xrv9k", "vr-veos", "xrd"}
 
 const (
 	defaultSRLType     = "ixrd2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Containerlab focuses on the containerized Network Operating Systems which are ty
 
 * [Nokia SR Linux](manual/kinds/srl.md)
 * [Arista cEOS](manual/kinds/ceos.md)
+* [Cisco XRd](manual/kinds/xrd.md)
 * [Azure SONiC](manual/kinds/sonic-vs.md)
 * [Juniper cRPD](manual/kinds/crpd.md)
 * [Cumulus VX](manual/kinds/cvx.md)

--- a/docs/lab-examples/srl-xrd.md
+++ b/docs/lab-examples/srl-xrd.md
@@ -1,0 +1,49 @@
+|                               |                                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| **Description**               | A Nokia SR Linux connected back-to-back with Cisco XRd                         |
+| **Components**                | [Nokia SR Linux][srl], [Cisco XRd][xrd]                                               |
+| **Resource requirements**[^1] | :fontawesome-solid-microchip: 2 <br/>:fontawesome-solid-memory: 4 GB             |
+| **Topology file**             | [srlxrd01.clab.yml][topofile]                                                   |
+| **Name**                      | srlxrd01                                                                        |
+| **Version information**[^2]   | `containerlab:0.34.0`, `srlinux:22.11.1`, `xrd:7.8.1`, `docker-ce:19.03.13` |
+
+## Description
+
+A lab consists of an SR Linux node connected with Cisco XRd via a point-to-point ethernet link. Both nodes are also connected with their management interfaces to the `containerlab` docker network.
+
+## Use cases
+
+This lab allows users to launch basic interoperability scenarios between Nokia SR Linux and Cisco XRd operating systems.
+
+## Configuration
+
+Both SR Linux and XRd nodes come with a startup config files referenced for them. These user-defined startup files introduce the following change on top of the default config that these nodes boot with:
+
+* On SR Linux, interface `ethernet-1/1` is configured with `192.168.0.0/31` address and this interface attached to the default network instance.
+* On XRd, interface `Gi 0/0/0/0` is configured with `192.168.0.1/31` address.
+
+## Verification
+
+When the deployment of the lab finishes, users can validate that the datapath works between the nodes by pinging the directly connected interfaces from either node.
+
+Here is an example from SR Linux side:
+
+```bash
+--{ running }--[  ]--
+A:srl# ping network-instance default 192.168.0.1 
+Using network instance default
+PING 192.168.0.1 (192.168.0.1) 56(84) bytes of data.
+64 bytes from 192.168.0.1: icmp_seq=1 ttl=255 time=12.0 ms
+64 bytes from 192.168.0.1: icmp_seq=2 ttl=255 time=6.83 ms
+^C
+--- 192.168.0.1 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 6.830/9.428/12.027/2.600 ms
+```
+
+[srl]: https://www.nokia.com/networks/products/service-router-linux-NOS/
+[xrd]: ../manual/kinds/xrd.md
+[topofile]: https://github.com/srl-labs/containerlab/tree/main/lab-examples/srlxrd01/srlxrd01.clab.yml
+
+[^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
+[^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.

--- a/docs/manual/kinds/xrd.md
+++ b/docs/manual/kinds/xrd.md
@@ -22,7 +22,7 @@ XRd image is available for download only for users who have an active service ac
 
 ## Managing XRd nodes
 
-There are many ways to manage SR Linux nodes, ranging from classic CLI management all the way up to the gNMI programming.
+There are several management interfaces supported by XRd nodes:
 
 === "bash"
     to connect to a `bash` shell of a running XRd container:
@@ -57,7 +57,7 @@ XRd container uses the following mapping for its linux interfaces[^2]:
 * `eth1` - first data interface mapped to `Gi0/0/0/0` internal interface.
 * `ethN` - Nth data interface mapped to `Gi0/0/0/N-1` internal interface.
 
-When containerlab launches XRd node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and XRd node will boot with that addresses configured for its `MgmthEth0`. Data interfaces `eth1+` need to be configured with IP addressing manually.
+When containerlab launches XRd node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and XRd node will boot with these addresses configured for its `MgmthEth0`. Data interfaces `eth1+` need to be configured with IP addressing manually.
 
 ```
 RP/0/RP0/CPU0:xrd#sh ip int br
@@ -71,11 +71,11 @@ MgmtEth0/RP0/CPU0/0            172.20.20.5     Up              Up       default
 
 ### Node configuration
 
-XRd nodes have a dedicated [`config`](../conf-artifacts.md#identifying-a-lab-directory) directory that is used to persist the configuration of the node and expose internal direcotories of the NOS.
+XRd nodes have a dedicated [`config`](../conf-artifacts.md#identifying-a-lab-directory) directory that is used to persist the configuration of the node and expose internal directories of the NOS.
 
-For XRd nodes, containerlab exposes the following file layout of node's lab directory:
+For XRd nodes, containerlab exposes the following file layout of the node's lab directory:
 
-* `xr-storage` (dir): a directory that is mounted to `/xr-storage` path of the NOS and provides access to logs and various runtime files.
+* `xr-storage` (dir): a directory that is mounted to `/xr-storage` path of the NOS and is used to persist changes made to the node as well as provides access to the logs and various runtime files.
 * `first-boot.cfg` - a configuration file in Cisco IOS-XR CLI format that the node boots with.
 
 #### Default node configuration
@@ -97,7 +97,7 @@ topology:
 
 #### User defined config
 
-It is possible to make XRd nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property a user sets the path to the config file that will be mounted to a container and used as a startup config:
+It is possible to make XRd nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property a user sets the path to the config file that will be mounted to a container and used as a startup-config:
 
 ```yaml
 name: xrd
@@ -110,12 +110,18 @@ topology:
 
 When a config file is passed via `startup-config` parameter it will be used during an initial lab deployment. However, a config file that might be in the lab directory of a node takes precedence over the startup-config[^3].
 
-With such topology file containerlab is instructed to take a file `xrd.cfg` from the current working directory and copy it to the lab directory for that specific node under the `/first-boot.cfg` name. This will result in this config to act as a startup config for the node.
+With such topology file containerlab is instructed to take a file `xrd.cfg` from the current working directory and copy it to the lab directory for that specific node under the `/first-boot.cfg` name. This will result in this config acting as a startup-config for the node.
 
 To provide a user-defined config, take the [default configuration template](https://github.com/srl-labs/containerlab/blob/main/nodes/xrd/xrd.cfg) and add the necessary configuration commands without changing the rest of the file. This will result in proper automatic assignment of IP addresses to the management interface, as well as applying user-defined commands.
 
 !!!tip
     Check [SR Linux and XRd](../../lab-examples/srl-xrd.md) lab example where startup configuration files are provided to both nodes to see it in action.
+
+#### Configuration persistency
+
+XRd nodes persist their configuration in `<lab-directory>/<node-name>/xr-storage` directory. When a user commits changes to XRd nodes using one of the management interfaces, they are kept in the configuration DB (but not exposed as a configuration file).
+
+This capability allows users to configure the XRd node, commit the changes, then destroy the lab (without using `--cleanup` flag to keep the lab dir intact) and on a subsequent deploy action, the node will boot with the previously saved configuration.
 
 ## Lab examples
 

--- a/docs/manual/kinds/xrd.md
+++ b/docs/manual/kinds/xrd.md
@@ -57,7 +57,7 @@ XRd container uses the following mapping for its linux interfaces[^2]:
 * `eth1` - first data interface mapped to `Gi0/0/0/0` internal interface.
 * `ethN` - Nth data interface mapped to `Gi0/0/0/N-1` internal interface.
 
-When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and XRd node will boot with that addresses configured for its `MgmthEth0`. Data interfaces `eth1+` need to be configured with IP addressing manually.
+When containerlab launches XRd node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and XRd node will boot with that addresses configured for its `MgmthEth0`. Data interfaces `eth1+` need to be configured with IP addressing manually.
 
 ```
 RP/0/RP0/CPU0:xrd#sh ip int br

--- a/docs/manual/kinds/xrd.md
+++ b/docs/manual/kinds/xrd.md
@@ -1,0 +1,128 @@
+---
+search:
+  boost: 4
+---
+# Cisco XRd
+
+[Cisco XRd](https://www.cisco.com/c/en/us/support/routers/ios-xrd/series.html) Network OS is identified with `xrd` or `cisco_xrd` kind in the [topology file](../topo-def-file.md). A kind defines a supported feature set and a startup procedure of a node.
+
+XRd comes in two [variants](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-xrd-images-where-can-one-get-them/#xrd-form-factors):
+
+* control-plane
+* vrouter
+
+Containerlab supports only the control-plane flavor of XRd, as it allows to build topologies using virtual interfaces, whereas vrouter requires PCI interfaces to be attached to it.
+
+!!!tip
+    Consult with [XRd Tutorials](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-xrd-images-where-can-one-get-them/) series to get an in-depth understanding of XRd requirements and capabilities.
+
+## Getting XRd
+
+XRd image is available for download only for users who have an active service account[^1].
+
+## Managing XRd nodes
+
+There are many ways to manage SR Linux nodes, ranging from classic CLI management all the way up to the gNMI programming.
+
+=== "bash"
+    to connect to a `bash` shell of a running XRd container:
+    ```bash
+    docker exec -it <container-name/id> bash
+    ```
+=== "SSH"
+    `ssh clab@<container-name>`  
+    Password: `clab@123`
+=== "gNMI"
+    gNMI server runs on `9339` port in the insecure mode (no TLS).  
+    Using [gnmic](https://gnmic.openconfig.net) gNMI client as an example:
+    ```bash
+    gnmic -a <container-name/node-mgmt-address>:9339 --insecure \
+      -u clab -p clab@123 \
+      capabilities
+    ```
+=== "Netconf"
+    Netconf server runs on `830` port:  
+    ```
+    ssh clab@<container-name> -p 830 -s netconf
+    ```
+
+!!!info
+    Default credentials: `clab:clab@123`
+
+## Interfaces mapping
+
+XRd container uses the following mapping for its linux interfaces[^2]:
+
+* `eth0` - management interface connected to the containerlab management network
+* `eth1` - first data interface mapped to `Gi0/0/0/0` internal interface.
+* `ethN` - Nth data interface mapped to `Gi0/0/0/N-1` internal interface.
+
+When containerlab launches ceos node, it will set IPv4/6 addresses as assigned by docker to the `eth0` interface and XRd node will boot with that addresses configured for its `MgmthEth0`. Data interfaces `eth1+` need to be configured with IP addressing manually.
+
+```
+RP/0/RP0/CPU0:xrd#sh ip int br
+Wed Dec 21 12:04:13.049 UTC
+
+Interface                      IP-Address      Status          Protocol Vrf-Name
+MgmtEth0/RP0/CPU0/0            172.20.20.5     Up              Up       default
+```
+
+## Features and options
+
+### Node configuration
+
+XRd nodes have a dedicated [`config`](../conf-artifacts.md#identifying-a-lab-directory) directory that is used to persist the configuration of the node and expose internal direcotories of the NOS.
+
+For XRd nodes, containerlab exposes the following file layout of node's lab directory:
+
+* `xr-storage` (dir): a directory that is mounted to `/xr-storage` path of the NOS and provides access to logs and various runtime files.
+* `first-boot.cfg` - a configuration file in Cisco IOS-XR CLI format that the node boots with.
+
+#### Default node configuration
+
+It is possible to launch nodes of `cisco_xrd` kind with a basic config or to provide a custom config file that will be used as a startup config instead.
+
+When a node is defined without `startup-config` statement present, containerlab will generate an empty config from [this template](https://github.com/srl-labs/containerlab/blob/main/nodes/xrd/xrd.cfg) and copy it to the config directory of the node.
+
+```yaml
+# example of a topo file that does not define a custom config
+# as a result, the config will be generated from a template
+# and used by this node
+name: xrd
+topology:
+  nodes:
+    xrd:
+      kind: cisco_xrd
+```
+
+#### User defined config
+
+It is possible to make XRd nodes to boot up with a user-defined config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property a user sets the path to the config file that will be mounted to a container and used as a startup config:
+
+```yaml
+name: xrd
+topology:
+  nodes:
+    xrd:
+      kind: cisco_xrd
+      startup-config: xrd.cfg
+```
+
+When a config file is passed via `startup-config` parameter it will be used during an initial lab deployment. However, a config file that might be in the lab directory of a node takes precedence over the startup-config[^3].
+
+With such topology file containerlab is instructed to take a file `xrd.cfg` from the current working directory and copy it to the lab directory for that specific node under the `/first-boot.cfg` name. This will result in this config to act as a startup config for the node.
+
+To provide a user-defined config, take the [default configuration template](https://github.com/srl-labs/containerlab/blob/main/nodes/xrd/xrd.cfg) and add the necessary configuration commands without changing the rest of the file. This will result in proper automatic assignment of IP addresses to the management interface, as well as applying user-defined commands.
+
+!!!tip
+    Check [SR Linux and XRd](../../lab-examples/srl-xrd.md) lab example where startup configuration files are provided to both nodes to see it in action.
+
+## Lab examples
+
+The following labs feature XRd nodes:
+
+* [SR Linux and XRd](../../lab-examples/srl-xrd.md)
+
+[^1]: https://xrdocs.io/virtual-routing/tutorials/2022-08-22-xrd-images-where-can-one-get-them/
+[^2]: It is not yet possible to manually assign interface mapping rules in containerlab for XRd nodes. PRs are welcome.
+[^3]: if startup config needs to be enforced, either deploy a lab with `--reconfigure` flag, or use [`enforce-startup-config`](../nodes.md#enforce-startup-config) setting.

--- a/lab-examples/srlxrd01/srl.cfg
+++ b/lab-examples/srlxrd01/srl.cfg
@@ -1,0 +1,9 @@
+set / interface ethernet-1/1
+set / interface ethernet-1/1 subinterface 0
+set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.0.0/31
+set / interface ethernet-1/1 subinterface 0 ipv6
+set / interface ethernet-1/1 subinterface 0 ipv6 address 2002::192.168.0.0/127
+
+set / network-instance default
+set / network-instance default interface ethernet-1/1.0

--- a/lab-examples/srlxrd01/srlxrd01.clab.yml
+++ b/lab-examples/srlxrd01/srlxrd01.clab.yml
@@ -13,4 +13,4 @@ topology:
       startup-config: xrd.cfg
 
   links:
-    - endpoints: ["srl:e1-1", "xrd:eth1"]
+    - endpoints: ["srl:e1-1", "xrd:Gi0-0-0-0"]

--- a/lab-examples/srlxrd01/srlxrd01.clab.yml
+++ b/lab-examples/srlxrd01/srlxrd01.clab.yml
@@ -1,0 +1,15 @@
+name: srlxrd01
+
+topology:
+  nodes:
+    srl:
+      kind: nokia_srlinux
+      image: ghcr.io/nokia/srlinux
+      startup-config: srl.cfg
+
+    xrd:
+      kind: cisco_xrd
+      image: xrd-control-plane
+
+  links:
+    - endpoints: ["srl:e1-1", "xrd:eth1"]

--- a/lab-examples/srlxrd01/srlxrd01.clab.yml
+++ b/lab-examples/srlxrd01/srlxrd01.clab.yml
@@ -10,6 +10,7 @@ topology:
     xrd:
       kind: cisco_xrd
       image: xrd-control-plane
+      startup-config: xrd.cfg
 
   links:
     - endpoints: ["srl:e1-1", "xrd:eth1"]

--- a/lab-examples/srlxrd01/xrd.cfg
+++ b/lab-examples/srlxrd01/xrd.cfg
@@ -1,0 +1,53 @@
+!
+hostname {{ .ShortName }}
+!
+username clab
+ group root-lr
+ group cisco-support
+ secret clab@123
+!
+grpc
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+ port 9339
+ no-tls
+ address-family dual
+!
+{{- if .Env.CLAB_MGMT_VRF }}
+vrf {{ .Env.CLAB_MGMT_VRF }}
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+{{- end}}
+!
+line default
+  transport input ssh
+!
+netconf-yang agent
+ ssh
+!
+interface MgmtEth0/RP0/CPU0/0
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+!
+interface GigabitEthernet0/0/0/0
+ ipv4 address 192.168.0.1 255.255.255.254
+!
+router static
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+{{- if .MgmtIPv4Gateway }}
+ address-family ipv4 unicast
+  0.0.0.0/0 MgmtEth0/RP0/CPU0/0 {{ .MgmtIPv4Gateway }}
+  !
+{{- end}}
+{{- if .MgmtIPv6Gateway }}
+ address-family ipv6 unicast
+  ::/0 MgmtEth0/RP0/CPU0/0 {{ .MgmtIPv6Gateway }}
+  !
+{{- end}}
+!
+ssh server v2
+{{- if .Env.CLAB_MGMT_VRF }}
+ssh server vrf {{ .Env.CLAB_MGMT_VRF }}
+{{- end}}
+ssh server netconf {{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+end

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,6 +185,7 @@ plugins:
   - redirects:
       redirect_maps:
         lab-examples/tls-cert.md: https://clabs.netdevops.me/security/gnmitls/
+  - typeset
 
 # Customization
 extra:
@@ -211,7 +212,7 @@ markdown_extensions:
   - markdown.extensions.def_list
   - markdown.extensions.footnotes
   - markdown.extensions.meta
-  - markdown.extensions.toc:
+  - toc:
       permalink: "#"
   - pymdownx.arithmatex
   - pymdownx.betterem:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
           - Juniper cRPD: manual/kinds/crpd.md
           - Juniper vMX: manual/kinds/vr-vmx.md
           - Juniper vQFX: manual/kinds/vr-vqfx.md
+          - Cisco XRd: manual/kinds/xrd.md
           - Cisco XRv9k: manual/kinds/vr-xrv9k.md
           - Cisco XRv: manual/kinds/vr-xrv.md
           - Cisco CSR1000v: manual/kinds/vr-csr.md

--- a/nodes/all/all.go
+++ b/nodes/all/all.go
@@ -31,6 +31,7 @@ import (
 	vr_vqfx "github.com/srl-labs/containerlab/nodes/vr_vqfx"
 	vr_xrv "github.com/srl-labs/containerlab/nodes/vr_xrv"
 	vr_xrv9k "github.com/srl-labs/containerlab/nodes/vr_xrv9k"
+	xrd "github.com/srl-labs/containerlab/nodes/xrd"
 )
 
 // RegisterAll registers all the nodes/kinds supported by containerlab.
@@ -61,4 +62,5 @@ func RegisterAll() {
 	vr_vqfx.Register()
 	vr_xrv.Register()
 	vr_xrv9k.Register()
+	xrd.Register()
 }

--- a/nodes/xrd/xrd.cfg
+++ b/nodes/xrd/xrd.cfg
@@ -1,6 +1,3 @@
-!! Copyright 2022 Nokia
-!! Licensed under the BSD 3-Clause License.
-!! SPDX-License-Identifier: BSD-3-Clause
 !
 hostname {{ .ShortName }}
 !

--- a/nodes/xrd/xrd.cfg
+++ b/nodes/xrd/xrd.cfg
@@ -45,6 +45,6 @@ router static
 ssh server v2
 {{- if .Env.CLAB_MGMT_VRF }}
 ssh server vrf {{ .Env.CLAB_MGMT_VRF }}
-ssh server netconf vrf {{ .Env.CLAB_MGMT_VRF }}
 {{- end}}
+ssh server netconf {{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
 end

--- a/nodes/xrd/xrd.cfg
+++ b/nodes/xrd/xrd.cfg
@@ -8,7 +8,7 @@ username clab
 !
 grpc
 {{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
- port 57344
+ port 9339
  no-tls
  address-family dual
 !

--- a/nodes/xrd/xrd.cfg
+++ b/nodes/xrd/xrd.cfg
@@ -1,0 +1,53 @@
+!! Copyright 2022 Nokia
+!! Licensed under the BSD 3-Clause License.
+!! SPDX-License-Identifier: BSD-3-Clause
+!
+hostname {{ .ShortName }}
+!
+username clab
+ group root-lr
+ group cisco-support
+ secret clab@123
+!
+grpc
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+ port 57344
+ no-tls
+ address-family dual
+!
+{{- if .Env.CLAB_MGMT_VRF }}
+vrf {{ .Env.CLAB_MGMT_VRF }}
+ address-family ipv4 unicast
+ !
+ address-family ipv6 unicast
+ !
+{{- end}}
+!
+line default
+  transport input ssh
+!
+netconf-yang agent
+ ssh
+!
+interface MgmtEth0/RP0/CPU0/0
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+!
+router static
+{{ if .Env.CLAB_MGMT_VRF }} vrf {{ .Env.CLAB_MGMT_VRF }}{{end}}
+{{- if .MgmtIPv4Gateway }}
+ address-family ipv4 unicast
+  0.0.0.0/0 MgmtEth0/RP0/CPU0/0 {{ .MgmtIPv4Gateway }}
+  !
+{{- end}}
+{{- if .MgmtIPv6Gateway }}
+ address-family ipv6 unicast
+  ::/0 MgmtEth0/RP0/CPU0/0 {{ .MgmtIPv6Gateway }}
+  !
+{{- end}}
+!
+ssh server v2
+{{- if .Env.CLAB_MGMT_VRF }}
+ssh server vrf {{ .Env.CLAB_MGMT_VRF }}
+ssh server netconf vrf {{ .Env.CLAB_MGMT_VRF }}
+{{- end}}
+end

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -1,0 +1,128 @@
+// Copyright 2022 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package xrd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/netconf"
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindnames = []string{"xrd", "cisco_xrd"}
+	xrdEnv    = map[string]string{
+		"XR_FIRST_BOOT_CONFIG": "/etc/xrd/first-boot.cfg",
+		"XR_MGMT_INTERFACES":   "linux:eth0,xr_name=Mg0/RP0/CPU0/0,chksum,snoop_v4,snoop_v6",
+	}
+
+	//go:embed xrd.cfg
+	cfgTemplate string
+)
+
+const (
+	scrapliPlatformName = "cisco_iosxr"
+	defaultUser         = "clab"
+	defaultPassword     = "clab@123"
+)
+
+// Register registers the node in the global Node map.
+func Register() {
+	nodes.Register(kindnames, func() nodes.Node {
+		return new(xrd)
+	})
+	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
+	if err != nil {
+		log.Error(err)
+	}
+}
+
+type xrd struct {
+	nodes.DefaultNode
+}
+
+func (n *xrd) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init DefaultNode
+	n.DefaultNode = *nodes.NewDefaultNode(n)
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+
+	var interfaceEnvContent string
+	for i := 1; i <= 90; i++ {
+		interfaceEnvContent += fmt.Sprintf("linux:eth%d,xr_name=Gi0/0/0/%d;", i, i-1)
+	}
+	interfaceEnv := map[string]string{"XR_INTERFACES": interfaceEnvContent}
+
+	n.Cfg.Env = utils.MergeStringMaps(xrdEnv, interfaceEnv, n.Cfg.Env)
+
+	n.Cfg.Binds = append(n.Cfg.Binds,
+		// mount first-boot config file
+		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "first-boot.cfg"), ":/etc/xrd/first-boot.cfg"),
+		// persist data by mounting /xr-storage
+		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "xr-storage"), ":/xr-storage"),
+	)
+
+	return nil
+}
+
+func (n *xrd) PreDeploy(ctx context.Context, _, _, _ string) error {
+	utils.CreateDirectory(n.Cfg.LabDir, 0777)
+	return n.createXRDFiles(ctx)
+}
+
+func (n *xrd) SaveConfig(_ context.Context) error {
+	err := netconf.SaveConfig(n.Cfg.LongName,
+		defaultUser,
+		defaultPassword,
+		scrapliPlatformName,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("saved %s running configuration to startup configuration file\n", n.Cfg.ShortName)
+	return nil
+}
+
+func (n *xrd) createXRDFiles(_ context.Context) error {
+	nodeCfg := n.Config()
+	// generate xr-storage directory
+	utils.CreateDirectory(filepath.Join(n.Cfg.LabDir, "xr-storage"), 0777)
+	// generate first-boot config
+	cfg := filepath.Join(n.Cfg.LabDir, "first-boot.cfg")
+	nodeCfg.ResStartupConfig = cfg
+
+	// set mgmt IPv4/IPv6 gateway as it is already known by now
+	// since the container network has been created before we launch nodes
+	// and mgmt gateway can be used in xrd.Cfg template to configure default route for mgmt
+	nodeCfg.MgmtIPv4Gateway = n.Runtime.Mgmt().IPv4Gw
+	nodeCfg.MgmtIPv6Gateway = n.Runtime.Mgmt().IPv6Gw
+
+	// use startup config file provided by a user
+	if nodeCfg.StartupConfig != "" {
+		c, err := os.ReadFile(nodeCfg.StartupConfig)
+		if err != nil {
+			return err
+		}
+		cfgTemplate = string(c)
+	}
+
+	err := n.GenerateConfig(nodeCfg.ResStartupConfig, cfgTemplate)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -125,12 +125,12 @@ func (n *xrd) createXRDFiles(_ context.Context) error {
 // genInterfacesEnv calculates how many interfaces were defined for xrd node
 // and populates the content of a required env var.
 func (n *xrd) genInterfacesEnv() {
-	// xrd (at least control-plane variant) needs XR_INTERFACE ENV var to be populated for all active interface
+	// xrd-control-plane variant needs XR_INTERFACE ENV var to be populated for all active interface
 	// here we take the number of links users set in the topology to get the right # of links
 	var interfaceEnvVar string
 
-	for i := range n.Config().Endpoints {
-		interfaceEnvVar += fmt.Sprintf("linux:eth%d,xr_name=Gi0/0/0/%d;", i+1, i)
+	for i, ep := range n.Config().Endpoints {
+		interfaceEnvVar += fmt.Sprintf("linux:%s,xr_name=Gi0/0/0/%d;", ep.EndpointName, i)
 	}
 
 	interfaceEnv := map[string]string{"XR_INTERFACES": interfaceEnvVar}

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -66,7 +66,8 @@
                         "keysight_ixia-c-one",
                         "ipinfusion_ocnos",
                         "checkpoint_cloudguard",
-                        "ext-container"
+                        "ext-container",
+                        "xrd"
                     ]
                 },
                 "license": {
@@ -544,6 +545,9 @@
                             "$ref": "#/definitions/node-config"
                         },
                         "ext-container": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "xrd": {
                             "$ref": "#/definitions/node-config"
                         }
                     }


### PR DESCRIPTION
This PR is created to include support of [Cisco IOS XRd](https://www.cisco.com/c/en/us/support/routers/ios-xrd/series.html): xrd-control-plane in containerlab

Here are some lab examples for testing(still work in progress):
- https://github.com/trustywolf/xrd-containerlab

Inspired by #1101 #1072 #1059

References:
- [xrd-tools](https://github.com/ios-xr/xrd-tools)
- [XRd tutorials Series](https://xrdocs.io/virtual-routing/tags/#xrd-tutorial-series)