### PR TITLE
Introducing NodeRegistry

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -15,7 +15,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
-	allNodes "github.com/srl-labs/containerlab/nodes/all"
 	"github.com/srl-labs/containerlab/runtime"
 	_ "github.com/srl-labs/containerlab/runtime/all"
 	"github.com/srl-labs/containerlab/runtime/docker"
@@ -129,7 +128,7 @@ func NewContainerLab(opts ...ClabOption) (*CLab, error) {
 	c.reg = nodes.NewNodeRegistry()
 
 	// register all nodes
-	allNodes.RegisterAll(c.reg)
+	c.RegisterNodes()
 
 	for _, opt := range opts {
 		err := opt(c)

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -23,8 +23,6 @@ import (
 	"github.com/srl-labs/containerlab/types"
 )
 
-var once sync.Once // nolint:gochecknoglobals
-
 type CLab struct {
 	Config        *Config   `json:"config,omitempty"`
 	TopoFile      *TopoFile `json:"topofile,omitempty"`
@@ -113,8 +111,12 @@ func WithTopoFile(file, varsFile string) ClabOption {
 
 // NewContainerLab function defines a new container lab.
 func NewContainerLab(opts ...ClabOption) (*CLab, error) {
-	// register all nodes just once
-	once.Do(allNodes.RegisterAll)
+
+	// init a new NodeRegistry
+	NodeKindRegistry := nodes.NewNodeRegistry()
+
+	// register all nodes
+	allNodes.RegisterAll(NodeKindRegistry)
 
 	c := &CLab{
 		Config: &Config{
@@ -137,7 +139,7 @@ func NewContainerLab(opts ...ClabOption) (*CLab, error) {
 
 	var err error
 	if c.TopoFile.path != "" {
-		err = c.parseTopology()
+		err = c.parseTopology(NodeKindRegistry)
 	}
 
 	return c, err

--- a/clab/clab_test.go
+++ b/clab/clab_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/srl-labs/containerlab/mocks"
 	"github.com/srl-labs/containerlab/nodes"
-	_ "github.com/srl-labs/containerlab/nodes/all"
 	"github.com/srl-labs/containerlab/runtime"
 	_ "github.com/srl-labs/containerlab/runtime/all"
 	"github.com/srl-labs/containerlab/types"

--- a/clab/config.go
+++ b/clab/config.go
@@ -61,7 +61,7 @@ type Config struct {
 }
 
 // ParseTopology parses the lab topology.
-func (c *CLab) parseTopology(nodeFactory nodes.NodeFactory) error {
+func (c *CLab) parseTopology() error {
 	log.Infof("Parsing & checking topology file: %s", c.TopoFile.fullName)
 
 	cwd, _ := filepath.Abs(os.Getenv("PWD"))
@@ -135,7 +135,7 @@ func (c *CLab) parseTopology(nodeFactory nodes.NodeFactory) error {
 
 	var err error
 	for idx, nodeName := range nodeNames {
-		err = c.NewNode(nodeName, nodeRuntimes[nodeName], c.Config.Topology.Nodes[nodeName], idx, nodeFactory)
+		err = c.NewNode(nodeName, nodeRuntimes[nodeName], c.Config.Topology.Nodes[nodeName], idx)
 		if err != nil {
 			return err
 		}
@@ -152,14 +152,14 @@ func (c *CLab) parseTopology(nodeFactory nodes.NodeFactory) error {
 }
 
 // NewNode initializes a new node object.
-func (c *CLab) NewNode(nodeName, nodeRuntime string, nodeDef *types.NodeDefinition, idx int, nodeFactory nodes.NodeFactory) error {
+func (c *CLab) NewNode(nodeName, nodeRuntime string, nodeDef *types.NodeDefinition, idx int) error {
 	nodeCfg, err := c.createNodeCfg(nodeName, nodeDef, idx)
 	if err != nil {
 		return err
 	}
 
 	// construct node
-	n, err := nodeFactory.NewNodeOfKind(nodeCfg.Kind)
+	n, err := c.reg.NewNodeOfKind(nodeCfg.Kind)
 	if err != nil {
 		return fmt.Errorf("error constructing node %q: %v", nodeCfg.ShortName, err)
 	}

--- a/clab/file.go
+++ b/clab/file.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -127,7 +126,7 @@ func readTemplateVariables(topo, varsFile string) (interface{}, error) {
 		return nil, nil
 	}
 READFILE:
-	data, err := ioutil.ReadFile(varsFile)
+	data, err := os.ReadFile(varsFile)
 	if err != nil {
 		return nil, err
 	}

--- a/clab/register.go
+++ b/clab/register.go
@@ -2,10 +2,9 @@
 // Licensed under the BSD 3-Clause License.
 // SPDX-License-Identifier: BSD-3-Clause
 
-package all
+package clab
 
 import (
-	"github.com/srl-labs/containerlab/nodes"
 	bridge "github.com/srl-labs/containerlab/nodes/bridge"
 	ceos "github.com/srl-labs/containerlab/nodes/ceos"
 	checkpoint_cloudguard "github.com/srl-labs/containerlab/nodes/checkpoint_cloudguard"
@@ -35,33 +34,33 @@ import (
 	xrd "github.com/srl-labs/containerlab/nodes/xrd"
 )
 
-// RegisterAll registers all the nodes/kinds supported by containerlab.
-func RegisterAll(r *nodes.NodeRegistry) {
-	bridge.Register(r)
-	ceos.Register(r)
-	checkpoint_cloudguard.Register(r)
-	crpd.Register(r)
-	cvx.Register(r)
-	ext_container.Register(r)
-	host.Register(r)
-	ipinfusion_ocnos.Register(r)
-	keysight_ixiacone.Register(r)
-	linux.Register(r)
-	mysocketio.Register(r)
-	ovs.Register(r)
-	sonic.Register(r)
-	srl.Register(r)
-	vr_csr.Register(r)
-	vr_ftosv.Register(r)
-	vr_n9kv.Register(r)
-	vr_nxos.Register(r)
-	vr_pan.Register(r)
-	vr_ros.Register(r)
-	vr_sros.Register(r)
-	vr_veos.Register(r)
-	vr_vmx.Register(r)
-	vr_vqfx.Register(r)
-	vr_xrv.Register(r)
-	vr_xrv9k.Register(r)
-	xrd.Register(r)
+// RegisterNodes registers all the nodes/kinds supported by containerlab.
+func (c *CLab) RegisterNodes() {
+	bridge.Register(c.reg)
+	ceos.Register(c.reg)
+	checkpoint_cloudguard.Register(c.reg)
+	crpd.Register(c.reg)
+	cvx.Register(c.reg)
+	ext_container.Register(c.reg)
+	host.Register(c.reg)
+	ipinfusion_ocnos.Register(c.reg)
+	keysight_ixiacone.Register(c.reg)
+	linux.Register(c.reg)
+	mysocketio.Register(c.reg)
+	ovs.Register(c.reg)
+	sonic.Register(c.reg)
+	srl.Register(c.reg)
+	vr_csr.Register(c.reg)
+	vr_ftosv.Register(c.reg)
+	vr_n9kv.Register(c.reg)
+	vr_nxos.Register(c.reg)
+	vr_pan.Register(c.reg)
+	vr_ros.Register(c.reg)
+	vr_sros.Register(c.reg)
+	vr_veos.Register(c.reg)
+	vr_vmx.Register(c.reg)
+	vr_vqfx.Register(c.reg)
+	vr_xrv.Register(c.reg)
+	vr_xrv9k.Register(c.reg)
+	xrd.Register(c.reg)
 }

--- a/nodes/all/all.go
+++ b/nodes/all/all.go
@@ -36,7 +36,7 @@ import (
 )
 
 // RegisterAll registers all the nodes/kinds supported by containerlab.
-func RegisterAll(r nodes.NodeRergistryRegistrator) {
+func RegisterAll(r *nodes.NodeRegistry) {
 	bridge.Register(r)
 	ceos.Register(r)
 	checkpoint_cloudguard.Register(r)

--- a/nodes/all/all.go
+++ b/nodes/all/all.go
@@ -5,6 +5,7 @@
 package all
 
 import (
+	"github.com/srl-labs/containerlab/nodes"
 	bridge "github.com/srl-labs/containerlab/nodes/bridge"
 	ceos "github.com/srl-labs/containerlab/nodes/ceos"
 	checkpoint_cloudguard "github.com/srl-labs/containerlab/nodes/checkpoint_cloudguard"
@@ -35,32 +36,32 @@ import (
 )
 
 // RegisterAll registers all the nodes/kinds supported by containerlab.
-func RegisterAll() {
-	bridge.Register()
-	ceos.Register()
-	checkpoint_cloudguard.Register()
-	crpd.Register()
-	cvx.Register()
-	ext_container.Register()
-	host.Register()
-	ipinfusion_ocnos.Register()
-	keysight_ixiacone.Register()
-	linux.Register()
-	mysocketio.Register()
-	ovs.Register()
-	sonic.Register()
-	srl.Register()
-	vr_csr.Register()
-	vr_ftosv.Register()
-	vr_n9kv.Register()
-	vr_nxos.Register()
-	vr_pan.Register()
-	vr_ros.Register()
-	vr_sros.Register()
-	vr_veos.Register()
-	vr_vmx.Register()
-	vr_vqfx.Register()
-	vr_xrv.Register()
-	vr_xrv9k.Register()
-	xrd.Register()
+func RegisterAll(r nodes.NodeRergistryRegistrator) {
+	bridge.Register(r)
+	ceos.Register(r)
+	checkpoint_cloudguard.Register(r)
+	crpd.Register(r)
+	cvx.Register(r)
+	ext_container.Register(r)
+	host.Register(r)
+	ipinfusion_ocnos.Register(r)
+	keysight_ixiacone.Register(r)
+	linux.Register(r)
+	mysocketio.Register(r)
+	ovs.Register(r)
+	sonic.Register(r)
+	srl.Register(r)
+	vr_csr.Register(r)
+	vr_ftosv.Register(r)
+	vr_n9kv.Register(r)
+	vr_nxos.Register(r)
+	vr_pan.Register(r)
+	vr_ros.Register(r)
+	vr_sros.Register(r)
+	vr_veos.Register(r)
+	vr_vmx.Register(r)
+	vr_vqfx.Register(r)
+	vr_xrv.Register(r)
+	vr_xrv9k.Register(r)
+	xrd.Register(r)
 }

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -26,8 +26,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(bridge)
 	}, nil)
 }

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -25,11 +25,11 @@ const (
 	iptAllowCmd = "-I FORWARD -i %s -j ACCEPT -w 5"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(bridge)
-	})
+	}, nil)
 }
 
 type bridge struct {

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -47,11 +47,11 @@ var (
 	saveCmd = "Cli -p 15 -c wr"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(ceos)
-	})
+	}, nil)
 }
 
 type ceos struct {

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -48,8 +48,8 @@ var (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(ceos)
 	}, nil)
 }

--- a/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
+++ b/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -18,19 +17,15 @@ var kindnames = []string{"checkpoint_cloudguard"}
 
 const (
 	scrapliPlatformName = "checkpoint_cloudguard"
-	defaultUser         = "admin"
-	defaultPassword     = "admin"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
+
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(CheckpointCloudguard)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type CheckpointCloudguard struct {
@@ -50,8 +45,8 @@ func (n *CheckpointCloudguard) Init(cfg *types.NodeConfig, opts ...nodes.NodeOpt
 	// env vars are used to set startup arguments in boxen container
 	defEnv := map[string]string{
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
 	}

--- a/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
+++ b/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
@@ -17,8 +17,8 @@ var kindnames = []string{"checkpoint_cloudguard"}
 var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(CheckpointCloudguard)
 	}, defaultCredentials)
 }

--- a/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
+++ b/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
@@ -14,11 +14,6 @@ import (
 )
 
 var kindnames = []string{"checkpoint_cloudguard"}
-
-const (
-	scrapliPlatformName = "checkpoint_cloudguard"
-)
-
 var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 // Register registers the node in the NodeRegistry.

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -35,8 +35,8 @@ var (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(crpd)
 	}, nil)
 }

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -34,11 +34,11 @@ var (
 	sshRestartCmd = "service ssh restart"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(crpd)
-	})
+	}, nil)
 }
 
 type crpd struct {

--- a/nodes/cvx/cvx.go
+++ b/nodes/cvx/cvx.go
@@ -24,8 +24,8 @@ var memoryReqs = map[string]string{
 }
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(cvx)
 	}, nil)
 	nodes.SetNonDefaultRuntimePerKind(kindnames, ignite.RuntimeName)

--- a/nodes/cvx/cvx.go
+++ b/nodes/cvx/cvx.go
@@ -23,11 +23,11 @@ var memoryReqs = map[string]string{
 	"4.4.0": "768MB",
 }
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(cvx)
-	})
+	}, nil)
 	nodes.SetNonDefaultRuntimePerKind(kindnames, ignite.RuntimeName)
 }
 

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -19,8 +19,8 @@ import (
 var kindnames = []string{"ext-container"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(extcont)
 	}, nil)
 }

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -18,11 +18,11 @@ import (
 
 var kindnames = []string{"ext-container"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(extcont)
-	})
+	}, nil)
 }
 
 type extcont struct {

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -15,11 +15,11 @@ import (
 
 var kindnames = []string{"host"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(host)
-	})
+	}, nil)
 }
 
 type host struct {

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -16,8 +16,8 @@ import (
 var kindnames = []string{"host"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(host)
 	}, nil)
 }

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -16,22 +16,17 @@ import (
 )
 
 var kindnames = []string{"ipinfusion_ocnos"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 const (
 	scrapliPlatformName = "ipinfusion_ocnos"
-	defaultUser         = "admin"
-	defaultPassword     = "admin"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(IPInfusionOcNOS)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type IPInfusionOcNOS struct {
@@ -51,8 +46,8 @@ func (s *IPInfusionOcNOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) 
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"DOCKER_NET_V4_ADDR": s.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": s.Mgmt.IPv6Subnet,
 	}
@@ -71,8 +66,8 @@ func (s *IPInfusionOcNOS) PreDeploy(_ context.Context, _, _, _ string) error {
 
 func (s *IPInfusionOcNOS) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(s.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(IPInfusionOcNOS)
 	}, defaultCredentials)
 }

--- a/nodes/keysight_ixiacone/ixiac-one.go
+++ b/nodes/keysight_ixiacone/ixiac-one.go
@@ -27,8 +27,8 @@ var ixiacStatusConfig = struct {
 }
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(ixiacOne)
 	}, nil)
 }

--- a/nodes/keysight_ixiacone/ixiac-one.go
+++ b/nodes/keysight_ixiacone/ixiac-one.go
@@ -26,11 +26,11 @@ var ixiacStatusConfig = struct {
 	readyFileName:       "/home/keysight/ixia-c-one/init-done",
 }
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(ixiacOne)
-	})
+	}, nil)
 }
 
 type ixiacOne struct {

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -17,8 +17,8 @@ import (
 var kindnames = []string{"linux"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(linux)
 	}, nil)
 }

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -16,11 +16,11 @@ import (
 
 var kindnames = []string{"linux"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(linux)
-	})
+	}, nil)
 }
 
 type linux struct {

--- a/nodes/mysocketio/mysocketio.go
+++ b/nodes/mysocketio/mysocketio.go
@@ -12,8 +12,8 @@ import (
 var Kindnames = []string{"mysocketio"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(Kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(Kindnames, func() nodes.Node {
 		return new(mySocketIO)
 	}, nil)
 }

--- a/nodes/mysocketio/mysocketio.go
+++ b/nodes/mysocketio/mysocketio.go
@@ -11,11 +11,11 @@ import (
 
 var Kindnames = []string{"mysocketio"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(Kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(Kindnames, func() nodes.Node {
 		return new(mySocketIO)
-	})
+	}, nil)
 }
 
 type mySocketIO struct {

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -33,9 +33,6 @@ var (
 	// a map of node kinds overriding the default global runtime.
 	NonDefaultRuntimes = map[string]string{}
 
-	// Nodes is a map of all supported kinds and their init functions.
-	Nodes = map[string]Initializer{}
-
 	DefaultConfigTemplates = map[string]string{
 		"vr-sros": "",
 	}
@@ -86,14 +83,6 @@ type Node interface {
 	RunExecs(ctx context.Context, cmds []string) ([]exec.ExecResultHolder, error)
 	// RunExec execute a single command for a given node.
 	RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error)
-}
-
-type Initializer func() Node
-
-func Register(names []string, initFn Initializer) {
-	for _, name := range names {
-		Nodes[name] = initFn
-	}
 }
 
 type NodeOption func(Node)

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -63,10 +63,6 @@ func (r *NodeRegistry) GetRegisteredNodeKindNames() []string {
 	return result
 }
 
-type NodeRergistryRegistrator interface {
-	Register(names []string, initf Initializer, credentials CredentialsGetter) error
-}
-
 type NodeFactory interface {
 	NewNodeOfKind(nodeKindName string) (Node, error)
 }

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -21,8 +21,8 @@ func NewNodeRegistry() *NodeRegistry {
 	}
 }
 
-// Register registers the node' init function for a provided names
-func (r *NodeRegistry) Register(names []string, initf Initializer, credentials CredentialsGetter) error {
+// Register registers the node' init function for all provided names
+func (r *NodeRegistry) Register(names []string, initf Initializer, credentials *Credentials) error {
 	newEntry := newRegistryEntry(names, initf, credentials)
 	return r.addEntry(newEntry)
 }
@@ -67,10 +67,10 @@ func (r *NodeRegistry) GetRegisteredNodeKindNames() []string {
 type nodeRegistryEntry struct {
 	nodeKindNames []string
 	initFunction  Initializer
-	credentials   CredentialsGetter
+	credentials   *Credentials
 }
 
-func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credentials CredentialsGetter) *nodeRegistryEntry {
+func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credentials *Credentials) *nodeRegistryEntry {
 	return &nodeRegistryEntry{
 		nodeKindNames: nodeKindNames,
 		initFunction:  initFunction,
@@ -78,13 +78,14 @@ func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credenti
 	}
 }
 
+// Credentials defines NOS SSH credentials
 type Credentials struct {
 	username string
 	password string
 }
 
 // NewCredentials constructor for the Credentials struct
-func NewCredentials(username, password string) CredentialsGetter {
+func NewCredentials(username, password string) *Credentials {
 	return &Credentials{
 		username: username,
 		password: password,
@@ -97,9 +98,4 @@ func (c *Credentials) GetUsername() string {
 
 func (c *Credentials) GetPassword() string {
 	return c.password
-}
-
-type CredentialsGetter interface {
-	GetUsername() string
-	GetPassword() string
 }

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -21,22 +21,22 @@ func NewNodeRegistry() *NodeRegistry {
 	}
 }
 
-// Register is used to register the init function for a kind under all the
-// provided string names in the string slice
+// Register registers the node' init function for a provided names
 func (r *NodeRegistry) Register(names []string, initf Initializer, credentials CredentialsGetter) error {
 	newEntry := newRegistryEntry(names, initf, credentials)
 	return r.addEntry(newEntry)
 }
 
-// finally add the node to the registry index
+// addEntry adds the node entry to the registry
 func (r *NodeRegistry) addEntry(entry *nodeRegistryEntry) error {
 	for _, name := range entry.nodeKindNames {
 		if _, exists := r.nodeIndex[name]; exists {
 			return fmt.Errorf("node kind %q already registered in Node Registry", name)
 		}
-		// if not a duplicate, add entry
+
 		r.nodeIndex[name] = entry
 	}
+
 	return nil
 }
 
@@ -60,11 +60,8 @@ func (r *NodeRegistry) GetRegisteredNodeKindNames() []string {
 	}
 	// sort and return
 	sort.Strings(result)
-	return result
-}
 
-type NodeFactory interface {
-	NewNodeOfKind(nodeKindName string) (Node, error)
+	return result
 }
 
 type nodeRegistryEntry struct {
@@ -74,12 +71,11 @@ type nodeRegistryEntry struct {
 }
 
 func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credentials CredentialsGetter) *nodeRegistryEntry {
-	result := &nodeRegistryEntry{
+	return &nodeRegistryEntry{
 		nodeKindNames: nodeKindNames,
 		initFunction:  initFunction,
 		credentials:   credentials,
 	}
-	return result
 }
 
 type Credentials struct {

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -1,0 +1,113 @@
+package nodes
+
+import (
+	"fmt"
+
+	"sort"
+	"strings"
+)
+
+type Initializer func() Node
+
+type NodeRegistry struct {
+	// the nodeindex is a helping struct to speedup kind lookups.
+	nodeIndex map[string]*nodeRegistryEntry
+}
+
+// NewNodeRegistry constructs a new Registry
+func NewNodeRegistry() *NodeRegistry {
+	return &NodeRegistry{
+		nodeIndex: map[string]*nodeRegistryEntry{},
+	}
+}
+
+// Register is used to register the init function for a kind under all the
+// provided string names in the string slice
+func (r *NodeRegistry) Register(names []string, initf Initializer, credentials CredentialsGetter) error {
+	newEntry := newRegistryEntry(names, initf, credentials)
+	return r.addEntry(newEntry)
+}
+
+// finally add the node to the registry index
+func (r *NodeRegistry) addEntry(entry *nodeRegistryEntry) error {
+	for _, name := range entry.nodeKindNames {
+		if _, exists := r.nodeIndex[name]; exists {
+			return fmt.Errorf("node kind %q already registered in Node Registry", name)
+		}
+		// if not a duplicate, add entry
+		r.nodeIndex[name] = entry
+	}
+	return nil
+}
+
+// NewNodeOfKind return a new Node of the given Node Kind
+func (r *NodeRegistry) NewNodeOfKind(nodeKindName string) (Node, error) {
+	nodeKindEntry, ok := r.nodeIndex[nodeKindName]
+	if !ok {
+		registeredKinds := strings.Join(r.GetRegisteredNodeKindNames(), ", ")
+		return nil, fmt.Errorf("kind %q is not supported. Supported kinds are %q", nodeKindName, registeredKinds)
+	}
+
+	// return a new instance of the requested node
+	return nodeKindEntry.initFunction(), nil
+}
+
+// GetRegisteredNodeKindNames returns a sorted slice of all the registered node kind names in the registry
+func (r *NodeRegistry) GetRegisteredNodeKindNames() []string {
+	var result []string
+	for k := range r.nodeIndex {
+		result = append(result, k)
+	}
+	// sort and return
+	sort.Strings(result)
+	return result
+}
+
+type NodeRergistryRegistrator interface {
+	Register(names []string, initf Initializer, credentials CredentialsGetter) error
+}
+
+type NodeFactory interface {
+	NewNodeOfKind(nodeKindName string) (Node, error)
+}
+
+type nodeRegistryEntry struct {
+	nodeKindNames []string
+	initFunction  Initializer
+	credentials   CredentialsGetter
+}
+
+func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credentials CredentialsGetter) *nodeRegistryEntry {
+	result := &nodeRegistryEntry{
+		nodeKindNames: nodeKindNames,
+		initFunction:  initFunction,
+		credentials:   credentials,
+	}
+	return result
+}
+
+type Credentials struct {
+	username string
+	password string
+}
+
+// NewCredentials constructor for the Credentials struct
+func NewCredentials(username, password string) CredentialsGetter {
+	return &Credentials{
+		username: username,
+		password: password,
+	}
+}
+
+func (c *Credentials) GetUsername() string {
+	return c.username
+}
+
+func (c *Credentials) GetPassword() string {
+	return c.password
+}
+
+type CredentialsGetter interface {
+	GetUsername() string
+	GetPassword() string
+}

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -17,8 +17,8 @@ import (
 var kindnames = []string{"ovs-bridge"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(ovs)
 	}, nil)
 }

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -16,11 +16,11 @@ import (
 
 var kindnames = []string{"ovs-bridge"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(ovs)
-	})
+	}, nil)
 }
 
 type ovs struct {

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -17,11 +17,11 @@ import (
 
 var kindnames = []string{"sonic-vs"}
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(sonic)
-	})
+	}, nil)
 }
 
 type sonic struct {

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -18,8 +18,8 @@ import (
 var kindnames = []string{"sonic-vs"}
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(sonic)
 	}, nil)
 }

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -106,8 +106,8 @@ var (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(srl)
 	}, defaultCredentials)
 }

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -73,6 +73,7 @@ var (
 		"net.ipv6.conf.all.autoconf":       "0",
 		"net.ipv6.conf.default.autoconf":   "0",
 	}
+	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	srlTypes = map[string]string{
 		"ixrd1":  "7220IXRD1.yml",
@@ -104,15 +105,11 @@ var (
 			Parse(srlConfigCmdsTpl)
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(srl)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, "admin", "admin")
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type srl struct {

--- a/nodes/vr_csr/vr-csr.go
+++ b/nodes/vr_csr/vr-csr.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrCsr)
 	}, defaultCredentials)
 }

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -9,30 +9,24 @@ import (
 	"fmt"
 	"path"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
 
 var kindnames = []string{"vr-ftosv", "vr-dell_ftosv"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 const (
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
-	defaultUser     = "admin"
-	defaultPassword = "admin"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrFtosv)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrFtosv struct {
@@ -52,8 +46,8 @@ func (s *vrFtosv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"DOCKER_NET_V4_ADDR": s.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": s.Mgmt.IPv6Subnet,
 	}
@@ -68,7 +62,7 @@ func (s *vrFtosv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrFtosv)
 	}, defaultCredentials)
 }

--- a/nodes/vr_n9kv/vr-n9kv.go
+++ b/nodes/vr_n9kv/vr-n9kv.go
@@ -24,8 +24,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrN9kv)
 	}, defaultCredentials)
 }

--- a/nodes/vr_nxos/vr-nxos.go
+++ b/nodes/vr_nxos/vr-nxos.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrNXOS)
 	}, defaultCredentials)
 }

--- a/nodes/vr_nxos/vr-nxos.go
+++ b/nodes/vr_nxos/vr-nxos.go
@@ -15,21 +15,18 @@ import (
 )
 
 var kindnames = []string{"vr-nxos", "vr-cisco_nxos"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 const (
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
-
-	defaultUser     = "admin"
-	defaultPassword = "admin"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrNXOS)
-	})
-	nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
+	}, defaultCredentials)
 }
 
 type vrNXOS struct {
@@ -48,8 +45,8 @@ func (s *vrNXOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
 		"VCPU":               "2",
 		"RAM":                "4096",
@@ -62,7 +59,7 @@ func (s *vrNXOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.Cfg.Binds = append(s.Cfg.Binds, fmt.Sprint(path.Join(s.Cfg.LabDir, configDirName), ":/config"))
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }

--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrPan)
 	}, defaultCredentials)
 }

--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -9,31 +9,24 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
 
 var kindnames = []string{"vr-pan", "vr-paloalto_panos"}
+var defaultCredentials = nodes.NewCredentials("admin", "Admin@123")
 
 const (
-	defaultUser     = "admin"
-	defaultPassword = "Admin@123"
-
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrPan)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrPan struct {
@@ -52,8 +45,8 @@ func (s *vrPan) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
 		"VCPU":               "2",
 		"RAM":                "6144",
@@ -71,7 +64,7 @@ func (s *vrPan) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrRos)
 	}, defaultCredentials)
 }

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -15,20 +15,18 @@ import (
 )
 
 var kindnames = []string{"vr-ros", "vr-mikrotik_ros"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 const (
-	defaultUser     = "admin"
-	defaultPassword = "admin"
-
 	configDirName   = "ftpboot"
 	startupCfgFName = "config.auto.rsc"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrRos)
-	})
+	}, defaultCredentials)
 }
 
 type vrRos struct {
@@ -47,8 +45,8 @@ func (s *vrRos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	defEnv := map[string]string{
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"DOCKER_NET_V4_ADDR": s.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": s.Mgmt.IPv6Subnet,
 	}
@@ -62,7 +60,7 @@ func (s *vrRos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -30,8 +30,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrSROS)
 	}, defaultCredentials)
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -19,26 +19,21 @@ import (
 )
 
 var kindnames = []string{"vr-sros", "vr-nokia_sros"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 const (
 	vrsrosDefaultType   = "sr-1"
 	scrapliPlatformName = "nokia_sros"
-	defaultUser         = "admin"
-	defaultPassword     = "admin"
 	configDirName       = "tftpboot"
 	startupCfgFName     = "config.txt"
 	licenseFName        = "license.txt"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrSROS)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrSROS struct {
@@ -92,8 +87,8 @@ func (s *vrSROS) PreDeploy(_ context.Context, _, _, _ string) error {
 
 func (s *vrSROS) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(s.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrVEOS)
 	}, defaultCredentials)
 }

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrVMX)
 	}, defaultCredentials)
 }

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -17,25 +17,20 @@ import (
 )
 
 var kindnames = []string{"vr-vmx", "vr-juniper_vmx"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 const (
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
 
 	scrapliPlatformName = "juniper_junos"
-	defaultUser         = "admin"
-	defaultPassword     = "admin@123"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrVMX)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrVMX struct {
@@ -54,8 +49,8 @@ func (s *vrVMX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
 		"DOCKER_NET_V4_ADDR": s.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": s.Mgmt.IPv6Subnet,
@@ -66,7 +61,7 @@ func (s *vrVMX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.Cfg.Binds = append(s.Cfg.Binds, fmt.Sprint(path.Join(s.Cfg.LabDir, configDirName), ":/config"))
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }
@@ -78,8 +73,8 @@ func (s *vrVMX) PreDeploy(_ context.Context, _, _, _ string) error {
 
 func (s *vrVMX) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(s.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -17,26 +17,20 @@ import (
 )
 
 var kindnames = []string{"vr-vqfx", "vr-juniper_vqfx"}
+var defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 const (
 	scrapliPlatformName = "juniper_junos"
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
-
-	defaultUser     = "admin"
-	defaultPassword = "admin@123"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrVQFX)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrVQFX struct {
@@ -55,8 +49,8 @@ func (s *vrVQFX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
-		"USERNAME":           defaultUser,
-		"PASSWORD":           defaultPassword,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
 		"DOCKER_NET_V4_ADDR": s.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": s.Mgmt.IPv6Subnet,
@@ -72,7 +66,7 @@ func (s *vrVQFX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName, s.Cfg.Env["CONNECTION_MODE"])
 
 	return nil
 }
@@ -84,8 +78,8 @@ func (s *vrVQFX) PreDeploy(_ context.Context, _, _, _ string) error {
 
 func (s *vrVQFX) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(s.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrVQFX)
 	}, defaultCredentials)
 }

--- a/nodes/vr_xrv/vr-xrv.go
+++ b/nodes/vr_xrv/vr-xrv.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrXRV)
 	}, defaultCredentials)
 }

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -27,8 +27,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(vrXRV9K)
 	}, defaultCredentials)
 }

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -17,26 +17,20 @@ import (
 )
 
 var kindnames = []string{"vr-xrv9k", "vr-cisco_xrv9k"}
+var defaultCredentials = nodes.NewCredentials("clab", "clab@123")
 
 const (
 	scrapliPlatformName = "cisco_iosxr"
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
-
-	defaultUser     = "clab"
-	defaultPassword = "clab@123"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(vrXRV9K)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type vrXRV9K struct {
@@ -55,8 +49,8 @@ func (s *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
-		"USERNAME":           "clab",
-		"PASSWORD":           "clab@123",
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
 		"VCPU":               "2",
 		"RAM":                "12288",
@@ -74,7 +68,7 @@ func (s *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	s.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --vcpu %s --ram %s --trace",
-		s.Cfg.Env["USERNAME"], s.Cfg.Env["PASSWORD"], s.Cfg.ShortName,
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), s.Cfg.ShortName,
 		s.Cfg.Env["CONNECTION_MODE"], s.Cfg.Env["VCPU"], s.Cfg.Env["RAM"])
 
 	return nil
@@ -87,8 +81,8 @@ func (s *vrXRV9K) PreDeploy(_ context.Context, _, _, _ string) error {
 
 func (s *vrXRV9K) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(s.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -37,8 +37,8 @@ const (
 )
 
 // Register registers the node in the NodeRegistry.
-func Register(rr nodes.NodeRergistryRegistrator) {
-	rr.Register(kindnames, func() nodes.Node {
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
 		return new(xrd)
 	}, defaultCredentials)
 }

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	kindnames = []string{"xrd", "cisco_xrd"}
-	xrdEnv    = map[string]string{
+	kindnames          = []string{"xrd", "cisco_xrd"}
+	defaultCredentials = nodes.NewCredentials("clab", "clab@123")
+	xrdEnv             = map[string]string{
 		"XR_FIRST_BOOT_CONFIG": "/etc/xrd/first-boot.cfg",
 		"XR_MGMT_INTERFACES":   "linux:eth0,xr_name=Mg0/RP0/CPU0/0,chksum,snoop_v4,snoop_v6",
 	}
@@ -33,19 +34,13 @@ var (
 
 const (
 	scrapliPlatformName = "cisco_iosxr"
-	defaultUser         = "clab"
-	defaultPassword     = "clab@123"
 )
 
-// Register registers the node in the global Node map.
-func Register() {
-	nodes.Register(kindnames, func() nodes.Node {
+// Register registers the node in the NodeRegistry.
+func Register(rr nodes.NodeRergistryRegistrator) {
+	rr.Register(kindnames, func() nodes.Node {
 		return new(xrd)
-	})
-	err := nodes.SetDefaultCredentials(kindnames, defaultUser, defaultPassword)
-	if err != nil {
-		log.Error(err)
-	}
+	}, defaultCredentials)
 }
 
 type xrd struct {
@@ -81,8 +76,8 @@ func (n *xrd) PreDeploy(ctx context.Context, _, _, _ string) error {
 
 func (n *xrd) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(n.Cfg.LongName,
-		defaultUser,
-		defaultPassword,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
 		scrapliPlatformName,
 	)
 	if err != nil {


### PR DESCRIPTION
The Implementation, using the once construct is ugly and not quite good practice. Also the global var we used as a node registry is non-optimal.
Here is a different approach introducing a NodeRegistry. A seperate object that keeps track of the registered Node types.