### PR TITLE
fix-exec-format-and-add-multipe-cmd

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,6 +47,8 @@ var skipPostDeploy bool
 // template file for topology data export.
 var exportTemplate string
 
+var deployFormat string
+
 // deployCmd represents the deploy command.
 var deployCmd = &cobra.Command{
 	Use:          "deploy",
@@ -64,6 +66,7 @@ func init() {
 	deployCmd.Flags().StringVarP(&mgmtNetName, "network", "", "", "management network name")
 	deployCmd.Flags().IPNetVarP(&mgmtIPv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
 	deployCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
+	deployCmd.Flags().StringVarP(&deployFormat, "format", "f", "table", "output format. One of [table, json]")
 	deployCmd.Flags().BoolVarP(&reconfigure, "reconfigure", "c", false,
 		"regenerate configuration artifacts and overwrite previous ones if any")
 	deployCmd.Flags().UintVarP(&maxWorkers, "max-workers", "", 0,
@@ -268,7 +271,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	newVerNotification(vCh)
 
 	// print table summary
-	return printContainerInspect(containers, format)
+	return printContainerInspect(containers, deployFormat)
 }
 
 func setFlags(conf *clab.Config) {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -26,9 +26,9 @@ import (
 )
 
 var (
-	format  string
-	details bool
-	all     bool
+	inspectFormat string
+	details       bool
+	all           bool
 )
 
 // inspectCmd represents the inspect command.
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.AddCommand(inspectCmd)
 
 	inspectCmd.Flags().BoolVarP(&details, "details", "", false, "print all details of lab containers")
-	inspectCmd.Flags().StringVarP(&format, "format", "f", "table", "output format. One of [table, json]")
+	inspectCmd.Flags().StringVarP(&inspectFormat, "format", "f", "table", "output format. One of [table, json]")
 	inspectCmd.Flags().BoolVarP(&all, "all", "a", false, "show all deployed containerlab labs")
 }
 
@@ -121,7 +121,7 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	err = printContainerInspect(containers, format)
+	err = printContainerInspect(containers, inspectFormat)
 	return err
 }
 


### PR DESCRIPTION
The format switch for exec was stored in a different variable then was set via cobra...
Also this PR introduces the capability of providing multiple `--cmd "<CONTAINER-COMMAND>"` options to the exec call.