### PR TITLE
jsonOutput embedding

### DIFF
--- a/clab/exec/exec_test.go
+++ b/clab/exec/exec_test.go
@@ -9,7 +9,7 @@ func TestParseExecOutputFormat(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    string
+		want    ExecFormat
 		wantErr bool
 	}{
 		{

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -254,7 +254,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	// execute commands specified for nodes with `exec` node parameter
 	execCollection := exec.NewExecCollection()
 	for _, n := range c.Nodes {
-		execResult, err := n.RunExecs(ctx, n.Config().Exec)
+		execResult, err := n.RunExecs(ctx, n.Config().Exec, exec.NewExecResult)
 		if err != nil {
 			log.Warnf("Failed to exec commands for node %q", n.Config().ShortName)
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -32,7 +32,7 @@ var execCmd = &cobra.Command{
 			return errors.New("provide command to execute")
 		}
 
-		outputFormat, err := exec.ParseExecOutputFormat(format)
+		outputFormat, err := exec.ParseExecOutputFormat(execFormat)
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,10 @@ var execCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		// create a new collection of execution results
 		resultCollection := exec.NewExecCollection()
+		// retrieve the create function for the output specific ResultHolder
+		execResultHolderCreateFn := exec.GetResultHolderCreateFnFor(outputFormat)
 
 		for _, node := range c.Nodes {
 			execCmd, err := exec.NewExecCmdFromString(execCommand)
@@ -65,7 +68,7 @@ var execCmd = &cobra.Command{
 				log.Error(err)
 			}
 
-			execResult, err := node.RunExec(ctx, execCmd)
+			execResult, err := node.RunExec(ctx, execCmd, execResultHolderCreateFn)
 			if err != nil {
 				// skip nodes that do not support exec
 				if err == exec.ErrRunExecNotSupported {

--- a/mocks/exec.go
+++ b/mocks/exec.go
@@ -8,7 +8,81 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	exec "github.com/srl-labs/containerlab/clab/exec"
 )
+
+// MockExecResultHolderSetter is a mock of ExecResultHolderSetter interface.
+type MockExecResultHolderSetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockExecResultHolderSetterMockRecorder
+}
+
+// MockExecResultHolderSetterMockRecorder is the mock recorder for MockExecResultHolderSetter.
+type MockExecResultHolderSetterMockRecorder struct {
+	mock *MockExecResultHolderSetter
+}
+
+// NewMockExecResultHolderSetter creates a new mock instance.
+func NewMockExecResultHolderSetter(ctrl *gomock.Controller) *MockExecResultHolderSetter {
+	mock := &MockExecResultHolderSetter{ctrl: ctrl}
+	mock.recorder = &MockExecResultHolderSetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockExecResultHolderSetter) EXPECT() *MockExecResultHolderSetterMockRecorder {
+	return m.recorder
+}
+
+// GetExecResultHolder mocks base method.
+func (m *MockExecResultHolderSetter) GetExecResultHolder() exec.ExecResultHolder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExecResultHolder")
+	ret0, _ := ret[0].(exec.ExecResultHolder)
+	return ret0
+}
+
+// GetExecResultHolder indicates an expected call of GetExecResultHolder.
+func (mr *MockExecResultHolderSetterMockRecorder) GetExecResultHolder() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecResultHolder", reflect.TypeOf((*MockExecResultHolderSetter)(nil).GetExecResultHolder))
+}
+
+// SetReturnCode mocks base method.
+func (m *MockExecResultHolderSetter) SetReturnCode(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReturnCode", arg0)
+}
+
+// SetReturnCode indicates an expected call of SetReturnCode.
+func (mr *MockExecResultHolderSetterMockRecorder) SetReturnCode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReturnCode", reflect.TypeOf((*MockExecResultHolderSetter)(nil).SetReturnCode), arg0)
+}
+
+// SetStdErr mocks base method.
+func (m *MockExecResultHolderSetter) SetStdErr(arg0 []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetStdErr", arg0)
+}
+
+// SetStdErr indicates an expected call of SetStdErr.
+func (mr *MockExecResultHolderSetterMockRecorder) SetStdErr(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStdErr", reflect.TypeOf((*MockExecResultHolderSetter)(nil).SetStdErr), arg0)
+}
+
+// SetStdOut mocks base method.
+func (m *MockExecResultHolderSetter) SetStdOut(arg0 []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetStdOut", arg0)
+}
+
+// SetStdOut indicates an expected call of SetStdOut.
+func (mr *MockExecResultHolderSetterMockRecorder) SetStdOut(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStdOut", reflect.TypeOf((*MockExecResultHolderSetter)(nil).SetStdOut), arg0)
+}
 
 // MockExecResultHolder is a mock of ExecResultHolder interface.
 type MockExecResultHolder struct {
@@ -34,7 +108,7 @@ func (m *MockExecResultHolder) EXPECT() *MockExecResultHolderMockRecorder {
 }
 
 // Dump mocks base method.
-func (m *MockExecResultHolder) Dump(format string) (string, error) {
+func (m *MockExecResultHolder) Dump(format exec.ExecFormat) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dump", format)
 	ret0, _ := ret[0].(string)

--- a/mocks/node.go
+++ b/mocks/node.go
@@ -227,33 +227,33 @@ func (mr *MockNodeMockRecorder) PreDeploy(ctx, configName, labCADir, labCARoot i
 }
 
 // RunExec mocks base method.
-func (m *MockNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+func (m *MockNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunExec", ctx, execCmd)
+	ret := m.ctrl.Call(m, "RunExec", ctx, execCmd, erhcf)
 	ret0, _ := ret[0].(exec.ExecResultHolder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunExec indicates an expected call of RunExec.
-func (mr *MockNodeMockRecorder) RunExec(ctx, execCmd interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) RunExec(ctx, execCmd, erhcf interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExec", reflect.TypeOf((*MockNode)(nil).RunExec), ctx, execCmd)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExec", reflect.TypeOf((*MockNode)(nil).RunExec), ctx, execCmd, erhcf)
 }
 
 // RunExecs mocks base method.
-func (m *MockNode) RunExecs(ctx context.Context, cmds []string) ([]exec.ExecResultHolder, error) {
+func (m *MockNode) RunExecs(ctx context.Context, cmds []string, erhcf exec.ExecResultHolderCreateFn) ([]exec.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunExecs", ctx, cmds)
+	ret := m.ctrl.Call(m, "RunExecs", ctx, cmds, erhcf)
 	ret0, _ := ret[0].([]exec.ExecResultHolder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunExecs indicates an expected call of RunExecs.
-func (mr *MockNodeMockRecorder) RunExecs(ctx, cmds interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) RunExecs(ctx, cmds, erhcf interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecs", reflect.TypeOf((*MockNode)(nil).RunExecs), ctx, cmds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunExecs", reflect.TypeOf((*MockNode)(nil).RunExecs), ctx, cmds, erhcf)
 }
 
 // SaveConfig mocks base method.

--- a/mocks/runtime.go
+++ b/mocks/runtime.go
@@ -109,18 +109,18 @@ func (mr *MockContainerRuntimeMockRecorder) DeleteNet(arg0 interface{}) *gomock.
 }
 
 // Exec mocks base method.
-func (m *MockContainerRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+func (m *MockContainerRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exec", ctx, cID, execCmd)
+	ret := m.ctrl.Call(m, "Exec", ctx, cID, execCmd, erhcf)
 	ret0, _ := ret[0].(exec.ExecResultHolder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exec indicates an expected call of Exec.
-func (mr *MockContainerRuntimeMockRecorder) Exec(ctx, cID, execCmd interface{}) *gomock.Call {
+func (mr *MockContainerRuntimeMockRecorder) Exec(ctx, cID, execCmd, erhcf interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockContainerRuntime)(nil).Exec), ctx, cID, execCmd)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockContainerRuntime)(nil).Exec), ctx, cID, execCmd, erhcf)
 }
 
 // ExecNotWait mocks base method.

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -112,7 +112,13 @@ func (b *bridge) UpdateConfigWithRuntimeInfo(_ context.Context) error { return n
 // GetContainers is a noop for bridges.
 func (b *bridge) GetContainers(_ context.Context) ([]types.GenericContainer, error) { return nil, nil }
 
-func (b *bridge) RunExecs(_ context.Context, _ []string) ([]cExec.ExecResultHolder, error) {
+func (b *bridge) RunExecs(_ context.Context, _ []string, _ cExec.ExecResultHolderCreateFn) ([]cExec.ExecResultHolder, error) {
+	log.Warnf("Exec operation is not implemented for kind %q", b.Config().Kind)
+
+	return nil, cExec.ErrRunExecNotSupported
+}
+
+func (b *bridge) RunExec(_ context.Context, _ *cExec.ExecCmd, _ cExec.ExecResultHolderCreateFn) (cExec.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", b.Config().Kind)
 
 	return nil, cExec.ErrRunExecNotSupported

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -109,7 +109,7 @@ func (n *ceos) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 
 func (n *ceos) SaveConfig(ctx context.Context) error {
 	cmd, _ := exec.NewExecCmdFromString(saveCmd)
-	execResult, err := n.RunExec(ctx, cmd)
+	execResult, err := n.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return fmt.Errorf("%s: failed to execute cmd: %v", n.Cfg.ShortName, err)
 	}

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -74,7 +74,7 @@ func (s *crpd) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 	log.Debugf("Running postdeploy actions for CRPD %q node", s.Cfg.ShortName)
 
 	cmd, _ := exec.NewExecCmdFromString(sshRestartCmd)
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (s *crpd) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 
 func (s *crpd) SaveConfig(ctx context.Context) error {
 	cmd, _ := exec.NewExecCmdFromString(saveCmd)
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -268,7 +268,7 @@ func LoadStartupConfigFileVr(node Node, configDirName, startupCfgFName string) e
 }
 
 // RunExecs executes cmds commands for a node. Commands is a list of strings.
-func (d *DefaultNode) RunExecs(ctx context.Context, cmds []string) ([]exec.ExecResultHolder, error) {
+func (d *DefaultNode) RunExecs(ctx context.Context, cmds []string, erhcf exec.ExecResultHolderCreateFn) ([]exec.ExecResultHolder, error) {
 	results := []exec.ExecResultHolder{}
 	for _, cmd := range cmds {
 		execCmd, err := exec.NewExecCmdFromString(cmd)
@@ -276,7 +276,7 @@ func (d *DefaultNode) RunExecs(ctx context.Context, cmds []string) ([]exec.ExecR
 			return nil, err
 		}
 
-		er, err := d.RunExec(ctx, execCmd)
+		er, err := d.RunExec(ctx, execCmd, erhcf)
 		if err != nil {
 			return nil, err
 		}
@@ -288,8 +288,8 @@ func (d *DefaultNode) RunExecs(ctx context.Context, cmds []string) ([]exec.ExecR
 }
 
 // RunExec executes a single command for a node.
-func (d *DefaultNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
-	execResult, err := d.GetRuntime().Exec(ctx, d.Cfg.LongName, execCmd)
+func (d *DefaultNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
+	execResult, err := d.GetRuntime().Exec(ctx, d.Cfg.LongName, execCmd, erhcf)
 	if err != nil {
 		log.Errorf("%s: failed to execute cmd: %q with error %v", d.Cfg.LongName, execCmd.GetCmdString(), err)
 		return nil, err

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -66,8 +66,8 @@ func (e *extcont) PullImage(_ context.Context) error             { return nil }
 
 // RunExecType is the final function that calls the runtime to execute a type.Exec on a container
 // This is to be overriden if the nodes implementation differs.
-func (e *extcont) RunExecType(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
-	execResult, err := e.GetRuntime().Exec(ctx, e.Cfg.ShortName, execCmd)
+func (e *extcont) RunExecType(ctx context.Context, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
+	execResult, err := e.GetRuntime().Exec(ctx, e.Cfg.ShortName, execCmd, erhcf)
 	if err != nil {
 		// On Ext-container we have to use the shortname, whilst default is to use longname
 		log.Errorf("%s: failed to execute cmd: %q with error %v", e.Cfg.ShortName, execCmd.GetCmdString(), err)

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -68,7 +68,13 @@ func (*host) GetContainers(_ context.Context) ([]types.GenericContainer, error) 
 	}, nil
 }
 
-func (h *host) RunExecs(_ context.Context, _ []string) ([]exec.ExecResultHolder, error) {
+func (h *host) RunExecs(_ context.Context, _ []string, _ exec.ExecResultHolderCreateFn) ([]exec.ExecResultHolder, error) {
+	log.Warnf("Exec operation is not implemented for kind %q", h.Config().Kind)
+
+	return nil, exec.ErrRunExecNotSupported
+}
+
+func (h *host) RunExec(_ context.Context, _ *exec.ExecCmd, _ exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", h.Config().Kind)
 
 	return nil, exec.ErrRunExecNotSupported

--- a/nodes/keysight_ixiacone/ixiac-one.go
+++ b/nodes/keysight_ixiacone/ixiac-one.go
@@ -60,7 +60,7 @@ func (l *ixiacOne) ixiacPostDeploy(ctx context.Context) error {
 	statusInProgressMsg := fmt.Sprintf("ls: %s: No such file or directory", ixiacStatusConfig.readyFileName)
 	for {
 		cmd, _ := exec.NewExecCmdFromString(ixiacOneCmd)
-		execResult, err := l.RunExec(ctx, cmd)
+		execResult, err := l.RunExec(ctx, cmd, exec.NewExecResult)
 		if err != nil {
 			return err
 		}

--- a/nodes/mysocketio/mysocket.go
+++ b/nodes/mysocketio/mysocket.go
@@ -32,7 +32,7 @@ func createMysocketTunnels(ctx context.Context, node *mySocketIO, nodesMap map[s
 	log.Debugf("Running postdeploy mysocketio command %s", removeSocketCmd)
 
 	cmd, _ := exec.NewExecCmdFromString(removeSocketCmd)
-	_, err := node.RunExec(ctx, cmd)
+	_, err := node.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return fmt.Errorf("failed to remove existing sockets: %v", err)
 	}
@@ -53,7 +53,7 @@ func createMysocketTunnels(ctx context.Context, node *mySocketIO, nodesMap map[s
 				`/bin/sh -c "%s | awk 'NR==4 {print $2}'"`, sockCmd))
 			log.Debugf("Running mysocketio command %s", cmd)
 
-			execResult, err := node.RunExec(ctx, cmd)
+			execResult, err := node.RunExec(ctx, cmd, exec.NewExecResult)
 			if err != nil {
 				return fmt.Errorf("failed to create mysocketio socket: %v", err)
 			}
@@ -63,7 +63,7 @@ func createMysocketTunnels(ctx context.Context, node *mySocketIO, nodesMap map[s
 			cmd, _ = exec.NewExecCmdFromString(fmt.Sprintf(
 				`/bin/sh -c "mysocketctl tunnel create -s %s | awk 'NR==4 {print $4}'"`, sockID))
 			log.Debugf("Running mysocketio command %q", cmd)
-			execResult, err = node.RunExec(ctx, cmd)
+			execResult, err = node.RunExec(ctx, cmd, exec.NewExecResult)
 			if err != nil {
 				return fmt.Errorf("failed to create mysocketio socket: %v", err)
 			}

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -83,9 +83,9 @@ type Node interface {
 	// UpdateConfigWithRuntimeInfo updates node config with runtime info like IP addresses assigned by runtime
 	UpdateConfigWithRuntimeInfo(context.Context) error
 	// RunExecs executes all exec commands specified for the node.
-	RunExecs(ctx context.Context, cmds []string) ([]exec.ExecResultHolder, error)
+	RunExecs(ctx context.Context, cmds []string, erhcf exec.ExecResultHolderCreateFn) ([]exec.ExecResultHolder, error)
 	// RunExec execute a single command for a given node.
-	RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error)
+	RunExec(ctx context.Context, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error)
 }
 
 type Initializer func() Node

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -56,7 +56,13 @@ func (*ovs) PullImage(_ context.Context) error             { return nil }
 func (*ovs) GetImages(_ context.Context) map[string]string { return map[string]string{} }
 func (*ovs) Delete(_ context.Context) error                { return nil }
 
-func (o *ovs) RunExecs(_ context.Context, _ []string) ([]exec.ExecResultHolder, error) {
+func (o *ovs) RunExecs(_ context.Context, _ []string, _ exec.ExecResultHolderCreateFn) ([]exec.ExecResultHolder, error) {
+	log.Warnf("Exec operation is not implemented for kind %q", o.Config().Kind)
+
+	return nil, exec.ErrRunExecNotSupported
+}
+
+func (o *ovs) RunExec(_ context.Context, _ *exec.ExecCmd, _ exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", o.Config().Kind)
 
 	return nil, exec.ErrRunExecNotSupported

--- a/nodes/srl/banner.go
+++ b/nodes/srl/banner.go
@@ -29,7 +29,7 @@ const banner = `................................................................
 func (s *srl) banner(ctx context.Context) (string, error) {
 	cmd, _ := exec.NewExecCmdFromString(`sr_cli -d "info from state /system information version | grep version"`)
 
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return "", err
 	}

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -276,7 +276,7 @@ func (s *srl) PostDeploy(ctx context.Context, nodes map[string]nodes.Node) error
 
 func (s *srl) SaveConfig(ctx context.Context) error {
 	cmd, _ := exec.NewExecCmdFromString(saveCmd)
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return fmt.Errorf("%s: failed to execute cmd: %v", s.Cfg.ShortName, err)
 	}
@@ -305,7 +305,7 @@ func (s *srl) Ready(ctx context.Context) error {
 		default:
 			// two commands are checked, first if the mgmt_server is running
 			cmd, _ := exec.NewExecCmdFromString(mgmtServerRdyCmd)
-			execResult, err := s.RunExec(ctx, cmd)
+			execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 			if err != nil {
 				time.Sleep(retryTimer)
 				continue
@@ -325,7 +325,7 @@ func (s *srl) Ready(ctx context.Context) error {
 			// once mgmt server is running, we need to check if it is ready to accept configuration commands
 			// this is done with checking readyForConfigCmd
 			cmd, _ = exec.NewExecCmdFromString(readyForConfigCmd)
-			execResult, err = s.RunExec(ctx, cmd)
+			execResult, err = s.RunExec(ctx, cmd, exec.NewExecResult)
 			if err != nil {
 				log.Debugf("error during readyForConfigCmd execution: %s", err)
 				time.Sleep(retryTimer)
@@ -466,7 +466,7 @@ func (s *srl) addDefaultConfig(ctx context.Context) error {
 		"bash", "-c",
 		fmt.Sprintf("echo '%s' > /tmp/clab-config", buf.String()),
 	})
-	_, err = s.RunExec(ctx, execCmd)
+	_, err = s.RunExec(ctx, execCmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}
@@ -476,7 +476,7 @@ func (s *srl) addDefaultConfig(ctx context.Context) error {
 		return err
 	}
 
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}
@@ -496,13 +496,13 @@ func (s *srl) addOverlayCLIConfig(ctx context.Context) error {
 		"bash", "-c",
 		fmt.Sprintf("echo '%s' > /tmp/clab-config", cfgStr),
 	})
-	_, err := s.RunExec(ctx, cmd)
+	_, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}
 
 	cmd, _ = exec.NewExecCmdFromString(`bash -c "sr_cli -ed --post 'commit save' < tmp/clab-config"`)
-	execResult, err := s.RunExec(ctx, cmd)
+	execResult, err := s.RunExec(ctx, cmd, exec.NewExecResult)
 	if err != nil {
 		return err
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -683,7 +683,7 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 }
 
 // Exec executes cmd on container identified with id and returns stdout, stderr bytes and an error.
-func (d *DockerRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+func (d *DockerRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	cont, err := d.Client.ContainerInspect(ctx, cID)
 	if err != nil {
 		return nil, err
@@ -731,13 +731,13 @@ func (d *DockerRuntime) Exec(ctx context.Context, cID string, execCmd *exec.Exec
 		return nil, err
 	}
 
-	execResult := exec.NewExecResult(execCmd)
+	execResult := erhcf(execCmd)
 
 	// set the result fields in the exec struct
 	execResult.SetReturnCode(execInspect.ExitCode)
 	execResult.SetStdOut(outBuf.Bytes())
 	execResult.SetStdErr(errBuf.Bytes())
-	return execResult, nil
+	return execResult.GetExecResultHolder(), nil
 }
 
 // ExecNotWait executes cmd on container identified with id but doesn't wait for output nor attaches stdout/err.

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -399,7 +399,7 @@ func (c *IgniteRuntime) GetNSPath(ctx context.Context, ctrId string) (string, er
 	return result, nil
 }
 
-func (*IgniteRuntime) Exec(_ context.Context, _ string, _ *exec.ExecCmd) (exec.ExecResultHolder, error) {
+func (*IgniteRuntime) Exec(_ context.Context, _ string, _ *exec.ExecCmd, _ exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	log.Infof("Exec is not yet implemented for Ignite runtime")
 	return nil, nil
 }

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -235,7 +235,7 @@ func (r *PodmanRuntime) GetNSPath(ctx context.Context, cID string) (string, erro
 	return nspath, nil
 }
 
-func (r *PodmanRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+func (r *PodmanRuntime) Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error) {
 	ctx, err := r.connect(ctx)
 	if err != nil {
 		return nil, err
@@ -270,12 +270,12 @@ func (r *PodmanRuntime) Exec(ctx context.Context, cID string, execCmd *exec.Exec
 	log.Debugf("Exec attached to the container %q and got stdout %q and stderr %q", cID, sOut.Bytes(), sErr.Bytes())
 
 	// fill the execution result
-	execResult := exec.NewExecResult(execCmd)
+	execResult := erhcf(execCmd)
 	execResult.SetStdErr(sErr.Bytes())
 	execResult.SetStdOut(sOut.Bytes())
 	execResult.SetReturnCode(inspectOut.ExitCode)
 
-	return execResult, nil
+	return execResult.GetExecResultHolder(), nil
 }
 
 func (r *PodmanRuntime) ExecNotWait(ctx context.Context, cID string, exec *exec.ExecCmd) error {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -47,7 +47,7 @@ type ContainerRuntime interface {
 	// Get a netns path using the pid of a container
 	GetNSPath(context.Context, string) (string, error)
 	// Executes cmd on container identified with id and returns stdout, stderr bytes and an error
-	Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error)
+	Exec(ctx context.Context, cID string, execCmd *exec.ExecCmd, erhcf exec.ExecResultHolderCreateFn) (exec.ExecResultHolder, error)
 	// ExecNotWait executes cmd on container identified with id but doesn't wait for output nor attaches stdout/err
 	ExecNotWait(ctx context.Context, cID string, execCmd *exec.ExecCmd) error
 	// Delete container by its name


### PR DESCRIPTION
This PR contains changes that allow for the exec output to be valid json, embedding the result of in container executions in the json output structure.
See #1158