### PR TITLE
Remove unnecessary entrypoint option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clint:
 
 .PHONY: docs
 docs:
-	docker run -v $$(pwd):/docs --entrypoint mkdocs squidfunk/mkdocs-material:$(MKDOCS_VER) build --clean --strict
+	docker run -v $$(pwd):/docs squidfunk/mkdocs-material:$(MKDOCS_VER) build --clean --strict
 
 .PHONY: site
 site:
@@ -60,7 +60,7 @@ serve-insiders:
 
 .PHONY: htmltest
 htmltest:
-	docker run --rm -v $$(pwd):/docs --entrypoint mkdocs squidfunk/mkdocs-material:$(MKDOCS_VER) build --clean --strict
+	docker run --rm -v $$(pwd):/docs squidfunk/mkdocs-material:$(MKDOCS_VER) build --clean --strict
 	docker run --rm -v $$(pwd):/test wjdp/htmltest --conf ./site/htmltest-w-github.yml
 	rm -rf ./site
 


### PR DESCRIPTION
`squidfunk/mkdocs-material` container image specifies `mkdocs` as the entrypoint and `--entrypoint mkdocs` is redundant.