### PR TITLE
Filtering Adjustments to Address Inspect/Table Problems

### DIFF
--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -121,7 +121,7 @@ func (d *DefaultNode) GetContainers(ctx context.Context) ([]types.GenericContain
 		{
 			FilterType: "name",
 			Operator:   "=",
-			Match:      fmt.Sprintf("%s", d.Cfg.LongName), // this regexp ensure we have an exact match for name
+			Match:      d.Cfg.LongName,
 		},
 	})
 	if err != nil {

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -120,7 +120,8 @@ func (d *DefaultNode) GetContainers(ctx context.Context) ([]types.GenericContain
 	cnts, err := d.Runtime.ListContainers(ctx, []*types.GenericFilter{
 		{
 			FilterType: "name",
-			Match:      fmt.Sprintf("^%s$", d.OverwriteNode.GetContainerName()), // this regexp ensure we have an exact match for name
+			Operator:   "=",
+			Match:      fmt.Sprintf("%s", d.Cfg.LongName), // this regexp ensure we have an exact match for name
 		},
 	})
 	if err != nil {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -596,7 +596,7 @@ func (*DockerRuntime) buildFilterString(gfilters []*types.GenericFilter) filters
 	for _, filterentry := range gfilters {
 		filterstr := filterentry.Field
 		if filterentry.Operator != "exists" {
-			filterstr = filterstr + filterentry.Operator + filterentry.Match
+			filterstr = filterstr + filterentry.Match
 		}
 
 		log.Debugf("Filter key: %s, filter value: %s", filterentry.FilterType, filterstr)

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -302,9 +302,9 @@ func (c *IgniteRuntime) ListContainers(_ context.Context, gfilters []*types.Gene
 
 	var labelStrings []string
 	for _, gf := range gfilters {
-		if gf.FilterType == "label" && gf.Operator == "=" {
+		if gf.FilterType == "name" && gf.Operator == "=" {
 			labelStrings = append(labelStrings, fmt.Sprintf(
-				"{{.ObjectMeta.Labels.%s}}=%s", gf.Field, gf.Match))
+				"{{.ObjectMeta.Name%s}}=%s", gf.Field, gf.Match))
 		}
 	}
 


### PR DESCRIPTION
The changes in this pull request are meant to address the following problem:

Basically, the way that the nodes/containers were filtered was causing more containers to be returned and tabled as below:

```
root@tower:/home/enduser/go/src/github.com/containerlab# containerlab inspect -t topology.yaml
INFO[0000] Parsing & checking topology file: topology.yaml
+-----+-----------------------+-------------------------+------------------------------+--------+---------+----------------+----------------------+
|  #  |         Name          |      Container ID       |            Image             |  Kind  |  State  |  IPv4 Address  |     IPv6 Address     |
+-----+-----------------------+-------------------------+------------------------------+--------+---------+----------------+----------------------+
|   1 | clab-vae-vae-br-aaf37 | 39cab7d9f0fb            | vrnetlab/vr-vmx:18.2R1.9     | vr-vmx | running | 172.20.20.2/24 | 2001:172:20:20::2/64 |
|   2 | clab-vae-vae-br-aag37 | d24b4fa781b6            | vrnetlab/vr-vmx:18.2R1.9     | vr-vmx | running | 172.20.20.3/24 | 2001:172:20:20::3/64 |
|   3 | clab-vae-vae-sw-aaa44 | 7833dd0bd76f            | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   4 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   5 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   6 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   7 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   8 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|   9 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  10 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  11 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  12 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  13 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  14 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  15 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  16 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  17 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  18 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  19 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  20 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  21 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  22 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  23 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  24 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  25 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  26 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  27 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  28 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
|  29 |                       |                         | docker.io/networkop/cx:4.3.0 | cvx    |         | 172.17.0.7/24  | N/A                  |
```
