### PR TITLE
fix ovs bridge check

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -257,6 +257,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	// execute commands specified for nodes with `exec` node parameter
 	execCollection := exec.NewExecCollection()
 	for _, n := range c.Nodes {
+		// do not try to execute commands if the list is empty
+		if len(n.Config().Exec) == 0 {
+			continue
+		}
+
 		execResult, err := n.RunExecs(ctx, n.Config().Exec)
 		if err != nil {
 			log.Warnf("Failed to exec commands for node %q", n.Config().ShortName)


### PR DESCRIPTION
during the refactoring we started to use linux bridge check as part of the `CheckDeploymentConditions`. This function doesn't work for ovs bridges.

In this PR the check is changed to list ovs bridges specifically.

The PR also fixes the exec bug for nodes which do not support it:

```
INFO[0001] Adding containerlab host entries to /etc/hosts file 
WARN[0001] Exec operation is not implemented for kind "ovs-bridge" 
WARN[0001] Failed to exec commands for node "myovs" 
```