### PR TITLE
Fixing filtering of containers for `clab exec`

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -563,6 +563,7 @@ func (c *CLab) ListNodesContainers(ctx context.Context) ([]runtime.GenericContai
 
 		containers = append(containers, cts...)
 	}
+
 	return containers, nil
 }
 

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -538,8 +538,8 @@ func (c *CLab) DeleteNodes(ctx context.Context, workers uint, serialNodes map[st
 }
 
 // ListContainers lists all containers using provided filter.
-func (c *CLab) ListContainers(ctx context.Context, filter []*types.GenericFilter) ([]types.GenericContainer, error) {
-	var containers []types.GenericContainer
+func (c *CLab) ListContainers(ctx context.Context, filter []*types.GenericFilter) ([]runtime.GenericContainer, error) {
+	var containers []runtime.GenericContainer
 
 	for _, r := range c.Runtimes {
 		ctrs, err := r.ListContainers(ctx, filter)
@@ -552,8 +552,8 @@ func (c *CLab) ListContainers(ctx context.Context, filter []*types.GenericFilter
 }
 
 // ListNodesContainers lists all containers based on the nodes stored in clab instance.
-func (c *CLab) ListNodesContainers(ctx context.Context) ([]types.GenericContainer, error) {
-	var containers []types.GenericContainer
+func (c *CLab) ListNodesContainers(ctx context.Context) ([]runtime.GenericContainer, error) {
+	var containers []runtime.GenericContainer
 
 	for _, n := range c.Nodes {
 		cts, err := n.GetContainers(ctx)

--- a/clab/graph.go
+++ b/clab/graph.go
@@ -17,6 +17,7 @@ import (
 	e "github.com/srl-labs/containerlab/errors"
 	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -183,7 +184,7 @@ func (c *CLab) BuildGraphFromTopo(g *GraphTopo) {
 	}
 }
 
-func (c *CLab) BuildGraphFromDeployedLab(g *GraphTopo, containers []types.GenericContainer) {
+func (c *CLab) BuildGraphFromDeployedLab(g *GraphTopo, containers []runtime.GenericContainer) {
 	containerNames := make(map[string]struct{})
 	for _, cont := range containers {
 		log.Debugf("looking for node name %s", cont.Labels[labels.NodeName])

--- a/clab/hostsfile.go
+++ b/clab/hostsfile.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/utils"
 )
 
@@ -19,7 +19,7 @@ const (
 	clabHostsFilename    = "/etc/hosts"
 )
 
-func AppendHostsFileEntries(containers []types.GenericContainer, labname string) error {
+func AppendHostsFileEntries(containers []runtime.GenericContainer, labname string) error {
 	filename := clabHostsFilename
 	if labname == "" {
 		return fmt.Errorf("missing lab name")
@@ -55,7 +55,7 @@ func AppendHostsFileEntries(containers []types.GenericContainer, labname string)
 }
 
 // generateHostsEntries builds an /etc/hosts compliant text blob (as []byte]) for containers ipv4/6 address<->name pairs.
-func generateHostsEntries(containers []types.GenericContainer, labname string) []byte {
+func generateHostsEntries(containers []runtime.GenericContainer, labname string) []byte {
 	entries := bytes.Buffer{}
 	v6entries := bytes.Buffer{}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -62,8 +62,8 @@ var execCmd = &cobra.Command{
 
 		filters := types.FilterFromLabelStrings(labelsFilter)
 
-		// list all nodes matching the filters
-		nodes, err := c.ListNodes(ctx, filters)
+		// list all containers using global runtime using provided filters
+		cnts, err := c.GlobalRuntime().ListContainers(ctx, filters)
 		if err != nil {
 			return err
 		}
@@ -81,19 +81,19 @@ var execCmd = &cobra.Command{
 			execCmds = append(execCmds, execCmd)
 		}
 
-		// run the exec commands on all the cotnainers matching the filter
-		for _, node := range nodes {
+		// run the exec commands on all the containers matching the filter
+		for _, cnt := range cnts {
 			// iterate over the commands
 			for _, execCmd := range execCmds {
 				// execute the commands
-				execResult, err := node.RunExec(ctx, execCmd)
+				execResult, err := cnt.RunExec(ctx, execCmd)
 				if err != nil {
 					// skip nodes that do not support exec
 					if err == exec.ErrRunExecNotSupported {
 						continue
 					}
 				}
-				resultCollection.Add(node.Cfg.ShortName, execResult)
+				resultCollection.Add(cnt.Names[0], execResult)
 			}
 		}
 

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -71,7 +71,7 @@ func graphFn(_ *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var containers []types.GenericContainer
+	var containers []runtime.GenericContainer
 	// if offline mode is not enforced, list containers matching lab name
 	if !offline {
 		labels := []*types.GenericFilter{{

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -82,7 +82,7 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var containers []types.GenericContainer
+	var containers []runtime.GenericContainer
 
 	// if the topo file is available, use it
 	if topo != "" {
@@ -149,7 +149,7 @@ func toTableData(det []types.ContainerDetails) [][]string {
 	return tabData
 }
 
-func printContainerInspect(containers []types.GenericContainer, format string) error {
+func printContainerInspect(containers []runtime.GenericContainer, format string) error {
 	contDetails := make([]types.ContainerDetails, 0, len(containers))
 	// do not print published ports unless mysocketio kind is found
 	printMysocket := false
@@ -328,7 +328,7 @@ type TokenFileResults struct {
 // mySocketIoTokenFileFromBindMounts runs through the provided slice of GenericContainers to deduce the mysocketio containers
 // if those are found the bindmounts are evaluated to find the hostpath to the referenced ".mysocketio_token" files. Since multiple
 // labs might be started the result is a slice of "".mysocketio_token" files.
-func mySocketIoTokenFileFromBindMounts(containers []types.GenericContainer) []*TokenFileResults {
+func mySocketIoTokenFileFromBindMounts(containers []runtime.GenericContainer) []*TokenFileResults {
 	result := []*TokenFileResults{}
 	for _, node := range containers {
 		// if not mysocketio kind then continue

--- a/mocks/default_node.go
+++ b/mocks/default_node.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	types "github.com/srl-labs/containerlab/types"
+	runtime "github.com/srl-labs/containerlab/runtime"
 )
 
 // MockNodeOverwrites is a mock of NodeOverwrites interface.
@@ -64,10 +64,10 @@ func (mr *MockNodeOverwritesMockRecorder) GetContainerName() *gomock.Call {
 }
 
 // GetContainers mocks base method.
-func (m *MockNodeOverwrites) GetContainers(ctx context.Context) ([]types.GenericContainer, error) {
+func (m *MockNodeOverwrites) GetContainers(ctx context.Context) ([]runtime.GenericContainer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainers", ctx)
-	ret0, _ := ret[0].([]types.GenericContainer)
+	ret0, _ := ret[0].([]runtime.GenericContainer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/node.go
+++ b/mocks/node.go
@@ -137,10 +137,10 @@ func (mr *MockNodeMockRecorder) GenerateConfig(dst, templ interface{}) *gomock.C
 }
 
 // GetContainers mocks base method.
-func (m *MockNode) GetContainers(ctx context.Context) ([]types.GenericContainer, error) {
+func (m *MockNode) GetContainers(ctx context.Context) ([]runtime.GenericContainer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainers", ctx)
-	ret0, _ := ret[0].([]types.GenericContainer)
+	ret0, _ := ret[0].([]runtime.GenericContainer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/runtime.go
+++ b/mocks/runtime.go
@@ -214,10 +214,10 @@ func (mr *MockContainerRuntimeMockRecorder) Init(arg0 ...interface{}) *gomock.Ca
 }
 
 // ListContainers mocks base method.
-func (m *MockContainerRuntime) ListContainers(arg0 context.Context, arg1 []*types.GenericFilter) ([]types.GenericContainer, error) {
+func (m *MockContainerRuntime) ListContainers(arg0 context.Context, arg1 []*types.GenericFilter) ([]runtime.GenericContainer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainers", arg0, arg1)
-	ret0, _ := ret[0].([]types.GenericContainer)
+	ret0, _ := ret[0].([]runtime.GenericContainer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	cExec "github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -110,7 +111,7 @@ func (*bridge) PullImage(_ context.Context) error { return nil }
 func (*bridge) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }
 
 // GetContainers is a noop for bridges.
-func (*bridge) GetContainers(_ context.Context) ([]types.GenericContainer, error) { return nil, nil }
+func (*bridge) GetContainers(_ context.Context) ([]runtime.GenericContainer, error) { return nil, nil }
 
 func (b *bridge) RunExecs(_ context.Context, _ []string) ([]cExec.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", b.Config().Kind)

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -309,9 +309,9 @@ func (d *DefaultNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.
 	return execResult, nil
 }
 
-// RunExecTypeWoWait is the final function that calls the runtime to execute a type.Exec on a container
-// This is to be overriden if the nodes implementation differs.
-func (d *DefaultNode) RunExecTypeWoWait(ctx context.Context, execCmd *exec.ExecCmd) error {
+// RunExecNotWait executes a command for a node, and doesn't block waiting for the output.
+// Should be overriden if the nodes implementation differs.
+func (d *DefaultNode) RunExecNotWait(ctx context.Context, execCmd *exec.ExecCmd) error {
 	err := d.GetRuntime().ExecNotWait(ctx, d.OverwriteNode.GetContainerName(), execCmd)
 	if err != nil {
 		log.Errorf("%s: failed to execute cmd: %q with error %v",

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -116,7 +116,7 @@ func (d *DefaultNode) GetImages(_ context.Context) map[string]string {
 	}
 }
 
-func (d *DefaultNode) GetContainers(ctx context.Context) ([]types.GenericContainer, error) {
+func (d *DefaultNode) GetContainers(ctx context.Context) ([]runtime.GenericContainer, error) {
 	cnts, err := d.Runtime.ListContainers(ctx, []*types.GenericFilter{
 		{
 			FilterType: "name",
@@ -242,7 +242,7 @@ type NodeOverwrites interface {
 	VerifyHostRequirements() error
 	PullImage(ctx context.Context) error
 	GetImages(ctx context.Context) map[string]string
-	GetContainers(ctx context.Context) ([]types.GenericContainer, error)
+	GetContainers(ctx context.Context) ([]runtime.GenericContainer, error)
 	GetContainerName() string
 }
 

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -69,7 +69,7 @@ func (e *extcont) GetContainerName() string {
 	return e.Cfg.ShortName
 }
 
-func (e *extcont) GetContainers(ctx context.Context) ([]types.GenericContainer, error) {
+func (e *extcont) GetContainers(ctx context.Context) ([]runtime.GenericContainer, error) {
 	cnts, err := e.DefaultNode.GetContainers(ctx)
 	if err != nil {
 		return nil, err

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 )
 
@@ -47,8 +48,8 @@ func (*host) WithMgmtNet(*types.MgmtNet)                    {}
 func (*host) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }
 
 // GetContainers returns a basic skeleton of a container to enable graphing of hosts kinds.
-func (*host) GetContainers(_ context.Context) ([]types.GenericContainer, error) {
-	return []types.GenericContainer{
+func (*host) GetContainers(_ context.Context) ([]runtime.GenericContainer, error) {
+	return []runtime.GenericContainer{
 		{
 			Names:   []string{"Host"},
 			State:   "running",
@@ -56,7 +57,7 @@ func (*host) GetContainers(_ context.Context) ([]types.GenericContainer, error) 
 			ShortID: "N/A",
 			Image:   "-",
 			Status:  "running",
-			NetworkSettings: types.GenericMgmtIPs{
+			NetworkSettings: runtime.GenericMgmtIPs{
 				IPv4addr: "N/A",
 				IPv4pLen: 0,
 				IPv4Gw:   "N/A",

--- a/nodes/mysocketio/mysocket.go
+++ b/nodes/mysocketio/mysocket.go
@@ -80,7 +80,7 @@ func createMysocketTunnels(ctx context.Context, node *mySocketIO, nodesMap map[s
 				n.Config().LongName, ms.Port, sockID, tunID, proxy,
 				n.Config().ShortName, ms.Stype, ms.Port))
 			log.Debugf("Running mysocketio command %q", cmd)
-			err = node.RunExecTypeWoWait(ctx, cmd)
+			err = node.RunExecNotWait(ctx, cmd)
 			if err != nil {
 				return err
 			}

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -61,7 +61,7 @@ func SetNonDefaultRuntimePerKind(kindnames []string, runtime string) error {
 type Node interface {
 	Init(*types.NodeConfig, ...NodeOption) error
 	// GetContainers returns a pointer to GenericContainer that the node uses.
-	GetContainers(ctx context.Context) ([]types.GenericContainer, error)
+	GetContainers(ctx context.Context) ([]runtime.GenericContainer, error)
 	DeleteNetnsSymlink() (err error)
 	Config() *types.NodeConfig // Config returns the nodes configuration
 	// CheckDeploymentConditions checks if node-scoped deployment conditions are met.

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -62,7 +63,7 @@ func (*ovs) DeleteNetnsSymlink() (err error)               { return nil }
 func (*ovs) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }
 
 // GetContainers is a noop for bridges.
-func (*ovs) GetContainers(_ context.Context) ([]types.GenericContainer, error) { return nil, nil }
+func (*ovs) GetContainers(_ context.Context) ([]runtime.GenericContainer, error) { return nil, nil }
 
 func (o *ovs) RunExecs(_ context.Context, _ []string) ([]exec.ExecResultHolder, error) {
 	log.Warnf("Exec operation is not implemented for kind %q", o.Config().Kind)

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -51,13 +51,13 @@ func (s *sonic) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
 	log.Debugf("Running postdeploy actions for sonic-vs '%s' node", s.Cfg.ShortName)
 
 	cmd, _ := exec.NewExecCmdFromString("supervisord")
-	err := s.RunExecTypeWoWait(ctx, cmd)
+	err := s.RunExecNotWait(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed post-deploy node %q: %w", s.Cfg.ShortName, err)
 	}
 
 	cmd, _ = exec.NewExecCmdFromString("supervisorctl start bgpd")
-	err = s.RunExecTypeWoWait(ctx, cmd)
+	err = s.RunExecNotWait(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("failed post-deploy node %q: %w", s.Cfg.ShortName, err)
 	}

--- a/runtime/containerd/containerd.go
+++ b/runtime/containerd/containerd.go
@@ -537,7 +537,7 @@ func (c *ContainerdRuntime) getContainerTask(ctx context.Context, containername 
 	return cont.Task(ctx, nil)
 }
 
-func (c *ContainerdRuntime) ListContainers(ctx context.Context, filter []*types.GenericFilter) ([]types.GenericContainer, error) {
+func (c *ContainerdRuntime) ListContainers(ctx context.Context, filter []*types.GenericFilter) ([]runtime.GenericContainer, error) {
 	log.Debug("listing containers")
 	ctx = namespaces.WithNamespace(ctx, containerdNamespace)
 
@@ -551,8 +551,8 @@ func (c *ContainerdRuntime) ListContainers(ctx context.Context, filter []*types.
 }
 
 // GetContainer TODO this will probably not work. need to work out the exact filter format.
-func (c *ContainerdRuntime) GetContainer(ctx context.Context, containerID string) (*types.GenericContainer, error) {
-	var ctr *types.GenericContainer
+func (c *ContainerdRuntime) GetContainer(ctx context.Context, containerID string) (*runtime.GenericContainer, error) {
+	var ctr *runtime.GenericContainer
 	gFilter := types.GenericFilter{
 		FilterType: "name",
 		Field:      "",
@@ -601,14 +601,14 @@ func (*ContainerdRuntime) buildFilterString(filter []*types.GenericFilter) strin
 }
 
 // Transform docker-specific to generic container format.
-func (*ContainerdRuntime) produceGenericContainerList(ctx context.Context,
+func (c *ContainerdRuntime) produceGenericContainerList(ctx context.Context,
 	input []containerd.Container,
-) ([]types.GenericContainer, error) {
-	var result []types.GenericContainer
+) ([]runtime.GenericContainer, error) {
+	var result []runtime.GenericContainer
 
 	for _, i := range input {
 
-		ctr := types.GenericContainer{}
+		ctr := runtime.GenericContainer{}
 
 		info, err := i.Info(ctx)
 		if err != nil {
@@ -620,6 +620,7 @@ func (*ContainerdRuntime) produceGenericContainerList(ctx context.Context,
 		ctr.ShortID = ctr.ID
 		ctr.Image = info.Image
 		ctr.Labels = info.Labels
+		ctr.SetRuntime(c)
 
 		ctr.NetworkSettings, err = extractIPInfoFromLabels(ctr.Labels)
 		if err != nil {
@@ -664,23 +665,23 @@ func (*ContainerdRuntime) produceGenericContainerList(ctx context.Context,
 	return result, nil
 }
 
-func extractIPInfoFromLabels(labels map[string]string) (types.GenericMgmtIPs, error) {
+func extractIPInfoFromLabels(labels map[string]string) (runtime.GenericMgmtIPs, error) {
 	var ipv4mask int
 	var ipv6mask int
 	var err error
 	if val, exists := labels["clab.ipv4.netmask"]; exists {
 		ipv4mask, err = strconv.Atoi(val)
 		if err != nil {
-			return types.GenericMgmtIPs{}, err
+			return runtime.GenericMgmtIPs{}, err
 		}
 	}
 	if val, exists := labels["clab.ipv6.netmask"]; exists {
 		ipv6mask, err = strconv.Atoi(val)
 		if err != nil {
-			return types.GenericMgmtIPs{}, err
+			return runtime.GenericMgmtIPs{}, err
 		}
 	}
-	return types.GenericMgmtIPs{
+	return runtime.GenericMgmtIPs{
 		IPv4addr: labels["clab.ipv4.addr"], IPv4pLen: ipv4mask,
 		IPv6addr: labels["clab.ipv6.addr"], IPv6pLen: ipv6mask, IPv4Gw: labels["clab.ipv4.gateway"],
 		IPv6Gw: labels["clab.ipv6.gateway"],

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -520,7 +520,7 @@ func (d *DockerRuntime) postStartActions(ctx context.Context, cID string, node *
 }
 
 // ListContainers lists all containers using the provided filters.
-func (d *DockerRuntime) ListContainers(ctx context.Context, gfilters []*types.GenericFilter) ([]types.GenericContainer, error) {
+func (d *DockerRuntime) ListContainers(ctx context.Context, gfilters []*types.GenericFilter) ([]runtime.GenericContainer, error) {
 	ctx, cancel := context.WithTimeout(ctx, d.config.Timeout)
 	defer cancel()
 
@@ -570,8 +570,8 @@ func (d *DockerRuntime) ListContainers(ctx context.Context, gfilters []*types.Ge
 	return d.produceGenericContainerList(ctrs, nr)
 }
 
-func (d *DockerRuntime) GetContainer(ctx context.Context, cID string) (*types.GenericContainer, error) {
-	var ctr *types.GenericContainer
+func (d *DockerRuntime) GetContainer(ctx context.Context, cID string) (*runtime.GenericContainer, error) {
+	var ctr *runtime.GenericContainer
 	gFilter := types.GenericFilter{
 		FilterType: "name",
 		Field:      "",
@@ -609,8 +609,8 @@ func (*DockerRuntime) buildFilterString(gfilters []*types.GenericFilter) filters
 // Transform docker-specific to generic container format.
 func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerTypes.Container,
 	inputNetworkResources []dockerTypes.NetworkResource,
-) ([]types.GenericContainer, error) {
-	var result []types.GenericContainer
+) ([]runtime.GenericContainer, error) {
+	var result []runtime.GenericContainer
 
 	for idx := range inputContainers {
 		i := inputContainers[idx]
@@ -622,7 +622,7 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 			names = append(names, strings.TrimLeft(n, "/"))
 		}
 
-		ctr := types.GenericContainer{
+		ctr := runtime.GenericContainer{
 			Names:           names,
 			ID:              i.ID,
 			ShortID:         i.ID[:12],
@@ -630,8 +630,9 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 			State:           i.State,
 			Status:          i.Status,
 			Labels:          i.Labels,
-			NetworkSettings: types.GenericMgmtIPs{},
+			NetworkSettings: runtime.GenericMgmtIPs{},
 		}
+		ctr.SetRuntime(d)
 
 		bridgeName := d.mgmt.Network
 
@@ -669,7 +670,7 @@ func (d *DockerRuntime) produceGenericContainerList(inputContainers []dockerType
 		}
 
 		// populating mounts information
-		var mount types.ContainerMount
+		var mount runtime.ContainerMount
 		for _, m := range i.Mounts {
 			mount.Source = m.Source
 			mount.Destination = m.Destination

--- a/runtime/generic_container.go
+++ b/runtime/generic_container.go
@@ -1,11 +1,7 @@
 package runtime
 
 import (
-	"context"
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/clab/exec"
 )
 
 // GenericContainer stores generic container data.
@@ -33,27 +29,27 @@ func (ctr *GenericContainer) SetRuntime(r ContainerRuntime) {
 	ctr.runtime = r
 }
 
-// RunExec executes a single command for a GenericContainer.
-func (gc *GenericContainer) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
-	containerName := gc.Names[0]
-	execResult, err := gc.runtime.Exec(ctx, containerName, execCmd)
-	if err != nil {
-		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
-		return nil, err
-	}
-	return execResult, nil
-}
+// // RunExec executes a single command for a GenericContainer.
+// func (gc *GenericContainer) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+// 	containerName := gc.Names[0]
+// 	execResult, err := gc.runtime.Exec(ctx, containerName, execCmd)
+// 	if err != nil {
+// 		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
+// 		return nil, err
+// 	}
+// 	return execResult, nil
+// }
 
-// RunExecTypeWoWait is the final function that calls the runtime to execute a type.Exec on a GenericContainer
-func (gc *GenericContainer) RunExecTypeWoWait(ctx context.Context, execCmd *exec.ExecCmd) error {
-	containerName := gc.Names[0]
-	err := gc.runtime.ExecNotWait(ctx, containerName, execCmd)
-	if err != nil {
-		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
-		return err
-	}
-	return nil
-}
+// // RunExecTypeWoWait is the final function that calls the runtime to execute a type.Exec on a GenericContainer
+// func (gc *GenericContainer) RunExecTypeWoWait(ctx context.Context, execCmd *exec.ExecCmd) error {
+// 	containerName := gc.Names[0]
+// 	err := gc.runtime.ExecNotWait(ctx, containerName, execCmd)
+// 	if err != nil {
+// 		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
+// 		return err
+// 	}
+// 	return nil
+// }
 
 func (ctr *GenericContainer) GetContainerIPv4() string {
 	if ctr.NetworkSettings.IPv4addr == "" {

--- a/runtime/generic_container.go
+++ b/runtime/generic_container.go
@@ -1,7 +1,11 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/clab/exec"
 )
 
 // GenericContainer stores generic container data.
@@ -29,16 +33,16 @@ func (ctr *GenericContainer) SetRuntime(r ContainerRuntime) {
 	ctr.runtime = r
 }
 
-// // RunExec executes a single command for a GenericContainer.
-// func (gc *GenericContainer) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
-// 	containerName := gc.Names[0]
-// 	execResult, err := gc.runtime.Exec(ctx, containerName, execCmd)
-// 	if err != nil {
-// 		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
-// 		return nil, err
-// 	}
-// 	return execResult, nil
-// }
+// RunExec executes a single command for a GenericContainer.
+func (gc *GenericContainer) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+	containerName := gc.Names[0]
+	execResult, err := gc.runtime.Exec(ctx, containerName, execCmd)
+	if err != nil {
+		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
+		return nil, err
+	}
+	return execResult, nil
+}
 
 // // RunExecTypeWoWait is the final function that calls the runtime to execute a type.Exec on a GenericContainer
 // func (gc *GenericContainer) RunExecTypeWoWait(ctx context.Context, execCmd *exec.ExecCmd) error {

--- a/runtime/generic_container.go
+++ b/runtime/generic_container.go
@@ -1,0 +1,79 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/clab/exec"
+)
+
+// GenericContainer stores generic container data.
+type GenericContainer struct {
+	Names           []string
+	ID              string
+	ShortID         string // trimmed ID for display purposes
+	Image           string
+	State           string
+	Status          string
+	Labels          map[string]string
+	Pid             int
+	NetworkSettings GenericMgmtIPs
+	Mounts          []ContainerMount
+	runtime         ContainerRuntime
+}
+
+type ContainerMount struct {
+	Source      string
+	Destination string
+}
+
+// SetRuntime sets the runtime for this GenericContainer
+func (ctr *GenericContainer) SetRuntime(r ContainerRuntime) {
+	ctr.runtime = r
+}
+
+// RunExec executes a single command for a GenericContainer.
+func (gc *GenericContainer) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (exec.ExecResultHolder, error) {
+	containerName := gc.Names[0]
+	execResult, err := gc.runtime.Exec(ctx, containerName, execCmd)
+	if err != nil {
+		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
+		return nil, err
+	}
+	return execResult, nil
+}
+
+// RunExecTypeWoWait is the final function that calls the runtime to execute a type.Exec on a GenericContainer
+func (gc *GenericContainer) RunExecTypeWoWait(ctx context.Context, execCmd *exec.ExecCmd) error {
+	containerName := gc.Names[0]
+	err := gc.runtime.ExecNotWait(ctx, containerName, execCmd)
+	if err != nil {
+		log.Errorf("%s: failed to execute cmd: %q with error %v", containerName, execCmd.GetCmdString(), err)
+		return err
+	}
+	return nil
+}
+
+func (ctr *GenericContainer) GetContainerIPv4() string {
+	if ctr.NetworkSettings.IPv4addr == "" {
+		return "N/A"
+	}
+	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv4addr, ctr.NetworkSettings.IPv4pLen)
+}
+
+func (ctr *GenericContainer) GetContainerIPv6() string {
+	if ctr.NetworkSettings.IPv6addr == "" {
+		return "N/A"
+	}
+	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv6addr, ctr.NetworkSettings.IPv6pLen)
+}
+
+type GenericMgmtIPs struct {
+	IPv4addr string
+	IPv4pLen int
+	IPv4Gw   string
+	IPv6addr string
+	IPv6pLen int
+	IPv6Gw   string
+}

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -297,8 +297,8 @@ func (*IgniteRuntime) StopContainer(_ context.Context, _ string) error {
 	return nil
 }
 
-func (c *IgniteRuntime) ListContainers(_ context.Context, gfilters []*types.GenericFilter) ([]types.GenericContainer, error) {
-	var result []types.GenericContainer
+func (c *IgniteRuntime) ListContainers(_ context.Context, gfilters []*types.GenericFilter) ([]runtime.GenericContainer, error) {
+	var result []runtime.GenericContainer
 
 	var labelStrings []string
 	for _, gf := range gfilters {
@@ -337,8 +337,8 @@ func (c *IgniteRuntime) ListContainers(_ context.Context, gfilters []*types.Gene
 	return c.produceGenericContainerList(filteredVMs)
 }
 
-func (c *IgniteRuntime) GetContainer(_ context.Context, containerID string) (*types.GenericContainer, error) {
-	var result *types.GenericContainer
+func (c *IgniteRuntime) GetContainer(_ context.Context, containerID string) (*runtime.GenericContainer, error) {
+	var result *runtime.GenericContainer
 	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(containerID))
 	if err != nil {
 		return result, err
@@ -356,18 +356,19 @@ func (c *IgniteRuntime) GetContainer(_ context.Context, containerID string) (*ty
 }
 
 // Transform docker-specific to generic container format.
-func (*IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]types.GenericContainer, error) {
-	var result []types.GenericContainer
+func (ir *IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]runtime.GenericContainer, error) {
+	var result []runtime.GenericContainer
 
 	for _, i := range input {
-		ctr := types.GenericContainer{
+		ctr := runtime.GenericContainer{
 			Names:           []string{i.Name},
 			ID:              i.GetUID().String(),
 			ShortID:         i.PrefixedID(),
 			Labels:          i.Labels,
 			Image:           i.Spec.Image.OCI.Normalized(),
-			NetworkSettings: types.GenericMgmtIPs{},
+			NetworkSettings: runtime.GenericMgmtIPs{},
 		}
+		ctr.SetRuntime(ir)
 
 		if i.Status.Runtime != nil && i.Status.Runtime.ID != "" && len(i.Status.Runtime.ID) > 12 {
 			ctr.ShortID = i.Status.Runtime.ID[:12]

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -208,7 +208,7 @@ func (r *PodmanRuntime) StopContainer(ctx context.Context, cID string) error {
 }
 
 // ListContainers returns a list of all available containers in the system in a containerlab-specific struct.
-func (r *PodmanRuntime) ListContainers(ctx context.Context, filters []*types.GenericFilter) ([]types.GenericContainer, error) {
+func (r *PodmanRuntime) ListContainers(ctx context.Context, filters []*types.GenericFilter) ([]runtime.GenericContainer, error) {
 	ctx, err := r.connect(ctx)
 	if err != nil {
 		return nil, err

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -274,14 +275,14 @@ func (*PodmanRuntime) convertMounts(_ context.Context, mounts []string) ([]specs
 // and transforms it into a GenericContainer type.
 func (r *PodmanRuntime) produceGenericContainerList(ctx context.Context,
 	cList []entities.ListContainer,
-) ([]types.GenericContainer, error) {
-	genericList := make([]types.GenericContainer, len(cList))
+) ([]runtime.GenericContainer, error) {
+	genericList := make([]runtime.GenericContainer, len(cList))
 	for i, v := range cList {
 		netSettings, err := r.extractMgmtIP(ctx, v.ID)
 		if err != nil {
 			return nil, err
 		}
-		genericList[i] = types.GenericContainer{
+		genericList[i] = runtime.GenericContainer{
 			Names:           v.Names,
 			ID:              v.ID,
 			ShortID:         v.ID[:12],
@@ -292,14 +293,15 @@ func (r *PodmanRuntime) produceGenericContainerList(ctx context.Context,
 			Pid:             v.Pid,
 			NetworkSettings: netSettings,
 		}
+		genericList[i].SetRuntime(r)
 	}
 	log.Debugf("Method produceGenericContainerList returns %+v", genericList)
 	return genericList, nil
 }
 
-func (*PodmanRuntime) extractMgmtIP(ctx context.Context, cID string) (types.GenericMgmtIPs, error) {
+func (*PodmanRuntime) extractMgmtIP(ctx context.Context, cID string) (runtime.GenericMgmtIPs, error) {
 	// First get all the data from the inspect
-	toReturn := types.GenericMgmtIPs{}
+	toReturn := runtime.GenericMgmtIPs{}
 	inspectRes, err := containers.Inspect(ctx, cID, &containers.InspectOptions{})
 	if err != nil {
 		log.Debugf("Couldn't extract mgmt IPs for container %q, %v", cID, err)
@@ -322,7 +324,7 @@ func (*PodmanRuntime) extractMgmtIP(ctx context.Context, cID string) (types.Gene
 	v6addr := mgmtData.GlobalIPv6Address
 	v6pLen := mgmtData.GlobalIPv6PrefixLen
 
-	toReturn = types.GenericMgmtIPs{
+	toReturn = runtime.GenericMgmtIPs{
 		IPv4addr: v4addr,
 		IPv4pLen: v4pLen,
 		IPv6addr: v6addr,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -43,7 +43,7 @@ type ContainerRuntime interface {
 	// UnPause / resume a container identified by its name
 	UnpauseContainer(context.Context, string) error
 	// List all containers matching labels
-	ListContainers(context.Context, []*types.GenericFilter) ([]types.GenericContainer, error)
+	ListContainers(context.Context, []*types.GenericFilter) ([]GenericContainer, error)
 	// Get a netns path using the pid of a container
 	GetNSPath(context.Context, string) (string, error)
 	// Executes cmd on container identified with id and returns stdout, stderr bytes and an error

--- a/tests/06-ext-container/01-ext-container.robot
+++ b/tests/06-ext-container/01-ext-container.robot
@@ -12,8 +12,8 @@ ${runtime}        docker
 *** Test Cases ***
 Start ext-containers
     Skip If    '${runtime}' == 'containerd'
-    Run     sudo ${runtime} run --name ext1 --rm -d --cap-add NET_ADMIN alpine sleep infinity
-    Run     sudo ${runtime} run --name ext2 --rm -d --cap-add NET_ADMIN alpine sleep infinity
+    Run     sudo ${runtime} run --name ext1 --label clab-node-name=ext1 --rm -d --cap-add NET_ADMIN alpine sleep infinity
+    Run     sudo ${runtime} run --name ext2 --label clab-node-name=ext2 --rm -d --cap-add NET_ADMIN alpine sleep infinity
 
 Deploy ${lab-name} lab
     Skip If    '${runtime}' == 'containerd'

--- a/tests/06-ext-container/01-ext-container.robot
+++ b/tests/06-ext-container/01-ext-container.robot
@@ -2,6 +2,7 @@
 Library           OperatingSystem
 Library           Process
 Resource          ../common.robot
+Suite Setup    Setup
 Suite Teardown    Run Keyword    Cleanup
 
 *** Variables ***
@@ -11,7 +12,6 @@ ${runtime}        docker
 
 *** Test Cases ***
 Start ext-containers
-    Skip If    '${runtime}' == 'containerd'
     Run     sudo ${runtime} run --name ext1 --label clab-node-name=ext1 --rm -d --cap-add NET_ADMIN alpine sleep infinity
     Run     sudo ${runtime} run --name ext2 --label clab-node-name=ext2 --rm -d --cap-add NET_ADMIN alpine sleep infinity
 
@@ -24,7 +24,6 @@ Deploy ${lab-name} lab
     Should Be Equal As Integers    ${rc}    0
 
 Verify links in node ext1
-    Skip If    '${runtime}' == 'containerd'
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=ext1 --cmd "ip link show dev eth1"
     Log    ${output}
@@ -32,7 +31,6 @@ Verify links in node ext1
     Should Contain    ${output}    state UP
 
 Verify ip and thereby exec on ext1
-    Skip If    '${runtime}' == 'containerd'
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=ext1 --cmd "ip address show dev eth1"
     Log    ${output}
@@ -40,7 +38,6 @@ Verify ip and thereby exec on ext1
     Should Contain    ${output}    192.168.0.1/24
 
 Verify links in node ext2
-    Skip If    '${runtime}' == 'containerd'
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=ext2 --cmd "ip link show dev eth1"
     Log    ${output}
@@ -48,15 +45,13 @@ Verify links in node ext2
     Should Contain    ${output}    state UP
 
 Verify ip and thereby exec on ext2
-    Skip If    '${runtime}' == 'containerd'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=ext1 --cmd "ip address show dev eth1"
+    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=ext2 --cmd "ip address show dev eth1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    192.168.0.2/24
 
 Verify ping from ext1 to ext2 on eth1
-    Skip If    '${runtime}' == 'containerd'
     ${result} =    Run Process
     ...    ${runtime} exec ext1 ping -w 2 -c 2 192.168.0.2       shell=True
     Log    ${result.stderr}
@@ -65,8 +60,11 @@ Verify ping from ext1 to ext2 on eth1
     Should Contain  ${result.stdout}    0% packet loss
 
 *** Keywords ***
+Setup
+    # skipping this test suite for non docker runtimes
+    Skip If    '${runtime}' != 'docker'
+
 Cleanup
-    Skip If    '${runtime}' == 'containerd'
     Run    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    ${runtime} rm -f ext1
     Run    ${runtime} rm -f ext2

--- a/types/types.go
+++ b/types/types.go
@@ -188,6 +188,10 @@ type GenericFilter struct {
 	Match string
 }
 
+// FilterFromLabelStrings creates a GenericFilter based on the list of label=value pairs or just label entries.
+// A filter of type `label` is created.
+// For each label=value input label, a filter with the Field matching the label and Match matching the value is created.
+// For each standalone label, a filter with Operator=exists and Field matching the label is created.
 func FilterFromLabelStrings(labels []string) []*GenericFilter {
 	gfl := []*GenericFilter{}
 	var gf *GenericFilter

--- a/types/types.go
+++ b/types/types.go
@@ -177,48 +177,6 @@ func DisableTxOffload(n *NodeConfig) error {
 	return err
 }
 
-// GenericContainer stores generic container data.
-type GenericContainer struct {
-	Names           []string
-	ID              string
-	ShortID         string // trimmed ID for display purposes
-	Image           string
-	State           string
-	Status          string
-	Labels          map[string]string
-	Pid             int
-	NetworkSettings GenericMgmtIPs
-	Mounts          []ContainerMount
-}
-
-type ContainerMount struct {
-	Source      string
-	Destination string
-}
-
-func (ctr *GenericContainer) GetContainerIPv4() string {
-	if ctr.NetworkSettings.IPv4addr == "" {
-		return "N/A"
-	}
-	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv4addr, ctr.NetworkSettings.IPv4pLen)
-}
-
-func (ctr *GenericContainer) GetContainerIPv6() string {
-	if ctr.NetworkSettings.IPv6addr == "" {
-		return "N/A"
-	}
-	return fmt.Sprintf("%s/%d", ctr.NetworkSettings.IPv6addr, ctr.NetworkSettings.IPv6pLen)
-}
-
-type GenericMgmtIPs struct {
-	IPv4addr string
-	IPv4pLen int
-	IPv4Gw   string
-	IPv6addr string
-	IPv6pLen int
-	IPv6Gw   string
-}
-
 type GenericFilter struct {
 	// defined by now "label" / "name" [then only Match is required]
 	FilterType string


### PR DESCRIPTION
A temp fix to support filtering with labels for `clab exec` command

Forked from here https://github.com/srl-labs/containerlab/pull/1168#pullrequestreview-1239788961, and instead of listing the nodes, listed containers using the default runtime