### PR TITLE
Align `clab exec` plain format with previous styling

### DIFF
--- a/clab/exec/exec.go
+++ b/clab/exec/exec.go
@@ -224,10 +224,10 @@ func (ec *ExecCollection) Log() {
 		for _, er := range execResults {
 			switch {
 			case er.GetReturnCode() != 0 || er.GetStdErrString() != "":
-				log.Errorf("Failed to execute command '%s' on node %s. rc=%d,\nstdout:\n%s\nstderr:\n%s",
+				log.Errorf("Failed to execute command %q on the node %q. rc=%d,\nstdout:\n%s\nstderr:\n%s",
 					er.GetCmdString(), k, er.GetReturnCode(), er.GetStdOutString(), er.GetStdErrString())
 			default:
-				log.Infof("Executed command '%s' on node %s. stdout:\n%s",
+				log.Infof("Executed command %q on the node %q. stdout:\n%s",
 					er.GetCmdString(), k, er.GetStdOutString())
 			}
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
@@ -97,13 +96,12 @@ var execCmd = &cobra.Command{
 			}
 		}
 
-		output, err := resultCollection.Dump(outputFormat)
-		if err != nil {
-			return err
+		switch outputFormat {
+		case exec.ExecFormatPlain:
+			resultCollection.Log()
 		}
-		fmt.Println(output)
 
-		return nil
+		return err
 	},
 }
 

--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -19,14 +19,17 @@ With the global `--topo | -t` flag a user specifies from which lab to take the c
 When the topology file flag is omitted, containerlab will try to find the matching file name by looking at the current working directory. If a single file is found, it will be used.
 
 #### cmd
+
 The command to be executed on the nodes is provided with `--cmd` flag. The command is provided as a string, thus it needs to be quoted to accommodate for spaces or special characters.
 
 #### format
+
 The `--format | -f` flag allows to select between plain text format output or a json variant. Consult with the examples below to see the differences between these two formatting options.
 
 Defaults to `plain` output format.
 
 #### label
+
 By default `exec` command will attempt to execute the command across all the nodes of a lab. To limit the scope of the execution, the users can leverage the `--label` flag to filter out the nodes of interest.
 
 ### Examples
@@ -46,6 +49,7 @@ INFO[0000] clab-srl02-srl2: stdout:
     inet 172.20.20.2/24 brd 172.20.20.255 scope global dummy-mgmt0
        valid_lft forever preferred_lft forever
 ```
+
 #### Execute a command on a node referenced by its name
 
 Show ipv4 information from a specific node of the lab with a plain text output


### PR DESCRIPTION
bringing back the logged messages to conform with the previous style patterns