### PR TITLE
added srl ping test

### DIFF
--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -78,6 +78,13 @@ Ensure srl1 is reachable over ssh with public key auth
     ...    keyfile=${key-path}
     ...    try_for=10
 
+Ensure srl1 can ping srl2 over ethernet-1/1 interface
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3s"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    0% packet loss
+
 *** Keywords ***
 Cleanup
     Run    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -11,6 +11,7 @@ topology:
   nodes:
     srl1:
       kind: srl
+      startup-config: srl1-startup.cli
     srl2:
       kind: srl
       startup-config: srl2-startup.cli

--- a/tests/02-basic-srl/srl1-startup.cli
+++ b/tests/02-basic-srl/srl1-startup.cli
@@ -1,0 +1,9 @@
+set / interface ethernet-1/1
+set / interface ethernet-1/1 subinterface 0
+set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.0.0/31
+set / interface ethernet-1/1 subinterface 0 ipv6
+set / interface ethernet-1/1 subinterface 0 ipv6 address 2002::192.168.0.0/127
+
+set / network-instance default
+set / network-instance default interface ethernet-1/1.0

--- a/tests/02-basic-srl/srl2-startup.cli
+++ b/tests/02-basic-srl/srl2-startup.cli
@@ -1,1 +1,11 @@
+set / interface ethernet-1/1
+set / interface ethernet-1/1 subinterface 0
+set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.0.1/31
+set / interface ethernet-1/1 subinterface 0 ipv6
+set / interface ethernet-1/1 subinterface 0 ipv6 address 2002::192.168.0.1/127
+
+set / network-instance default
+set / network-instance default interface ethernet-1/1.0
+
 set / system information location test123


### PR DESCRIPTION
The test ensures that the startup config provided to the nodes is sufficient for the nodes to be able to ping each other.

This test has a little flaw that waits for #1188 to be merged, as it currently executes the ping command on both nodes, due to the `exec` filtering not working right.

The test uses `ip netns exec` approach, but later should be moved to RF ability to invoke the shell and do the pings via the SRL CLI, which is more closer to what users would have used.

close #1015
