### PR TITLE
Update get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -234,11 +234,7 @@ setPkgInstaller() {
         if [[ -n "$VARIANT_ID" && $VARIANT_ID == "coreos" ]]; then
             PKG_INSTALLER="rpm-ostree install --uninstall=containerlab --idempotent"
         else
-          if [ "$(printf '%s\n' "$TAG_WO_VER" "v$version" | sort -V | head -n1)" = "$TAG_WO_VER" ]; then
-              PKG_INSTALLER="rpm -U --oldpackage"
-          else
-              PKG_INSTALLER="rpm -U"
-          fi
+            PKG_INSTALLER="rpm -U --oldpackage"
         fi
     fi
 }


### PR DESCRIPTION
Allowing containerlab downgrades using this script for package installation on CentOS (i.e. rpm based packages). Was only tested on CentOS.