### PR TITLE
Allow adjustment of LabDir base directory via env var

### DIFF
--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -96,6 +96,11 @@ Useful when running in an automated environments with restricted network access.
 
 Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 
+#### CLAB_LABS_BASE_DIR
+
+Can be set to alter the [lab directory](../manual/conf-artifacts.md#identifying-a-lab-directory) destination.
+The default is to create this directory in the current working dir. 
+
 ### Examples
 
 #### Deploy a lab using the given topology file

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -96,10 +96,11 @@ Useful when running in an automated environments with restricted network access.
 
 Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 
-#### CLAB_LABS_BASE_DIR
+#### CLAB_LAB_DIR
 
-Can be set to alter the [lab directory](../manual/conf-artifacts.md#identifying-a-lab-directory) destination.
-The default is to create this directory in the current working dir. 
+To change the [lab directory](../manual/conf-artifacts.md#identifying-a-lab-directory) location, set `CLAB_LAB_DIR`` env variable accordingly.
+
+The default behavior is to create the lab directory in the current working dir.
 
 ### Examples
 
@@ -124,7 +125,7 @@ containerlab deploy
 ```
 
 #### Deploy a lab using short flag names
+
 ```bash
 clab dep -t mylab.clab.yml
 ```
-

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -56,16 +56,18 @@ func (t *TopoPaths) SetTopologyFilePath(topologyFile string) error {
 }
 
 // SetLabDir sets the labDir.
-func (t *TopoPaths) SetLabDir(topologyName string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
+func (t *TopoPaths) SetLabDir(topologyName string) (err error) {
+	// if "CLAB_LABS_BASE_DIR" Env Var is set, use that dir as a base
+	// for the labDir, otherwise use PWD.
+	baseDir := os.Getenv("CLAB_LABS_BASE_DIR")
+	if baseDir == "" {
+		baseDir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
 	}
-
-	ldPath := path.Join(cwd, labDirPrefix+topologyName)
-
-	t.labDir = ldPath
-
+	// construct the path
+	t.labDir = path.Join(baseDir, labDirPrefix+topologyName)
 	return nil
 }
 

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -57,9 +57,9 @@ func (t *TopoPaths) SetTopologyFilePath(topologyFile string) error {
 
 // SetLabDir sets the labDir.
 func (t *TopoPaths) SetLabDir(topologyName string) (err error) {
-	// if "CLAB_LABS_BASE_DIR" Env Var is set, use that dir as a base
+	// if "CLAB_LAB_DIR" Env Var is set, use that dir as a base
 	// for the labDir, otherwise use PWD.
-	baseDir := os.Getenv("CLAB_LABS_BASE_DIR")
+	baseDir := os.Getenv("CLAB_LAB_DIR")
 	if baseDir == "" {
 		baseDir, err = os.Getwd()
 		if err != nil {


### PR DESCRIPTION
referring to #1179, this PR allows defining the `CLAB_LABS_BASE_DIR` environment variable.

Usually the lab directory is created under the current working dir (CWD). Via setting the `CLAB_LABS_BASE_DIR` env var, lab directories ("clab-TOPOLOGY_NAME") will be created under the `CLAB_LABS_BASE_DIR` defined path.