### PR TITLE
added parameter struct to deploy methods in node interface

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -341,13 +341,13 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int,
 				}
 
 				// PreDeploy
-				err = node.PreDeploy(ctx, nodecert)
+				err = node.PreDeploy(ctx, &nodes.PreDeployParams{Certificate: nodecert})
 				if err != nil {
 					log.Errorf("failed pre-deploy phase for node %q: %v", node.Config().ShortName, err)
 					continue
 				}
 				// Deploy
-				err = node.Deploy(ctx)
+				err = node.Deploy(ctx, &nodes.DeployParams{})
 				if err != nil {
 					log.Errorf("failed deploy phase for node %q: %v", node.Config().ShortName, err)
 					continue

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -224,7 +224,8 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		for _, node := range c.Nodes {
 			go func(node nodes.Node, wg *sync.WaitGroup) {
 				defer wg.Done()
-				err := node.PostDeploy(ctx, c.Nodes)
+
+				err := node.PostDeploy(ctx, &nodes.PostDeployParams{Nodes: c.Nodes})
 				if err != nil {
 					log.Errorf("failed to run postdeploy task for node %s: %v", node.Config().ShortName, err)
 				}

--- a/mocks/node.go
+++ b/mocks/node.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	cert "github.com/srl-labs/containerlab/cert"
 	exec "github.com/srl-labs/containerlab/clab/exec"
 	nodes "github.com/srl-labs/containerlab/nodes"
 	runtime "github.com/srl-labs/containerlab/runtime"
@@ -110,17 +109,17 @@ func (mr *MockNodeMockRecorder) DeleteNetnsSymlink() *gomock.Call {
 }
 
 // Deploy mocks base method.
-func (m *MockNode) Deploy(arg0 context.Context) error {
+func (m *MockNode) Deploy(arg0 context.Context, arg1 *nodes.DeployParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Deploy", arg0)
+	ret := m.ctrl.Call(m, "Deploy", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Deploy indicates an expected call of Deploy.
-func (mr *MockNodeMockRecorder) Deploy(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) Deploy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockNode)(nil).Deploy), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockNode)(nil).Deploy), arg0, arg1)
 }
 
 // GenerateConfig mocks base method.
@@ -200,31 +199,31 @@ func (mr *MockNodeMockRecorder) Init(arg0 interface{}, arg1 ...interface{}) *gom
 }
 
 // PostDeploy mocks base method.
-func (m *MockNode) PostDeploy(arg0 context.Context, arg1 map[string]nodes.Node) error {
+func (m *MockNode) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostDeploy", arg0, arg1)
+	ret := m.ctrl.Call(m, "PostDeploy", ctx, params)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PostDeploy indicates an expected call of PostDeploy.
-func (mr *MockNodeMockRecorder) PostDeploy(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) PostDeploy(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeploy", reflect.TypeOf((*MockNode)(nil).PostDeploy), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeploy", reflect.TypeOf((*MockNode)(nil).PostDeploy), ctx, params)
 }
 
 // PreDeploy mocks base method.
-func (m *MockNode) PreDeploy(ctx context.Context, certificate *cert.Certificate) error {
+func (m *MockNode) PreDeploy(ctx context.Context, params *nodes.PreDeployParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreDeploy", ctx, certificate)
+	ret := m.ctrl.Call(m, "PreDeploy", ctx, params)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PreDeploy indicates an expected call of PreDeploy.
-func (mr *MockNodeMockRecorder) PreDeploy(ctx, certificate interface{}) *gomock.Call {
+func (mr *MockNodeMockRecorder) PreDeploy(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreDeploy", reflect.TypeOf((*MockNode)(nil).PreDeploy), ctx, certificate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreDeploy", reflect.TypeOf((*MockNode)(nil).PreDeploy), ctx, params)
 }
 
 // RunExec mocks base method.

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -50,14 +50,14 @@ func (s *bridge) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (*bridge) Deploy(_ context.Context) error                { return nil }
-func (*bridge) Delete(_ context.Context) error                { return nil }
-func (*bridge) GetImages(_ context.Context) map[string]string { return map[string]string{} }
+func (*bridge) Deploy(_ context.Context, _ *nodes.DeployParams) error { return nil }
+func (*bridge) Delete(_ context.Context) error                        { return nil }
+func (*bridge) GetImages(_ context.Context) map[string]string         { return map[string]string{} }
 
 // DeleteNetnsSymlink is a noop for bridge nodes.
 func (b *bridge) DeleteNetnsSymlink() (err error) { return nil }
 
-func (b *bridge) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
+func (b *bridge) PostDeploy(_ context.Context, _ *nodes.PostDeployParams) error {
 	return b.installIPTablesBridgeFwdRule()
 }
 

--- a/nodes/c8000/c8000.go
+++ b/nodes/c8000/c8000.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -60,7 +59,7 @@ func (n *c8000) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (n *c8000) PreDeploy(ctx context.Context, _ *cert.Certificate) error {
+func (n *c8000) PreDeploy(ctx context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(n.Cfg.LabDir, 0777)
 
 	return n.create8000Files(ctx)

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -99,12 +98,12 @@ func (n *ceos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (n *ceos) PreDeploy(ctx context.Context, _ *cert.Certificate) error {
+func (n *ceos) PreDeploy(ctx context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(n.Cfg.LabDir, 0777)
 	return n.createCEOSFiles(ctx)
 }
 
-func (n *ceos) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
+func (n *ceos) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Arista cEOS '%s' node", n.Cfg.ShortName)
 	return n.ceosPostDeploy(ctx)
 }

--- a/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
+++ b/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -56,7 +55,7 @@ func (n *CheckpointCloudguard) Init(cfg *types.NodeConfig, opts ...nodes.NodeOpt
 	return nil
 }
 
-func (n *CheckpointCloudguard) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (n *CheckpointCloudguard) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(n.Cfg.LabDir, 0777)
 	return nil
 }

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -68,12 +67,12 @@ func (s *crpd) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *crpd) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *crpd) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return createCRPDFiles(s)
 }
 
-func (s *crpd) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
+func (s *crpd) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for CRPD %q node", s.Cfg.ShortName)
 
 	cmd, _ := exec.NewExecCmdFromString(sshRestartCmd)

--- a/nodes/cvx/cvx.go
+++ b/nodes/cvx/cvx.go
@@ -73,7 +73,7 @@ func (c *cvx) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (c *cvx) Deploy(ctx context.Context) error {
+func (c *cvx) Deploy(ctx context.Context, _ *nodes.DeployParams) error {
 	// CreateContainer is no-op in case of ignite runtime
 	cID, err := c.Runtime.CreateContainer(ctx, c.Cfg)
 	if err != nil {
@@ -89,7 +89,7 @@ func (c *cvx) Deploy(ctx context.Context) error {
 	return nil
 }
 
-func (c *cvx) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
+func (c *cvx) PostDeploy(_ context.Context, _ *nodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for cvx '%s' node", c.Cfg.ShortName)
 	if c.vmChans == nil {
 		return nil

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hairyhenderson/gomplate/v3"
 	"github.com/hairyhenderson/gomplate/v3/data"
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
@@ -48,12 +47,12 @@ func NewDefaultNode(n NodeOverwrites) *DefaultNode {
 	return dn
 }
 
-func (d *DefaultNode) WithMgmtNet(mgmt *types.MgmtNet)                      { d.Mgmt = mgmt }
-func (d *DefaultNode) WithRuntime(r runtime.ContainerRuntime)               { d.Runtime = r }
-func (d *DefaultNode) GetRuntime() runtime.ContainerRuntime                 { return d.Runtime }
-func (d *DefaultNode) Config() *types.NodeConfig                            { return d.Cfg }
-func (*DefaultNode) PreDeploy(_ context.Context, _ *cert.Certificate) error { return nil }
-func (*DefaultNode) PostDeploy(_ context.Context, _ map[string]Node) error  { return nil }
+func (d *DefaultNode) WithMgmtNet(mgmt *types.MgmtNet)                       { d.Mgmt = mgmt }
+func (d *DefaultNode) WithRuntime(r runtime.ContainerRuntime)                { d.Runtime = r }
+func (d *DefaultNode) GetRuntime() runtime.ContainerRuntime                  { return d.Runtime }
+func (d *DefaultNode) Config() *types.NodeConfig                             { return d.Cfg }
+func (*DefaultNode) PreDeploy(_ context.Context, _ *PreDeployParams) error   { return nil }
+func (*DefaultNode) PostDeploy(_ context.Context, _ *PostDeployParams) error { return nil }
 
 func (d *DefaultNode) SaveConfig(_ context.Context) error {
 	// nodes should have the save method defined on their respective structs.
@@ -105,7 +104,7 @@ func (d *DefaultNode) VerifyHostRequirements() error {
 	return d.HostRequirements.Verify(d.Cfg.Kind, d.Cfg.ShortName)
 }
 
-func (d *DefaultNode) Deploy(ctx context.Context) error {
+func (d *DefaultNode) Deploy(ctx context.Context, _ *DeployParams) error {
 	cID, err := d.Runtime.CreateContainer(ctx, d.Cfg)
 	if err != nil {
 		return err

--- a/nodes/ext_container/ext_container.go
+++ b/nodes/ext_container/ext_container.go
@@ -37,7 +37,7 @@ func (s *extcont) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (e *extcont) Deploy(ctx context.Context) error {
+func (e *extcont) Deploy(ctx context.Context, _ *nodes.DeployParams) error {
 	// check for the external dependency to be running
 	err := runtime.WaitForContainerRunning(ctx, e.Runtime, e.Cfg.ShortName, e.Cfg.ShortName)
 	if err != nil {

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -38,11 +38,11 @@ func (n *host) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	n.Cfg.IsRootNamespaceBased = true
 	return nil
 }
-func (*host) Deploy(_ context.Context) error                { return nil }
-func (*host) GetImages(_ context.Context) map[string]string { return map[string]string{} }
-func (*host) PullImage(_ context.Context) error             { return nil }
-func (*host) Delete(_ context.Context) error                { return nil }
-func (*host) WithMgmtNet(*types.MgmtNet)                    {}
+func (*host) Deploy(_ context.Context, _ *nodes.DeployParams) error { return nil }
+func (*host) GetImages(_ context.Context) map[string]string         { return map[string]string{} }
+func (*host) PullImage(_ context.Context) error                     { return nil }
+func (*host) Delete(_ context.Context) error                        { return nil }
+func (*host) WithMgmtNet(*types.MgmtNet)                            {}
 
 // UpdateConfigWithRuntimeInfo is a noop for hosts.
 func (*host) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -62,7 +61,7 @@ func (s *IPInfusionOcNOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) 
 	return nil
 }
 
-func (s *IPInfusionOcNOS) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *IPInfusionOcNOS) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nil
 }

--- a/nodes/keysight_ixiacone/ixiac-one.go
+++ b/nodes/keysight_ixiacone/ixiac-one.go
@@ -49,7 +49,7 @@ func (l *ixiacOne) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (l *ixiacOne) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
+func (l *ixiacOne) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for keysight_ixia-c-one '%s' node", l.Cfg.ShortName)
 	return l.ixiacPostDeploy(ctx)
 }

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -46,7 +46,7 @@ func (n *linux) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (n *linux) Deploy(ctx context.Context) error {
+func (n *linux) Deploy(ctx context.Context, _ *nodes.DeployParams) error {
 	cID, err := n.Runtime.CreateContainer(ctx, n.Cfg)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (n *linux) Deploy(ctx context.Context) error {
 	return err
 }
 
-func (n *linux) PostDeploy(_ context.Context, _ map[string]nodes.Node) error {
+func (n *linux) PostDeploy(_ context.Context, _ *nodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for Linux '%s' node", n.Cfg.ShortName)
 	if err := types.DisableTxOffload(n.Cfg); err != nil {
 		return err

--- a/nodes/mysocketio/mysocketio.go
+++ b/nodes/mysocketio/mysocketio.go
@@ -34,7 +34,7 @@ func (s *mySocketIO) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error
 	return nil
 }
 
-func (s *mySocketIO) PostDeploy(ctx context.Context, ns map[string]nodes.Node) error {
+func (s *mySocketIO) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for mysocketio '%s' node", s.Cfg.ShortName)
 	err := types.DisableTxOffload(s.Cfg)
 	if err != nil {
@@ -42,6 +42,6 @@ func (s *mySocketIO) PostDeploy(ctx context.Context, ns map[string]nodes.Node) e
 	}
 
 	log.Infof("Creating mysocketio tunnels...")
-	err = createMysocketTunnels(ctx, s, ns)
+	err = createMysocketTunnels(ctx, s, params.Nodes)
 	return err
 }

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -43,6 +43,16 @@ func SetNonDefaultRuntimePerKind(kindnames []string, runtime string) error {
 	return nil
 }
 
+type PreDeployParams struct {
+	Certificate *cert.Certificate
+}
+
+type DeployParams struct{}
+
+type PostDeployParams struct {
+	Nodes map[string]Node
+}
+
 type Node interface {
 	Init(*types.NodeConfig, ...NodeOption) error
 	// GetContainers returns a pointer to GenericContainer that the node uses.
@@ -51,9 +61,9 @@ type Node interface {
 	Config() *types.NodeConfig // Config returns the nodes configuration
 	// CheckDeploymentConditions checks if node-scoped deployment conditions are met.
 	CheckDeploymentConditions(context.Context) error
-	PreDeploy(ctx context.Context, certificate *cert.Certificate) error
-	Deploy(context.Context) error // Deploy triggers the deployment of this node
-	PostDeploy(context.Context, map[string]Node) error
+	PreDeploy(ctx context.Context, params *PreDeployParams) error
+	Deploy(context.Context, *DeployParams) error // Deploy triggers the deployment of this node
+	PostDeploy(ctx context.Context, params *PostDeployParams) error
 	WithMgmtNet(*types.MgmtNet)           // WithMgmtNet provides the management network for the node
 	WithRuntime(runtime.ContainerRuntime) // WithRuntime provides the runtime for the node
 	// CheckInterfaceName checks if a name of the interface referenced in the topology file is correct for this node

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -56,11 +56,11 @@ func (n *ovs) CheckDeploymentConditions(_ context.Context) error {
 	return nil
 }
 
-func (*ovs) Deploy(_ context.Context) error                { return nil }
-func (*ovs) PullImage(_ context.Context) error             { return nil }
-func (*ovs) GetImages(_ context.Context) map[string]string { return map[string]string{} }
-func (*ovs) Delete(_ context.Context) error                { return nil }
-func (*ovs) DeleteNetnsSymlink() (err error)               { return nil }
+func (*ovs) Deploy(_ context.Context, _ *nodes.DeployParams) error { return nil }
+func (*ovs) PullImage(_ context.Context) error                     { return nil }
+func (*ovs) GetImages(_ context.Context) map[string]string         { return map[string]string{} }
+func (*ovs) Delete(_ context.Context) error                        { return nil }
+func (*ovs) DeleteNetnsSymlink() (err error)                       { return nil }
 
 // UpdateConfigWithRuntimeInfo is a noop for bridges.
 func (*ovs) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -43,12 +42,12 @@ func (s *sonic) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *sonic) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *sonic) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nil
 }
 
-func (s *sonic) PostDeploy(ctx context.Context, _ map[string]nodes.Node) error {
+func (s *sonic) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for sonic-vs '%s' node", s.Cfg.ShortName)
 
 	cmd, _ := exec.NewExecCmdFromString("supervisord")

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -182,12 +181,12 @@ func (s *srl) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *srl) PreDeploy(_ context.Context, certificate *cert.Certificate) error {
+func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 
 	// set the certificate data
-	s.Config().TLSCert = string(certificate.Cert)
-	s.Config().TLSKey = string(certificate.Key)
+	s.Config().TLSCert = string(params.Certificate.Cert)
+	s.Config().TLSKey = string(params.Certificate.Key)
 
 	// Create appmgr subdir for agent specs and copy files, if needed
 	if s.Cfg.Extras != nil && len(s.Cfg.Extras.SRLAgents) != 0 {
@@ -219,10 +218,10 @@ func (s *srl) PreDeploy(_ context.Context, certificate *cert.Certificate) error 
 	return s.createSRLFiles()
 }
 
-func (s *srl) PostDeploy(ctx context.Context, nodes map[string]nodes.Node) error {
+func (s *srl) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Nokia SR Linux '%s' node", s.Cfg.ShortName)
 	// Populate /etc/hosts for service discovery on mgmt interface
-	if err := s.populateHosts(ctx, nodes); err != nil {
+	if err := s.populateHosts(ctx, params.Nodes); err != nil {
 		log.Warnf("Unable to populate hosts for node %q: %v", s.Cfg.ShortName, err)
 	}
 

--- a/nodes/vr_csr/vr-csr.go
+++ b/nodes/vr_csr/vr-csr.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -74,7 +73,7 @@ func (s *vrCsr) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrCsr) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrCsr) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -70,7 +69,7 @@ func (s *vrFtosv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrFtosv) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrFtosv) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_n9kv/vr-n9kv.go
+++ b/nodes/vr_n9kv/vr-n9kv.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 
 	"github.com/srl-labs/containerlab/types"
@@ -71,7 +70,7 @@ func (s *vrN9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrN9kv) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrN9kv) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_nxos/vr-nxos.go
+++ b/nodes/vr_nxos/vr-nxos.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -67,7 +66,7 @@ func (s *vrNXOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrNXOS) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrNXOS) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -72,7 +71,7 @@ func (s *vrPan) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrPan) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrPan) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
@@ -68,7 +67,7 @@ func (s *vrRos) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrRos) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrRos) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -80,7 +79,7 @@ func (s *vrSROS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrSROS) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrSROS) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return createVrSROSFiles(s)
 }

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -74,7 +73,7 @@ func (s *vrVEOS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrVEOS) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrVEOS) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -69,7 +68,7 @@ func (s *vrVMX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrVMX) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrVMX) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -74,7 +73,7 @@ func (s *vrVQFX) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrVQFX) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrVQFX) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_xrv/vr-xrv.go
+++ b/nodes/vr_xrv/vr-xrv.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -74,7 +73,7 @@ func (s *vrXRV) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrXRV) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrXRV) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -77,7 +76,7 @@ func (s *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (s *vrXRV9K) PreDeploy(_ context.Context, _ *cert.Certificate) error {
+func (s *vrXRV9K) PreDeploy(_ context.Context, _ *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -67,7 +66,7 @@ func (n *xrd) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	return nil
 }
 
-func (n *xrd) PreDeploy(ctx context.Context, _ *cert.Certificate) error {
+func (n *xrd) PreDeploy(ctx context.Context, _ *nodes.PreDeployParams) error {
 	n.genInterfacesEnv()
 
 	utils.CreateDirectory(n.Cfg.LabDir, 0777)


### PR DESCRIPTION
Whenever we need more or different information in the pre-/post-/deploy phase all the kinds have to be changed.
I've now created 3 structs 
```
PreDeployParams 
DeployParams 
PostDeployParams
```
https://github.com/srl-labs/containerlab/pull/1263/files#diff-09882d300c601744375447cf7117fc641a310926d7701fc04deafbdbcbaff8f3R46-R54

which can easily be extended with additional values without touching any Kind method signature.