### PR TITLE
Allow StartupConfig to be an http or https url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ site/
 __rd*
 tests/out
 **/.*clab.y?ml
+
+# ignore clab backup topo files in test directories
 clab/test_data/*.bak
+tests/**/*.bak

--- a/clab/config.go
+++ b/clab/config.go
@@ -271,17 +271,17 @@ func (c *CLab) processStartupConfig(nodeCfg *types.NodeConfig) error {
 
 	// if the startup-config is a remote file, download it to the temp directory
 	if strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://") {
-		tmpLoc := c.TopoPaths.StartupConfigDownloadDir()
+		tmpLoc := c.TopoPaths.ClabTmpDir()
 
 		utils.CreateDirectory(tmpLoc, 0755)
 
-		// Try to deduce a filename from the url
-		postfix := utils.CalcFilename(p)
+		// get file name from an URL
+		fname := utils.FilenameForURL(p)
 
 		// Deduce the absolute destination filename for the downloaded content
-		absDestFile := c.TopoPaths.StartupConfigDownloadFileAbsPath(nodeCfg.ShortName, postfix)
+		absDestFile := c.TopoPaths.StartupConfigDownloadFileAbsPath(nodeCfg.ShortName, fname)
 
-		log.Debugf("Fetching startup-config %q for node %q storing as %q", p, nodeCfg.ShortName, absDestFile)
+		log.Debugf("Fetching startup-config %q for node %q storing at %q", p, nodeCfg.ShortName, absDestFile)
 		// download the file to tmp location
 
 		err := utils.CopyFileContents(p, absDestFile, 0755)

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -117,6 +117,26 @@ For some kinds it's possible to pass a path to a config file that a node will us
 
 Note, that if a config file exists in the lab directory for a given node, then it will take preference over the startup config passed with this setting. If it is desired to discard the previously saved config and use the startup config instead, use the `enforce-startup-config` setting or deploy a lab with the [`reconfigure`](../cmd/deploy.md#reconfigure) flag.
 
+#### remote startup-config
+
+It is possible to specify a remote `http(s)` location for a startup-config file. Simply provide a URL that can be accessed from the containerlab host.
+
+```yaml
+topology:
+  kinds:
+    srl:
+      type: ixrd3
+      image: ghcr.io/nokia/srlinux
+      startup-config: https://raw.githubusercontent.com/srl-labs/containerlab/main/tests/02-basic-srl/srl2-startup.cli
+```
+
+The remote file will be downloaded to the containerlab's temp directory at `$TMP/.clab/<filename>` path and provided to the node as a locally available startup-config file. The filename will have a generated name that follows the pattern `<lab-name>-<node-name>-<filename-from-url>`, where `<filename-from-url>` is the last element of the URL path.
+
+!!!note
+
+    * Upon deletion of a lab, the downloaded startup-config files will not be removed. A manual cleanup should be performed if required.
+    * If a lab is redeployed with the lab name and startup-config paths unchanged, the local file will be overwritten.
+
 ### enforce-startup-config
 
 By default, containerlab will use the config file that is available in the lab directory for a given node even if the `startup config` parameter points to another file. To make a node to boot with the config set with `startup-config` parameter no matter what, set the `enforce-startup-config` to `true`.

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -22,20 +22,20 @@ Create SSH keypair
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E containerlab --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    sudo -E %{CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Verify links in node srl1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip link show e1-1"
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify links in node srl2
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "ip link show e1-1"
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
@@ -45,21 +45,21 @@ Verify e1-1 interface have been admin enabled on srl1
     ...    This test cases ensures that e1-1 interface referenced in links section
     ...    has been automatically admin enabled
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    ethernet-1/1 is up
 
 Verify srl2 accepted user-provided CLI config
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "sr_cli 'info /system information location'"
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "sr_cli 'info /system information location'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    test123
 
 Verify saving config
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${output}    ERRO
@@ -79,13 +79,14 @@ Ensure srl1 is reachable over ssh with public key auth
     ...    try_for=10
 
 Ensure srl1 can ping srl2 over ethernet-1/1 interface
-    Sleep    5s    give some time for networking stack to setlle
+    Sleep    5s    give some time for networking stack to settle
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo containerlab --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3s"
+    ...    sudo %{CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3s"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0% packet loss
 
 *** Keywords ***
 Cleanup
-    Run    sudo containerlab --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    sudo %{CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    rm -f ${key-path}

--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -15,7 +15,7 @@ topology:
     srl2:
       kind: nokia_srlinux
       image: ghcr.io/nokia/srlinux
-      startup-config: srl2-startup.cli
+      startup-config: https://raw.githubusercontent.com/srl-labs/containerlab/main/tests/02-basic-srl/srl2-startup.cli
 
   links:
     - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/tests/rf-run.sh
+++ b/tests/rf-run.sh
@@ -7,4 +7,12 @@
 # $1 - container runtime: [docker, containerd]
 # $2 - test suite to execute
 
+# set containerlab binary path to a value of CLAB_BIN env variable
+# unless it is not set, then use 'containerlab' as a default value
+if [[ -z "${CLAB_BIN}" ]]; then
+  export CLAB_BIN="containerlab"
+fi
+
+echo "Running tests with containerlab binary at $(which ${CLAB_BIN}) path and selected runtime: $1"
+
 robot --consolecolors on -r none --variable runtime:$1 -l ./tests/out/$(basename $2)-$1-log --output ./tests/out/$(basename $2)-$1-out.xml $2

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -20,6 +21,11 @@ const (
 	CertFileSuffix            = ".pem"
 	KeyFileSuffix             = ".key"
 	CSRFileSuffix             = ".csr"
+	startupConfigDlSubDir     = "clab-download"
+)
+
+var (
+	startupConfigDlBaseDir = os.TempDir()
 )
 
 // TopoPaths creates all the required absolute paths and filenames for a topology.
@@ -27,6 +33,7 @@ const (
 type TopoPaths struct {
 	topoFile string
 	labDir   string
+	topoName string
 }
 
 // NewTopoPaths constructs a new TopoPaths instance.
@@ -66,6 +73,7 @@ func (t *TopoPaths) SetTopologyFilePath(topologyFile string) error {
 
 // SetLabDir sets the labDir.
 func (t *TopoPaths) SetLabDir(topologyName string) (err error) {
+	t.topoName = topologyName
 	// if "CLAB_LABDIR_BASE" Env Var is set, use that dir as a base
 	// for the labDir, otherwise use PWD.
 	baseDir := os.Getenv("CLAB_LABDIR_BASE")
@@ -133,6 +141,17 @@ func (t *TopoPaths) AnsibleInventoryFileAbsPath() string {
 // TopologyFilenameAbsPath returns the absolute path to the topology file.
 func (t *TopoPaths) TopologyFilenameAbsPath() string {
 	return t.topoFile
+}
+
+// StartupConfigDownloadDir returns the StartupConfg Download directory.
+// If a non-local startup config is provied (e.g. http/https) then config needs
+// to be downloaded and this provides the directory for storing the configs.
+func (t *TopoPaths) StartupConfigDownloadDir() string {
+	return filepath.Join(startupConfigDlBaseDir, startupConfigDlSubDir)
+}
+
+func (t *TopoPaths) StartupConfigDownloadFileAbsPath(node string, postfix string) string {
+	return filepath.Join(t.StartupConfigDownloadDir(), fmt.Sprintf("%s-%s-%s", t.topoName, node, postfix))
 }
 
 // TopologyFilenameBase returns the full filename of the topology file

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	// clabTmpDir is the directory where clab stores temporary and/or downloaded files.
-	clabTmpDir = filepath.Join(os.TempDir() + "clab")
+	clabTmpDir = filepath.Join(os.TempDir(), ".clab")
 )
 
 // TopoPaths creates all the required absolute paths and filenames for a topology.
@@ -148,6 +148,8 @@ func (t *TopoPaths) ClabTmpDir() string {
 	return clabTmpDir
 }
 
+// StartupConfigDownloadFileAbsPath returns the absolute path to the startup-config file
+// when it is downloaded from a remote location to the clab temp directory.
 func (t *TopoPaths) StartupConfigDownloadFileAbsPath(node string, postfix string) string {
 	return filepath.Join(t.ClabTmpDir(), fmt.Sprintf("%s-%s-%s", t.topoName, node, postfix))
 }

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -21,11 +21,11 @@ const (
 	CertFileSuffix            = ".pem"
 	KeyFileSuffix             = ".key"
 	CSRFileSuffix             = ".csr"
-	startupConfigDlSubDir     = "clab-download"
 )
 
 var (
-	startupConfigDlBaseDir = os.TempDir()
+	// clabTmpDir is the directory where clab stores temporary and/or downloaded files.
+	clabTmpDir = filepath.Join(os.TempDir() + "clab")
 )
 
 // TopoPaths creates all the required absolute paths and filenames for a topology.
@@ -143,15 +143,13 @@ func (t *TopoPaths) TopologyFilenameAbsPath() string {
 	return t.topoFile
 }
 
-// StartupConfigDownloadDir returns the StartupConfg Download directory.
-// If a non-local startup config is provied (e.g. http/https) then config needs
-// to be downloaded and this provides the directory for storing the configs.
-func (t *TopoPaths) StartupConfigDownloadDir() string {
-	return filepath.Join(startupConfigDlBaseDir, startupConfigDlSubDir)
+// ClabTmpDir returns the path to the temporary directory where clab stores temporary and/or downloaded files.
+func (t *TopoPaths) ClabTmpDir() string {
+	return clabTmpDir
 }
 
 func (t *TopoPaths) StartupConfigDownloadFileAbsPath(node string, postfix string) string {
-	return filepath.Join(t.StartupConfigDownloadDir(), fmt.Sprintf("%s-%s-%s", t.topoName, node, postfix))
+	return filepath.Join(t.ClabTmpDir(), fmt.Sprintf("%s-%s-%s", t.topoName, node, postfix))
 }
 
 // TopologyFilenameBase returns the full filename of the topology file

--- a/types/topology.go
+++ b/types/topology.go
@@ -163,7 +163,6 @@ func (t *Topology) GetNodeStartupConfig(name string) (string, error) {
 		if cfg == "" {
 			cfg = t.GetDefaults().GetStartupConfig()
 		}
-
 	}
 	return cfg, nil
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,4 +176,23 @@ func ResolvePath(p, base string) string {
 		p = filepath.Join(base, p)
 	}
 	return p
+}
+
+const (
+	CalcFilename_Undefined = "undefined"
+)
+
+// CalcFilename tries to deduce a filename from the given url
+// returns "undefined" if facing issues
+func CalcFilename(rawUrl string) string {
+	u, err := url.Parse(rawUrl)
+	if err != nil {
+		return CalcFilename_Undefined
+	}
+	pathElems := strings.Split(u.Path, "/")
+	lastPathElem := pathElems[len(pathElems)-1]
+	if len(lastPathElem) == 0 {
+		return CalcFilename_Undefined
+	}
+	return lastPathElem
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -179,20 +179,16 @@ func ResolvePath(p, base string) string {
 }
 
 const (
-	CalcFilename_Undefined = "undefined"
+	UndefinedFileName = "undefined"
 )
 
-// CalcFilename tries to deduce a filename from the given url
-// returns "undefined" if facing issues
-func CalcFilename(rawUrl string) string {
+// FilenameForURL extracts a filename from a given url
+// returns "undefined" when unsuccessful.
+func FilenameForURL(rawUrl string) string {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
-		return CalcFilename_Undefined
+		return UndefinedFileName
 	}
-	pathElems := strings.Split(u.Path, "/")
-	lastPathElem := pathElems[len(pathElems)-1]
-	if len(lastPathElem) == 0 {
-		return CalcFilename_Undefined
-	}
-	return lastPathElem
+
+	return filepath.Base(u.Path)
 }

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import "testing"
+
+func Test_CalcFilename(t *testing.T) {
+	type args struct {
+		rawUrl string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "regular filename url",
+			args: args{
+				rawUrl: "http://myserver.foo/download/raw/node1.cfg",
+			},
+			want: "node1.cfg",
+		},
+		{
+			name: "folder URL",
+			args: args{
+				rawUrl: "http://myserver.foo/download/raw/",
+			},
+			want: CalcFilename_Undefined,
+		},
+		{
+			name: "with get parameters",
+			args: args{
+				rawUrl: "http://myserver.foo/download/raw/node1.cfg?foo=bar&bar=foo",
+			},
+			want: "node1.cfg",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalcFilename(tt.args.rawUrl); got != tt.want {
+				t.Errorf("calcFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -6,7 +6,7 @@ package utils
 
 import "testing"
 
-func Test_CalcFilename(t *testing.T) {
+func TestFilenameForURL(t *testing.T) {
 	type args struct {
 		rawUrl string
 	}
@@ -27,7 +27,7 @@ func Test_CalcFilename(t *testing.T) {
 			args: args{
 				rawUrl: "http://myserver.foo/download/raw/",
 			},
-			want: CalcFilename_Undefined,
+			want: "raw",
 		},
 		{
 			name: "with get parameters",
@@ -39,8 +39,8 @@ func Test_CalcFilename(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CalcFilename(tt.args.rawUrl); got != tt.want {
-				t.Errorf("calcFilename() = %v, want %v", got, tt.want)
+			if got := FilenameForURL(tt.args.rawUrl); got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Of your configs are e.g. stored in a git repo with http(s) UI or pastebin or something along those lines, you can now define a raw url as the startup-config.
This will result in clab creating a clab-download in your $TEMP directory (e.g. /tmp/clab-download) where the referenced files will be downloaded before the nodes are being started.
If you want to redeploy with new configs e.g. the git branch evolved, simply add the `--reconfigure` flag to the clab deploy command.