### PR TITLE
Respect network-mode being set to none for nodes on the docker runtime.

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -833,6 +833,8 @@ func (d *DockerRuntime) processNetworkMode(
 	netMode := strings.SplitN(node.NetworkMode, ":", 2)
 
 	switch netMode[0] {
+	case "none":
+		containerHostConfig.NetworkMode = "none"
 	// clab allows its containers to be attached to a netns of another container
 	// this can be a container that is managed by clab, or an external container.
 	case "container":

--- a/types/types.go
+++ b/types/types.go
@@ -142,7 +142,7 @@ type NodeConfig struct {
 
 func DisableTxOffload(n *NodeConfig) error {
 	// skip this if node runs in host mode
-	if strings.ToLower(n.NetworkMode) == "host" {
+	if strings.ToLower(n.NetworkMode) == "host" || strings.ToLower(n.NetworkMode) == "none" {
 		return nil
 	}
 	// disable tx checksum offload for linux containers on eth0 interfaces


### PR DESCRIPTION
This is useful for selectively preventing docker's automatic default kernel route injection, as well as disabling connection to the management interface.

This makes it easier to test isolation scenarios, control lab egress, and prevent confusion over unexpected default kernel route injection. 