### PR TITLE
Respect network-mode being set to none for nodes on the docker runtime.

### DIFF
--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -494,6 +494,10 @@ sidecar-node:
 
 Container name used after `container:` portion can refer to a node defined in containerlab topology or can refer to a name of a container that was launched outside of containerlab. This is useful when containerlab node needs to connect to a network namespace of a container deployed by 3rd party management tool (e.g. k8s kind).
 
+#### none mode
+
+If you want to completely disable the networking stack on a container, you can use the `none` network mode. In this mode containerlab will deploy nodes without `eth0` interface and docker networking. See [docker docs](https://docs.docker.com/network/none/) for more details.
+
 ### runtime
 
 By default containerlab nodes will be started by `docker` container runtime. Besides that, containerlab has experimental support for `podman`, `containerd`, and `ignite` runtimes.

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -833,6 +833,8 @@ func (d *DockerRuntime) processNetworkMode(
 	netMode := strings.SplitN(node.NetworkMode, ":", 2)
 
 	switch netMode[0] {
+	case "none":
+		containerHostConfig.NetworkMode = "none"
 	// clab allows its containers to be attached to a netns of another container
 	// this can be a container that is managed by clab, or an external container.
 	case "container":

--- a/types/types.go
+++ b/types/types.go
@@ -142,7 +142,7 @@ type NodeConfig struct {
 
 func DisableTxOffload(n *NodeConfig) error {
 	// skip this if node runs in host mode
-	if strings.ToLower(n.NetworkMode) == "host" {
+	if strings.ToLower(n.NetworkMode) == "host" || strings.ToLower(n.NetworkMode) == "none" {
 		return nil
 	}
 	// disable tx checksum offload for linux containers on eth0 interfaces


### PR DESCRIPTION
This is useful for selectively preventing docker's automatic default kernel route injection, as well as disabling connection to the management network.

This makes it easier to test isolation scenarios, control lab egress, and prevent confusion over unexpected default kernel route injection.