### PR TITLE
Permit per endpoint MTU settings.

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -267,10 +267,16 @@ func (c *CLab) NewLink(l *types.LinkConfig) *types.Link {
 		log.Fatalf("endpoint %q has wrong syntax, unexpected number of items", l.Endpoints) // skipcq: RVV-A0003
 	}
 
+	mtu := l.MTU
+
+	if mtu == 0 {
+		mtu = DefaultVethLinkMTU
+	}
+
 	return &types.Link{
 		A:      c.NewEndpoint(l.Endpoints[0]),
 		B:      c.NewEndpoint(l.Endpoints[1]),
-		MTU:    DefaultVethLinkMTU,
+		MTU:    mtu,
 		Labels: l.Labels,
 		Vars:   l.Vars,
 	}

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -287,9 +287,20 @@ Management network is used to provide management access to the NOS containers, i
 
 The above diagram shows how links are created in the topology definition file. In this example, the datapath consists of the two virtual point-to-point wires between SR Linux and cEOS containers. These links are created on-demand by containerlab itself.
 
-The p2p links are provided by the `veth` device pairs where each end of the `veth` pair is attached to a respective container. The MTU on these veth links is set to 9500, so a regular 9212 MTU on the network links shouldn't be a problem.
+The p2p links are provided by the `veth` device pairs where each end of the `veth` pair is attached to a respective container.
 
-### host links
+### Link MTU
+
+The MTU on the veth links is set by default to 9500B, so a regular jumbo frame shouldn't traverse the links without problems. If you need to change the MTU, you can do so by setting the `mtu` property in the link definition:
+
+```yaml
+topology:
+  links:
+    - endpoints: ["router2:eth2", "router3:eth1"]
+      mtu: 1500
+```
+
+### Host links
 
 It is also possible to interconnect container' data interface not with other container or add it to a [bridge](kinds/bridge.md), but to attach it to a host's root namespace. This is, for example, needed to create a L2 connectivity between containerlab nodes running on different VMs (aka multi-node labs).
 

--- a/types/topology.go
+++ b/types/topology.go
@@ -26,6 +26,7 @@ type LinkConfig struct {
 	Endpoints []string
 	Labels    map[string]string      `yaml:"labels,omitempty"`
 	Vars      map[string]interface{} `yaml:"vars,omitempty"`
+	MTU       int                    `yaml:"mtu,omitempty"`
 }
 
 func (t *Topology) GetDefaults() *NodeDefinition {


### PR DESCRIPTION
Allow configuration of per endpoint MTU.

Useful for testing MTU related behavior, or working around differing platforms.

Example:
```yaml
topology:
  links:
    - endpoints: ["router2:eth2", "router3:eth1"]
      mtu: 1500
```