### PR TITLE
Add newline if needed

### DIFF
--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -425,6 +425,11 @@ func (s *srl) addDefaultConfig(ctx context.Context) error {
 		b,
 	}
 
+	// remove newlines from tls key/cert so that they nicely apply via the cli provisioning
+	// during the template execution
+	tplData.TLSKey = strings.TrimSpace(tplData.TLSKey)
+	tplData.TLSCert = strings.TrimSpace(tplData.TLSCert)
+
 	buf := new(bytes.Buffer)
 	err = srlCfgTpl.Execute(buf, tplData)
 	if err != nil {

--- a/utils/file.go
+++ b/utils/file.go
@@ -125,7 +125,12 @@ func CreateFile(file, content string) (err error) {
 		return err
 	}
 
-	_, err = f.WriteString(content + "\n")
+	// add newline if missing
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	_, err = f.WriteString(content)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
changes:

* do not append newline when not needed
* trim spaces from tls cert/keys before adding them to the cli template executed by srl