### PR TITLE
Jvb add deploy filter

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -100,12 +100,12 @@ func WithKeepMgmtNet() ClabOption {
 	}
 }
 
-func WithTopoFile(file, varsFile string) ClabOption {
+func WithTopoFile(file, varsFile string, deployFilter []string) ClabOption {
 	return func(c *CLab) error {
 		if file == "" {
 			return fmt.Errorf("provide a path to the clab topology file")
 		}
-		if err := c.GetTopology(file, varsFile); err != nil {
+		if err := c.GetTopology(file, varsFile, deployFilter); err != nil {
 			return fmt.Errorf("failed to read topology file: %v", err)
 		}
 

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -61,7 +61,7 @@ func TestLicenseInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -115,7 +115,7 @@ func TestBindsInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -176,7 +176,7 @@ func TestTypeInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -257,7 +257,7 @@ func TestEnvInit(t *testing.T) {
 			}
 
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -309,7 +309,7 @@ func TestUserInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -348,7 +348,7 @@ func TestVerifyLinks(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -435,7 +435,7 @@ func TestLabelsInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {
@@ -468,7 +468,7 @@ func TestLabelsInit(t *testing.T) {
 
 func TestVerifyRootNetnsInterfaceUniqueness(t *testing.T) {
 	opts := []ClabOption{
-		WithTopoFile("test_data/topo7-dup-rootnetns.yml", ""),
+		WithTopoFile("test_data/topo7-dup-rootnetns.yml", "", []string{}),
 	}
 	c, err := NewContainerLab(opts...)
 	if err != nil {
@@ -514,7 +514,7 @@ func TestEnvFileInit(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {

--- a/clab/file.go
+++ b/clab/file.go
@@ -86,18 +86,26 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 
 		for name, node := range c.Config.Topology.Nodes {
 			if slices.Contains(deployFilter, name) {
-				log.Infof("Including node %s", name)
+				log.Debugf("Including node %s", name)
 				newNodes[name] = node
 			} else {
-				log.Infof("Excluding node %s", name)
+				log.Debugf("Excluding node %s", name)
 			}
 		}
 		c.Config.Topology.Nodes = newNodes
 
-		for i, l := range c.Config.Topology.Links {
-			if len(l.Endpoints) != 2 || (slices.Contains(deployFilter, l.Endpoints[0]) &&
-				slices.Contains(deployFilter, l.Endpoints[1])) {
-				newLinks[i] = l
+		for _, l := range c.Config.Topology.Links {
+			if len(l.Endpoints) != 2 {
+				newLinks = append(newLinks, l)
+			} else {
+				ep1 := strings.Split(l.Endpoints[0], ":")[0]
+				ep2 := strings.Split(l.Endpoints[1], ":")[0]
+				if slices.Contains(deployFilter, ep1) && slices.Contains(deployFilter, ep2) {
+					log.Debugf("Including link %+v", l)
+					newLinks = append(newLinks, l)
+				} else {
+					log.Debugf("Excluding link %+v between %s and %s", l, ep1, ep2)
+				}
 			}
 		}
 		c.Config.Topology.Links = newLinks

--- a/clab/file.go
+++ b/clab/file.go
@@ -29,7 +29,7 @@ const (
 
 // GetTopology parses the topology file into c.Conf structure
 // as well as populates the TopoFile structure with the topology file related information.
-func (c *CLab) GetTopology(topo, varsFile string) error {
+func (c *CLab) GetTopology(topo, varsFile string, nodeFilter []string) error {
 	var err error
 
 	c.TopoPaths, err = types.NewTopoPaths(topo)
@@ -78,14 +78,14 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 	}
 
 	// If a subset of nodes is specified, remove other nodes and links referring to them
-	if len(deployFilter) > 0 {
-		log.Infof("Applying deployFilter %+v", deployFilter)
+	if len(nodeFilter) > 0 {
+		log.Infof("Applying nodeFilter %+v", nodeFilter)
 
 		newNodes := make(map[string]*types.NodeDefinition)
 		newLinks := make([]*types.LinkConfig, 0)
 
 		for name, node := range c.Config.Topology.Nodes {
-			if slices.Contains(deployFilter, name) {
+			if slices.Contains(nodeFilter, name) {
 				log.Debugf("Including node %s", name)
 				newNodes[name] = node
 			} else {
@@ -100,7 +100,7 @@ func (c *CLab) GetTopology(topo, varsFile string) error {
 			} else {
 				ep1 := strings.Split(l.Endpoints[0], ":")[0]
 				ep2 := strings.Split(l.Endpoints[1], ":")[0]
-				if slices.Contains(deployFilter, ep1) && slices.Contains(deployFilter, ep2) {
+				if slices.Contains(nodeFilter, ep1) && slices.Contains(nodeFilter, ep2) {
 					log.Debugf("Including link %+v", l)
 					newLinks = append(newLinks, l)
 				} else {

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -60,7 +60,7 @@ func TestGenerateAnsibleInventory(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			opts := []ClabOption{
-				WithTopoFile(tc.got, ""),
+				WithTopoFile(tc.got, "", []string{}),
 			}
 			c, err := NewContainerLab(opts...)
 			if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -60,7 +60,7 @@ func configRun(_ *cobra.Command, args []string) error {
 
 	c, err := clab.NewContainerLab(
 		clab.WithTimeout(timeout),
-		clab.WithTopoFile(topo, varsFile),
+		clab.WithTopoFile(topo, varsFile, configFilter),
 		clab.WithDebug(debug),
 	)
 	if err != nil {

--- a/cmd/config_template.go
+++ b/cmd/config_template.go
@@ -23,7 +23,7 @@ var configTemplateCmd = &cobra.Command{
 
 		c, err := clab.NewContainerLab(
 			clab.WithTimeout(timeout),
-			clab.WithTopoFile(topo, varsFile),
+			clab.WithTopoFile(topo, varsFile, []string{}),
 			clab.WithDebug(debug),
 		)
 		if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -84,7 +84,7 @@ func init() {
 func deployFn(_ *cobra.Command, _ []string) error {
 	var err error
 
-	log.Infof("Containerlab v%s started", version)
+	log.Infof("Containerlab v%s started, %+v", version, deployFilter)
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -76,7 +76,7 @@ func init() {
 	deployCmd.Flags().StringVarP(&exportTemplate, "export-template", "",
 		defaultExportTemplateFPath, "template file for topology data export")
 
-	deployCmd.Flags().StringSliceVarP(&deployFilter, "filter", "f", []string{},
+	deployCmd.Flags().StringSliceVarP(&deployFilter, "filter", "", []string{},
 		"comma separated list of nodes to include, optional")
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,6 +47,9 @@ var exportTemplate string
 
 var deployFormat string
 
+// subset of nodes to deploy
+var deployFilter []string
+
 // deployCmd represents the deploy command.
 var deployCmd = &cobra.Command{
 	Use:          "deploy",
@@ -72,6 +75,9 @@ func init() {
 	deployCmd.Flags().BoolVarP(&skipPostDeploy, "skip-post-deploy", "", false, "skip post deploy action")
 	deployCmd.Flags().StringVarP(&exportTemplate, "export-template", "",
 		defaultExportTemplateFPath, "template file for topology data export")
+
+	deployCmd.Flags().StringSliceVarP(&deployFilter, "filter", "f", []string{},
+		"comma separated list of nodes to include, optional")
 }
 
 // deployFn function runs deploy sub command.
@@ -82,7 +88,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
-		clab.WithTopoFile(topo, varsFile),
+		clab.WithTopoFile(topo, varsFile, deployFilter),
 		clab.WithRuntime(rt,
 			&runtime.RuntimeConfig{
 				Debug:            debug,

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -96,7 +96,7 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 	for topo := range topos {
 		opts := []clab.ClabOption{
 			clab.WithTimeout(timeout),
-			clab.WithTopoFile(topo, varsFile),
+			clab.WithTopoFile(topo, varsFile, []string{}), // TODO could support filter)
 			clab.WithRuntime(rt,
 				&runtime.RuntimeConfig{
 					Debug:            debug,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -43,7 +43,7 @@ func execFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
-		clab.WithTopoFile(topo, varsFile),
+		clab.WithTopoFile(topo, varsFile, []string{}),
 		clab.WithRuntime(rt,
 			&runtime.RuntimeConfig{
 				Debug:            debug,

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -45,7 +45,7 @@ func graphFn(_ *cobra.Command, _ []string) error {
 
 	opts := []clab.ClabOption{
 		clab.WithTimeout(timeout),
-		clab.WithTopoFile(topo, varsFile),
+		clab.WithTopoFile(topo, varsFile, []string{}),
 		clab.WithRuntime(rt,
 			&runtime.RuntimeConfig{
 				Debug:            debug,

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -68,7 +68,7 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 	}
 
 	if topo != "" {
-		opts = append(opts, clab.WithTopoFile(topo, varsFile))
+		opts = append(opts, clab.WithTopoFile(topo, varsFile, []string{}))
 	}
 
 	c, err := clab.NewContainerLab(opts...)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -29,7 +29,7 @@ Refer to the https://containerlab.dev/cmd/save/ documentation to see the exact c
 		}
 		opts := []clab.ClabOption{
 			clab.WithTimeout(timeout),
-			clab.WithTopoFile(topo, varsFile),
+			clab.WithTopoFile(topo, varsFile, []string{}),
 			clab.WithRuntime(rt,
 				&runtime.RuntimeConfig{
 					Debug:            debug,

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -77,6 +77,10 @@ Following values are accepted, ordered from most verbose to least: `trace`, `deb
 
 It should be useful to enable more verbose logging when something doesn't work as expected, to better understand what's going on, and to provide more useful output logs when reporting containerlab issues, while making it more terse in production environments.
 
+#### filter
+
+The local `--filter` flag allows a user to specify a subset of nodes from the topology to deploy, instead of all (default). This can be useful e.g. in CI/CD test case scenarios, where resource constraints may prohibit the deployment of a full representative topology.
+
 ### Environment variables
 
 #### CLAB_RUNTIME


### PR DESCRIPTION
related to https://github.com/srl-labs/containerlab/issues/1295

Note that the '--filter' option applies to several (most) commands, and could/should be generalized (just like --topology)

Note also that the link filtering logic may need updating; corner cases like a node connected to a bridge are not handled