### PR TITLE
Throw an error if GetContainers does not find any containers

### DIFF
--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -133,6 +133,11 @@ func (d *DefaultNode) GetContainers(ctx context.Context) ([]runtime.GenericConta
 	if err != nil {
 		return nil, err
 	}
+	// check that we retrieved some container information
+	// otherwise throw ErrContainersNotFound error
+	if len(cnts) == 0 {
+		return nil, fmt.Errorf("Node: %s. %w", d.GetContainerName(), ErrContainersNotFound)
+	}
 
 	return cnts, err
 }

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -31,6 +31,8 @@ var (
 
 	// ErrCommandExecError is an error returned when a command is failed to execute on a given node.
 	ErrCommandExecError = errors.New("command execution error")
+	// ErrContainersNotFound indicated that for a given node no containers where found in the runtime.
+	ErrContainersNotFound = errors.New("containers not found")
 )
 
 // SetNonDefaultRuntimePerKind sets a non default runtime for kinds that requires that (see cvx).


### PR DESCRIPTION
lets hava a discussion if we should throw an error if on the GetContainers there is no match and no nodes are found.
I have the feeling that we should throw an error, that can be handled be the caller if required.