### PR TITLE
introduce license required knob

### DIFF
--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -31,7 +31,7 @@ type DefaultNode struct {
 	Runtime          runtime.ContainerRuntime
 	HostRequirements *types.HostRequirements
 	// Indicates that the node should not start without no license file defined
-	LicenseRequired bool
+	LicensePolicy types.LicensePolicyValues
 	// OverwriteNode stores the interface used to overwrite methods defined
 	// for DefaultNode, so that particular nodes can provide custom implementations.
 	OverwriteNode NodeOverwrites
@@ -44,6 +44,7 @@ func NewDefaultNode(n NodeOverwrites) *DefaultNode {
 	dn := &DefaultNode{
 		HostRequirements: types.NewHostRequirements(),
 		OverwriteNode:    n,
+		LicensePolicy:    types.LicensePolicyNon,
 	}
 
 	return dn
@@ -325,17 +326,22 @@ func (d *DefaultNode) RunExecNotWait(ctx context.Context, execCmd *exec.ExecCmd)
 
 // VerifyLicenseFileExists checks if a license file with a provided path exists.
 func (d *DefaultNode) VerifyLicenseFileExists(_ context.Context) error {
-
-	// if a license is required by the kind but not provided
-	if d.LicenseRequired && d.Config().License == "" {
-		return fmt.Errorf("node %s of kind %s requires a license. Provide one via 'license' knob in the topology file", d.Config().ShortName, d.Cfg.Kind)
-	}
-
-	// if license is not required and also not provided, return without error
 	if d.Config().License == "" {
-		return nil
+		switch d.LicensePolicy {
+		// if a license is required by the kind but not provided
+		case types.LicensePolicyRequired:
+			return fmt.Errorf("node %s of kind %s requires a license. Provide one via 'license' knob in the topology file", d.Config().ShortName, d.Cfg.Kind)
+		case types.LicensePolicyWarn:
+			// just warn when no license is provided
+			log.Warnf("node %s of kind %s requires a license. Make sure to provide it in some way (e.g. license knob or baked into image)", d.Config().ShortName, d.Cfg.Kind)
+			return nil
+		case types.LicensePolicyNon:
+			// no policy attached, ruturn successfull
+			return nil
+		default:
+			return fmt.Errorf("unknown license policy value %s for node %s kind %s", d.LicensePolicy, d.Config().ShortName, d.Cfg.Kind)
+		}
 	}
-
 	// if license is provided check path exists
 	rlic := utils.ResolvePath(d.Config().License, d.Cfg.LabDir)
 	if !utils.FileExists(rlic) {

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -31,7 +31,7 @@ type DefaultNode struct {
 	Runtime          runtime.ContainerRuntime
 	HostRequirements *types.HostRequirements
 	// Indicates that the node should not start without no license file defined
-	LicensePolicy types.LicensePolicyValues
+	LicensePolicy types.LicensePolicy
 	// OverwriteNode stores the interface used to overwrite methods defined
 	// for DefaultNode, so that particular nodes can provide custom implementations.
 	OverwriteNode NodeOverwrites
@@ -44,7 +44,7 @@ func NewDefaultNode(n NodeOverwrites) *DefaultNode {
 	dn := &DefaultNode{
 		HostRequirements: types.NewHostRequirements(),
 		OverwriteNode:    n,
-		LicensePolicy:    types.LicensePolicyNon,
+		LicensePolicy:    types.LicensePolicyNone,
 	}
 
 	return dn
@@ -335,8 +335,8 @@ func (d *DefaultNode) VerifyLicenseFileExists(_ context.Context) error {
 			// just warn when no license is provided
 			log.Warnf("node %s of kind %s requires a license. Make sure to provide it in some way (e.g. license knob or baked into image)", d.Config().ShortName, d.Cfg.Kind)
 			return nil
-		case types.LicensePolicyNon:
-			// no policy attached, ruturn successfull
+		case types.LicensePolicyNone:
+			// license is not required
 			return nil
 		default:
 			return fmt.Errorf("unknown license policy value %s for node %s kind %s", d.LicensePolicy, d.Config().ShortName, d.Cfg.Kind)

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -56,7 +56,7 @@ func (s *vrSROS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.DefaultNode = *nodes.NewDefaultNode(s)
 	// set virtualization requirement
 	s.HostRequirements.VirtRequired = true
-	s.LicenseRequired = true
+	s.LicensePolicy = types.LicensePolicyWarn
 
 	s.Cfg = cfg
 	for _, o := range opts {

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -56,6 +56,7 @@ func (s *vrSROS) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	s.DefaultNode = *nodes.NewDefaultNode(s)
 	// set virtualization requirement
 	s.HostRequirements.VirtRequired = true
+	s.LicenseRequired = true
 
 	s.Cfg = cfg
 	for _, o := range opts {

--- a/types/license_policy_value.go
+++ b/types/license_policy_value.go
@@ -1,6 +1,6 @@
 package types
 
-// LicensePolicyValue is a value of LicensePolicy.
+// LicensePolicy is a value of LicensePolicy.
 type LicensePolicy string
 
 const (

--- a/types/license_policy_value.go
+++ b/types/license_policy_value.go
@@ -1,9 +1,13 @@
 package types
 
-type LicensePolicyValues string
+// LicensePolicyValue is a value of LicensePolicy.
+type LicensePolicy string
 
 const (
+	// LicensePolicyRequired means a node should exit if no license provided.
 	LicensePolicyRequired = "required"
-	LicensePolicyWarn     = "warn"
-	LicensePolicyNon      = "non"
+	// LicensePolicyWarn means a node should warn (but not exit) if no license provided.
+	LicensePolicyWarn = "warn"
+	// LicensePolicyNone means a node doesn't care about a license.
+	LicensePolicyNone = "none"
 )

--- a/types/license_policy_value.go
+++ b/types/license_policy_value.go
@@ -1,0 +1,9 @@
+package types
+
+type LicensePolicyValues string
+
+const (
+	LicensePolicyRequired = "required"
+	LicensePolicyWarn     = "warn"
+	LicensePolicyNon      = "non"
+)


### PR DESCRIPTION
In default node we introduce `LicenseRequired` knob, to indicate that a kind requires a license file to function properly. The knob is taken into account in `Node.VerifyLicenseFileExists()`