### PR TITLE
SRL Post-Deploy cert creation

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -226,7 +226,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	for _, n := range c.Nodes {
 		err = n.UpdateConfigWithRuntimeInfo(ctx)
 		if err != nil {
-			log.Errorf("failed to update node runtime infromation for node %s: %v", n.Config().ShortName, err)
+			log.Errorf("failed to update node runtime information for node %s: %v", n.Config().ShortName, err)
 		}
 	}
 

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -283,6 +283,15 @@ In case user-provided certificates/keys need to be used, the `ca.pem`, `<node-na
 
 In case only `ca.pem` and `ca.key` files are provided, the node certificates will be generated using these CA files.
 
+The certificate is generated for the following subjects (assuming node name is `srl`, lab name is `srl` and container runtime assigned the below listed IP addresses):
+
+```
+DNS:srl
+DNS:clab-srl-srl
+DNS:srl.srl.io
+IP Address:172.20.20.3, IP Address:2001:172:20:20:0:0:0:3
+```
+
 Nokia SR Linux nodes support setting of [SANs](../nodes.md#subject-alternative-names-san).
 
 ### License

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -90,6 +90,7 @@ For a topology node named "srl" in a lab named "srl01", the following SANs are s
 - `srl`
 - `clab-srl01-srl`
 - `srl.srl01.io`
+- IPv4/6 addresses of the node
 
 ```yaml
 name: srl01

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/srl-labs/containerlab/cert"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -121,6 +122,10 @@ type srl struct {
 	nodes.DefaultNode
 	// startup-config passed as a path to a file with CLI instructions will be read into this byte slice
 	startupCliCfg []byte
+
+	// Params provided in Pre-Deploy, that will in SRL be used in Post-Deploy phase
+	cert         *cert.Cert
+	topologyName string
 }
 
 func (s *srl) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
@@ -195,15 +200,6 @@ func (s *srl) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 
-	certificate, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
-	if err != nil {
-		return nil
-	}
-
-	// set the certificate data
-	s.Config().TLSCert = string(certificate.Cert)
-	s.Config().TLSKey = string(certificate.Key)
-
 	// Create appmgr subdir for agent specs and copy files, if needed
 	if s.Cfg.Extras != nil && len(s.Cfg.Extras.SRLAgents) != 0 {
 		agents := s.Cfg.Extras.SRLAgents
@@ -240,11 +236,39 @@ func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error 
 		)
 	}
 
+	// store the certificate creation related parameters in the node itself for
+	// cert generation including Mgmt IPs as SANs in Post-Deploy phase
+	s.cert = params.Cert
+	s.topologyName = params.TopologyName
+
 	return s.createSRLFiles()
 }
 
 func (s *srl) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Nokia SR Linux '%s' node", s.Cfg.ShortName)
+
+	// populate config with mgmt ip addresses
+	if err := s.UpdateConfigWithRuntimeInfo(ctx); err != nil {
+		return err
+	}
+
+	// add the ips as SANs
+	for _, ip := range []string{s.Cfg.MgmtIPv4Address, s.Cfg.MgmtIPv6Address} {
+		if ip != "" {
+			s.Cfg.SANs = append(s.Cfg.SANs, ip)
+		}
+	}
+
+	// generate the certificate
+	certificate, err := s.LoadOrGenerateCertificate(s.cert, s.topologyName)
+	if err != nil {
+		return err
+	}
+
+	// set the certificate data
+	s.Config().TLSCert = string(certificate.Cert)
+	s.Config().TLSKey = string(certificate.Key)
+
 	// Populate /etc/hosts for service discovery on mgmt interface
 	if err := s.populateHosts(ctx, params.Nodes); err != nil {
 		log.Warnf("Unable to populate hosts for node %q: %v", s.Cfg.ShortName, err)

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -123,7 +123,8 @@ type srl struct {
 	// startup-config passed as a path to a file with CLI instructions will be read into this byte slice
 	startupCliCfg []byte
 
-	// Params provided in Pre-Deploy, that will in SRL be used in Post-Deploy phase
+	// Params provided in Pre-Deploy, that srl uses in Post-Deploy phase
+	// to generate certificates
 	cert         *cert.Cert
 	topologyName string
 }
@@ -236,8 +237,8 @@ func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error 
 		)
 	}
 
-	// store the certificate creation related parameters in the node itself for
-	// cert generation including Mgmt IPs as SANs in Post-Deploy phase
+	// store the certificate-related parameters
+	// for cert generation to happen in Post-Deploy phase with mgmt IPs as SANs
 	s.cert = params.Cert
 	s.topologyName = params.TopologyName
 
@@ -246,11 +247,6 @@ func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error 
 
 func (s *srl) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Nokia SR Linux '%s' node", s.Cfg.ShortName)
-
-	// populate config with mgmt ip addresses
-	if err := s.UpdateConfigWithRuntimeInfo(ctx); err != nil {
-		return err
-	}
 
 	// add the ips as SANs
 	for _, ip := range []string{s.Cfg.MgmtIPv4Address, s.Cfg.MgmtIPv6Address} {

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -100,6 +100,13 @@ Verify TLS works with JSON-RPC and certificate check
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${output}    error
 
+Verify TLS works with JSON-RPC, certificate check and IP address as SAN
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    curl --cacert ./clab-${lab-name}/.tls/ca/ca.pem 'https://admin:NokiaSrl1!@172.20.20.2/jsonrpc' -d '{"jsonrpc":"2.0","id":0,"method":"get","params":{"commands":[{"path":"/system/information/version","datastore":"state"}]}}'
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${output}    error
+
 *** Keywords ***
 Cleanup
     Run    sudo %{CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup


### PR DESCRIPTION
create srl certificate in post-deploy phase, thereby including the mgmt IPs as SANs

```
mava@server01:~/projects/containerlab$ openssl s_client -connect 172.20.20.2:57400 </dev/null 2>/dev/null | openssl x509 -noout -text | grep DNS:
                DNS:srl1, DNS:clab-srl02-srl1, DNS:srl1.srl02.io, IP Address:172.20.20.2, IP Address:2001:172:20:20:0:0:0:2
```