### PR TITLE
Store information about NodeGeneration in registry.

### DIFF
--- a/clab/config/utils.go
+++ b/clab/config/utils.go
@@ -64,7 +64,7 @@ func PrepareVars(c *clab.CLab) map[string]*NodeConfig {
 			vars[vkRole] = nodeCfg.Kind
 		}
 
-		creds := c.Reg.Kind(nodeCfg.Kind).Credentials().Slice()
+		creds := c.Reg.Kind(nodeCfg.Kind).GetCredentials().Slice()
 
 		res[name] = &NodeConfig{
 			TargetNode:  nodeCfg,

--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -81,8 +81,8 @@ func (c *CLab) generateAnsibleInventory(w io.Writer) error {
 		// assumption is that all nodes of the same kind have the same credentials
 		nodeRegEntry := c.Reg.Kind(n.Config().Kind)
 		if nodeRegEntry != nil {
-			kindProps.Username = nodeRegEntry.Credentials().GetUsername()
-			kindProps.Password = nodeRegEntry.Credentials().GetPassword()
+			kindProps.Username = nodeRegEntry.GetCredentials().GetUsername()
+			kindProps.Password = nodeRegEntry.GetCredentials().GetPassword()
 		}
 
 		// add network_os to the node

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -68,7 +68,7 @@ func (c *CLab) addSSHConfig() error {
 		NodeRegistryEntry := c.Reg.Kind(n.Config().Kind)
 		nodeData := SSHConfigNodeTmpl{
 			Name:      n.Config().LongName,
-			Username:  NodeRegistryEntry.Credentials().GetUsername(),
+			Username:  NodeRegistryEntry.GetCredentials().GetUsername(),
 			SSHConfig: n.GetSSHConfig(),
 		}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -216,8 +216,10 @@ func generateTopologyConfig(name, network, ipv4range, ipv6range string,
 				// create a raw veth link
 				l := &links.LinkVEthRaw{
 					Endpoints: []*links.EndpointRaw{
-						links.NewEndpointRaw(node1, fmt.Sprintf(generateNodesAttributes[nodes[i].kind].GetInterfaceFormat(), k+1+interfaceOffset), ""),
-						links.NewEndpointRaw(node2, fmt.Sprintf(generateNodesAttributes[nodes[i+1].kind].GetInterfaceFormat(), j+1), ""),
+						links.NewEndpointRaw(node1, fmt.Sprintf(
+							generateNodesAttributes[nodes[i].kind].GetInterfaceFormat(), k+1+interfaceOffset), ""),
+						links.NewEndpointRaw(node2, fmt.Sprintf(
+							generateNodesAttributes[nodes[i+1].kind].GetInterfaceFormat(), j+1), ""),
 					},
 				}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -108,10 +108,11 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
-	// init a new NodeRegistry
-	reg = nodes.NewNodeRegistry()
-	// register all nodes
-	clab.RegisterNodes(reg)
+	c := &clab.CLab{}
+	c.Reg = nodes.NewNodeRegistry()
+	c.RegisterNodes()
+
+	reg = c.Reg
 
 	generateNodesAttributes := reg.GetGenerateNodeAttributes()
 	supportedKinds := []string{}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -83,7 +83,7 @@ var generateCmd = &cobra.Command{
 		}
 		log.Debugf("generated topo: %s", string(b))
 		if file != "" {
-			err = saveTopoFile(file, b)
+			err = utils.CreateFile(file, string(b))
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ var generateCmd = &cobra.Command{
 			reconfigure = true
 			if file == "" {
 				file = fmt.Sprintf("%s.clab.yml", name)
-				err = saveTopoFile(file, b)
+				err = utils.CreateFile(file, string(b))
 				if err != nil {
 					return err
 				}
@@ -316,18 +316,4 @@ func parseNodesFlag(kind string, nodes ...string) ([]nodesDef, error) {
 		result[idx] = def
 	}
 	return result, nil
-}
-
-func saveTopoFile(path string, data []byte) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666) // skipcq: GSC-G302
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(data)
-	if err != nil {
-		return err
-	}
-
-	return f.Close()
 }

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -200,7 +200,7 @@ func parseVethEndpoint(s string) (parsedEndpoint, error) {
 
 	case 3:
 		if _, ok := utils.StringInSlice([]string{"ovs-bridge", "bridge"}, arr[0]); !ok {
-			return ep, fmt.Errorf("node type %s is not supported, supported nodes are %q", arr[0], supportedKinds)
+			return ep, fmt.Errorf("only bride and ovs-bridge can be used as a first block in the link definition. Got: %s", arr[0])
 		}
 
 		switch arr[0] {

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-var kindnames = []string{"bridge"}
+var kindNames = []string{"bridge"}
 
 const (
 	iptCheckCmd = "-vL FORWARD -w 5"
@@ -38,7 +38,7 @@ func Register(r *nodes.NodeRegistry) {
 	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
 	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
 
-	r.Register(kindnames, func() nodes.Node {
+	r.Register(kindNames, func() nodes.Node {
 		return new(bridge)
 	}, nrea)
 }

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -28,13 +28,20 @@ var kindnames = []string{"bridge"}
 const (
 	iptCheckCmd = "-vL FORWARD -w 5"
 	iptAllowCmd = "-I FORWARD -i %s -j ACCEPT -w 5"
+
+	generateable      = true
+	generateIfFornamt = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(bridge)
-	}, nil)
+	}, nrea)
 }
 
 type bridge struct {

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -29,13 +29,13 @@ const (
 	iptCheckCmd = "-vL FORWARD -w 5"
 	iptAllowCmd = "-I FORWARD -i %s -j ACCEPT -w 5"
 
-	generateable      = true
-	generateIfFornamt = "eth%d"
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
 	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
 
 	r.Register(kindnames, func() nodes.Node {

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -35,7 +35,6 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-
 	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
 	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
 

--- a/nodes/c8000/c8000.go
+++ b/nodes/c8000/c8000.go
@@ -33,9 +33,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(c8000)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type c8000 struct {

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -26,6 +26,8 @@ import (
 
 const (
 	ifWaitScriptContainerPath = "/mnt/flash/if-wait.sh"
+	generateable              = true
+	generateIfFormat          = "eth%d"
 )
 
 var (
@@ -52,9 +54,13 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
 	r.Register(KindNames, func() nodes.Node {
 		return new(ceos)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type ceos struct {

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -54,7 +54,6 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-
 	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
 	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
 

--- a/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
+++ b/nodes/checkpoint_cloudguard/checkpoint_cloudguard.go
@@ -20,9 +20,10 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(CheckpointCloudguard)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type CheckpointCloudguard struct {

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -20,13 +20,17 @@ import (
 )
 
 const (
+
 	// licDir is the directory where Junos 22+ expects to find the license file.
 	licDir  = "/config/license"
 	licFile = "license.lic"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 var (
-	KindNames = []string{"crpd", "juniper_crpd"}
+	kindNames = []string{"crpd", "juniper_crpd"}
 	//go:embed crpd.cfg
 	defaultCfgTemplate string
 
@@ -41,9 +45,12 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(crpd)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type crpd struct {

--- a/nodes/dell_sonic/dell_sonic.go
+++ b/nodes/dell_sonic/dell_sonic.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
-	kindnames          = []string{"dell_sonic"}
+	kindNames          = []string{"dell_sonic"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
+	generateable       = true
+	generateIfFormat   = "eth%d"
 )
 
 const (
@@ -29,9 +31,12 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(dell_sonic)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type dell_sonic struct {

--- a/nodes/fortinet_fortigate/fortigate.go
+++ b/nodes/fortinet_fortigate/fortigate.go
@@ -27,15 +27,20 @@ var (
 const (
 	// scrapligo doesn't have a driver for fortigate, can be copied from scrapli community
 	// scrapliPlatformName = "fortinet_fortigate".
-	configDirName   = "config"
-	startupCfgFName = "startup-config.cfg"
+	configDirName    = "config"
+	startupCfgFName  = "startup-config.cfg"
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(fortigate)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type fortigate struct {

--- a/nodes/generic_vm/generic_vm.go
+++ b/nodes/generic_vm/generic_vm.go
@@ -20,14 +20,19 @@ var (
 )
 
 const (
-	configDirName = "config"
+	configDirName    = "config"
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(genericVM)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type genericVM struct {

--- a/nodes/huawei_vrp/huawei_vrp.go
+++ b/nodes/huawei_vrp/huawei_vrp.go
@@ -26,13 +26,19 @@ const (
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(huawei_vrp)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type huawei_vrp struct {

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -30,10 +30,13 @@ const (
 	typeL2  = "l2"
 
 	iol_workdir = "/iol"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 var (
-	kindnames          = []string{"cisco_iol"}
+	kindNames          = []string{"cisco_iol"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	//go:embed iol.cfg.tmpl
@@ -51,9 +54,12 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(iol)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type iol struct {

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -23,12 +23,12 @@ var (
 const (
 	scrapliPlatformName = "ipinfusion_ocnos"
 	generateable        = false
-	generateIfFornamt   = ""
+	generateIfFormat    = ""
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
 	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
 
 	r.Register(kindnames, func() nodes.Node {

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -28,7 +28,6 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-
 	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
 	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
 

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -22,13 +22,19 @@ var (
 
 const (
 	scrapliPlatformName = "ipinfusion_ocnos"
+	generateable        = false
+	generateIfFornamt   = ""
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(IPInfusionOcNOS)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type IPInfusionOcNOS struct {

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -19,13 +19,21 @@ import (
 	"github.com/weaveworks/ignite/pkg/operations"
 )
 
+const (
+	generateable      = true
+	generateIfFornamt = "eth%d"
+)
+
 var kindnames = []string{"linux"}
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
+
 	r.Register(kindnames, func() nodes.Node {
 		return new(linux)
-	}, nil)
+	}, nrea)
 }
 
 type linux struct {

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -20,15 +20,15 @@ import (
 )
 
 const (
-	generateable      = true
-	generateIfFornamt = "eth%d"
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 var kindnames = []string{"linux"}
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFornamt)
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
 	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
 
 	r.Register(kindnames, func() nodes.Node {

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -21,8 +21,8 @@ func NewNodeRegistry() *NodeRegistry {
 }
 
 // Register registers the node' init function for all provided names.
-func (r *NodeRegistry) Register(names []string, initf Initializer, credentials *Credentials) error {
-	newEntry := newRegistryEntry(names, initf, credentials)
+func (r *NodeRegistry) Register(names []string, initf Initializer, attributes *NodeRegistryEntryAttributes) error {
+	newEntry := newRegistryEntry(names, initf, attributes)
 	return r.addEntry(newEntry)
 }
 
@@ -63,6 +63,14 @@ func (r *NodeRegistry) GetRegisteredNodeKindNames() []string {
 	return result
 }
 
+func (r *NodeRegistry) GetGenerateNodeAttributes() map[string]*GenerateNodeAttributes {
+	result := map[string]*GenerateNodeAttributes{}
+	for k, v := range r.nodeIndex {
+		result[k] = v.GetGenerateAttributes()
+	}
+	return result
+}
+
 func (r *NodeRegistry) Kind(kind string) *NodeRegistryEntry {
 	return r.nodeIndex[kind]
 }
@@ -70,11 +78,26 @@ func (r *NodeRegistry) Kind(kind string) *NodeRegistryEntry {
 type NodeRegistryEntry struct {
 	nodeKindNames []string
 	initFunction  Initializer
-	credentials   *Credentials
+	attributes    *NodeRegistryEntryAttributes
+}
+
+func (nre *NodeRegistryEntry) GetCredentials() *Credentials {
+	if nre.attributes == nil {
+		return nil
+	}
+	return nre.attributes.credentials
+}
+
+func (nre *NodeRegistryEntry) GetGenerateAttributes() *GenerateNodeAttributes {
+	if nre.attributes == nil {
+		return nil
+	}
+	return nre.attributes.generateAttributes
 }
 
 // Credentials returns entry's credentials.
-func (e *NodeRegistryEntry) Credentials() *Credentials {
+// might return nil if no default credentials present
+func (e *NodeRegistryEntryAttributes) Credentials() *Credentials {
 	if e == nil {
 		return nil
 	}
@@ -82,12 +105,62 @@ func (e *NodeRegistryEntry) Credentials() *Credentials {
 	return e.credentials
 }
 
-func newRegistryEntry(nodeKindNames []string, initFunction Initializer, credentials *Credentials) *NodeRegistryEntry {
+func newRegistryEntry(nodeKindNames []string, initFunction Initializer, attributes *NodeRegistryEntryAttributes) *NodeRegistryEntry {
 	return &NodeRegistryEntry{
 		nodeKindNames: nodeKindNames,
 		initFunction:  initFunction,
-		credentials:   credentials,
+		attributes:    attributes,
 	}
+}
+
+type NodeRegistryEntryAttributes struct {
+	credentials        *Credentials
+	generateAttributes *GenerateNodeAttributes
+}
+
+func NewNodeRegistryEntryAttributes(c *Credentials, ga *GenerateNodeAttributes) *NodeRegistryEntryAttributes {
+	// set default value for GenerateNodeAttributes
+	if ga == nil {
+		ga = NewGenerateNodeAttributes(false, "")
+	}
+	return &NodeRegistryEntryAttributes{
+		credentials:        c,
+		generateAttributes: ga,
+	}
+}
+
+func (nrea *NodeRegistryEntryAttributes) GetCredentials() *Credentials {
+	return nrea.credentials
+}
+
+func (nrea *NodeRegistryEntryAttributes) GetGenerateAttributes() *GenerateNodeAttributes {
+	return nrea.generateAttributes
+}
+
+type GenerateNodeAttributes struct {
+	generateable    bool
+	interfaceFormat string
+}
+
+func NewGenerateNodeAttributes(generateable bool, ifFormat string) *GenerateNodeAttributes {
+	return &GenerateNodeAttributes{
+		generateable:    generateable,
+		interfaceFormat: ifFormat,
+	}
+}
+
+func (ga *GenerateNodeAttributes) IsGenerateable() bool {
+	if ga == nil {
+		return false
+	}
+	return ga.generateable
+}
+
+func (ga *GenerateNodeAttributes) GetInterfaceFormat() string {
+	if ga == nil {
+		return ""
+	}
+	return ga.interfaceFormat
 }
 
 // Credentials defines NOS SSH credentials.

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -85,7 +85,8 @@ func (nre *NodeRegistryEntry) GetCredentials() *Credentials {
 	if nre.attributes == nil {
 		return nil
 	}
-	return nre.attributes.credentials
+
+	return nre.attributes.GetCredentials()
 }
 
 func (nre *NodeRegistryEntry) GetGenerateAttributes() *GenerateNodeAttributes {

--- a/nodes/node_registry.go
+++ b/nodes/node_registry.go
@@ -96,7 +96,7 @@ func (nre *NodeRegistryEntry) GetGenerateAttributes() *GenerateNodeAttributes {
 }
 
 // Credentials returns entry's credentials.
-// might return nil if no default credentials present
+// might return nil if no default credentials present.
 func (e *NodeRegistryEntryAttributes) Credentials() *Credentials {
 	if e == nil {
 		return nil
@@ -105,7 +105,9 @@ func (e *NodeRegistryEntryAttributes) Credentials() *Credentials {
 	return e.credentials
 }
 
-func newRegistryEntry(nodeKindNames []string, initFunction Initializer, attributes *NodeRegistryEntryAttributes) *NodeRegistryEntry {
+func newRegistryEntry(nodeKindNames []string, initFunction Initializer,
+	attributes *NodeRegistryEntryAttributes,
+) *NodeRegistryEntry {
 	return &NodeRegistryEntry{
 		nodeKindNames: nodeKindNames,
 		initFunction:  initFunction,

--- a/nodes/rare/rare.go
+++ b/nodes/rare/rare.go
@@ -14,13 +14,21 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
-var KindNames = []string{"rare"}
+var kindNames = []string{"rare"}
+
+const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+)
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(rare)
-	}, nil)
+	}, nrea)
 }
 
 type rare struct {

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -15,13 +15,21 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
-var KindNames = []string{"sonic-vs"}
+const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+)
+
+var kindNames = []string{"sonic-vs"}
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(sonic)
-	}, nil)
+	}, nrea)
 }
 
 type sonic struct {

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -19,8 +19,11 @@ import (
 )
 
 var (
-	kindnames          = []string{"sonic-vm"}
+	kindNames          = []string{"sonic-vm"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 const (
@@ -31,9 +34,12 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(sonic_vm)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type sonic_vm struct {

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -36,7 +36,11 @@ const (
 	SRLinuxDefaultType = "ixrd2l" // default srl node type
 
 	readyTimeout = time.Minute * 5 // max wait time for node to boot
-	retryTimer   = time.Second
+
+	generateable     = true
+	generateIfFormat = "e1-%d"
+
+	retryTimer = time.Second
 
 	// defaultCfgPath is a path to a file with default config that clab adds on top of the factory config.
 	// Default config is a config that adds some basic configuration to the node, such as tls certs, gnmi/json-rpc, login-banner.
@@ -52,7 +56,7 @@ var (
 	//go:embed srl_default_config.go.tpl
 	srlConfigCmdsTpl string
 
-	KindNames = []string{"srl", "nokia_srlinux"}
+	kindNames = []string{"srl", "nokia_srlinux"}
 	srlSysctl = map[string]string{
 		"net.ipv4.ip_forward":              "0",
 		"net.ipv6.conf.all.disable_ipv6":   "0",
@@ -111,9 +115,12 @@ var (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(srl)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type srl struct {

--- a/nodes/vr_aoscx/vr-aoscx.go
+++ b/nodes/vr_aoscx/vr-aoscx.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"aruba_aoscx", "vr-aoscx", "vr-aruba_aoscx"}
+	kindNames          = []string{"aruba_aoscx", "vr-aoscx", "vr-aruba_aoscx"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`1/1/(?P<port>\d+)`)
@@ -27,9 +27,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrAosCX)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrAosCX struct {

--- a/nodes/vr_c8000v/vr-c8000v.go
+++ b/nodes/vr_c8000v/vr-c8000v.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"cisco_c8000v"}
+	kindNames          = []string{"cisco_c8000v"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:Gi|GigabitEthernet)\s?(?P<port>\d+)$`)
@@ -31,13 +31,19 @@ const (
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrC8000v)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrC8000v struct {

--- a/nodes/vr_cat9kv/vr-cat9kv.go
+++ b/nodes/vr_cat9kv/vr-cat9kv.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"cisco_cat9kv"}
+	kindNames          = []string{"cisco_cat9kv"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:Gi|GigabitEthernet)\s?1/0/(?P<port>\d+)$`)
@@ -31,13 +31,19 @@ const (
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrCat9kv)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrCat9kv struct {

--- a/nodes/vr_csr/vr-csr.go
+++ b/nodes/vr_csr/vr-csr.go
@@ -35,9 +35,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrCsr)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrCsr struct {

--- a/nodes/vr_freebsd/vr-freebsd.go
+++ b/nodes/vr_freebsd/vr-freebsd.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"freebsd"}
+	kindNames          = []string{"freebsd"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 	saveCmd            = "sh -c \"/backup.sh -u $USERNAME -p $PASSWORD backup\""
 	InterfaceRegexp    = regexp.MustCompile(`vtnet(?P<port>\d+)`)
@@ -28,13 +28,19 @@ var (
 
 const (
 	configDirName = "config"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrFreeBSD)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrFreeBSD struct {

--- a/nodes/vr_ftdv/vr-ftdv.go
+++ b/nodes/vr_ftdv/vr-ftdv.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"cisco_ftdv"}
+	kindNames          = []string{"cisco_ftdv"}
 	defaultCredentials = nodes.NewCredentials("admin", "Admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:GigabitEthernet|Gi)\s?0/(?P<port>\d+)`)
@@ -23,11 +23,19 @@ var (
 	InterfaceHelp   = "GigabitEthernet0/X or Gi0/X (where X >= 0) or ethX (where X >= 1)"
 )
 
+const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+)
+
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrFtdv)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrFtdv struct {

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -26,9 +26,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrFtosv)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrFtosv struct {

--- a/nodes/vr_n9kv/vr-n9kv.go
+++ b/nodes/vr_n9kv/vr-n9kv.go
@@ -32,9 +32,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrN9kv)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrN9kv struct {

--- a/nodes/vr_openbsd/vr-openbsd.go
+++ b/nodes/vr_openbsd/vr-openbsd.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"openbsd"}
+	kindNames          = []string{"openbsd"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 	saveCmd            = "sh -c \"/backup.sh -u $USERNAME -p $PASSWORD backup\""
 
@@ -29,13 +29,19 @@ var (
 
 const (
 	configDirName = "config"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(kindnames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrOpenBSD)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrOpenBSD struct {

--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -31,9 +31,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrPan)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrPan struct {

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -31,9 +31,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrRos)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrRos struct {

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"nokia_sros", "vr-sros", "vr-nokia_sros"}
+	kindNames          = []string{"nokia_sros", "vr-sros", "vr-nokia_sros"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`1/1/(?P<port>\d+)`)
@@ -41,6 +41,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	vrsrosDefaultType   = "sr-1"
 	scrapliPlatformName = "nokia_sros"
 	configDirName       = "tftpboot"
@@ -56,9 +59,11 @@ type SROSTemplateData struct {
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrSROS)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrSROS struct {

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "1/1/%d"
 
 	vrsrosDefaultType   = "sr-1"
 	scrapliPlatformName = "nokia_sros"

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "Et1/%d"
 
 	scrapliPlatformName = "arista_eos"
 

--- a/nodes/vr_veos/vr-veos.go
+++ b/nodes/vr_veos/vr-veos.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"arista_veos", "vr-veos", "vr-arista_veos"}
+	kindNames          = []string{"arista_veos", "vr-veos", "vr-arista_veos"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:Et|Ethernet)1/(?P<port>\d+)`)
@@ -27,6 +27,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	scrapliPlatformName = "arista_eos"
 
 	configDirName   = "config"
@@ -35,9 +38,12 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVEOS)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVEOS struct {

--- a/nodes/vr_vjunosevolved/vr-vjunosevolved.go
+++ b/nodes/vr_vjunosevolved/vr-vjunosevolved.go
@@ -33,7 +33,7 @@ const (
 	startupCfgFName = "startup-config.cfg"
 
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "et-0/0/%d"
 )
 
 // Register registers the node in the NodeRegistry.

--- a/nodes/vr_vjunosevolved/vr-vjunosevolved.go
+++ b/nodes/vr_vjunosevolved/vr-vjunosevolved.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"juniper_vjunosevolved"}
+	kindNames          = []string{"juniper_vjunosevolved"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`)
@@ -31,13 +31,19 @@ const (
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVJUNOSEVOLVED)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVJUNOSEVOLVED struct {

--- a/nodes/vr_vjunosswitch/vr-vjunosswitch.go
+++ b/nodes/vr_vjunosswitch/vr-vjunosswitch.go
@@ -33,7 +33,7 @@ const (
 	startupCfgFName = "startup-config.cfg"
 
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "et-0/0/%d"
 )
 
 // Register registers the node in the NodeRegistry.

--- a/nodes/vr_vjunosswitch/vr-vjunosswitch.go
+++ b/nodes/vr_vjunosswitch/vr-vjunosswitch.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"juniper_vjunosrouter", "juniper_vjunosswitch"}
+	kindNames          = []string{"juniper_vjunosrouter", "juniper_vjunosswitch"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`)
@@ -31,13 +31,19 @@ const (
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVJUNOSSWITCH)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVJUNOSSWITCH struct {

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "ge-0/0/%d"
 
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"

--- a/nodes/vr_vmx/vr-vmx.go
+++ b/nodes/vr_vmx/vr-vmx.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"juniper_vmx", "vr-vmx", "vr-juniper_vmx"}
+	kindNames          = []string{"juniper_vmx", "vr-vmx", "vr-juniper_vmx"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`)
@@ -27,6 +27,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	configDirName   = "config"
 	startupCfgFName = "startup-config.cfg"
 
@@ -35,9 +38,12 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVMX)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVMX struct {

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "ge-0/0/%d"
 
 	scrapliPlatformName = "juniper_junos"
 

--- a/nodes/vr_vqfx/vr-vqfx.go
+++ b/nodes/vr_vqfx/vr-vqfx.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"juniper_vqfx", "vr-vqfx", "vr-juniper_vqfx"}
+	kindNames          = []string{"juniper_vqfx", "vr-vqfx", "vr-juniper_vqfx"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`)
@@ -27,6 +27,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	scrapliPlatformName = "juniper_junos"
 
 	configDirName   = "config"
@@ -35,9 +38,11 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVQFX)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVQFX struct {

--- a/nodes/vr_vsrx/vr-vsrx.go
+++ b/nodes/vr_vsrx/vr-vsrx.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "ge-0/0/%d"
 
 	scrapliPlatformName = "juniper_junos"
 

--- a/nodes/vr_vsrx/vr-vsrx.go
+++ b/nodes/vr_vsrx/vr-vsrx.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"juniper_vsrx", "vr-vsrx", "vr-juniper_vsrx"}
+	kindNames          = []string{"juniper_vsrx", "vr-vsrx", "vr-juniper_vsrx"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`)
@@ -27,6 +27,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	scrapliPlatformName = "juniper_junos"
 
 	configDirName   = "config"
@@ -35,9 +38,12 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrVSRX)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrVSRX struct {

--- a/nodes/vr_xrv/vr-xrv.go
+++ b/nodes/vr_xrv/vr-xrv.go
@@ -34,9 +34,10 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, nil)
 	r.Register(kindnames, func() nodes.Node {
 		return new(vrXRV)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrXRV struct {

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"cisco_xrv9k", "vr-xrv9k", "vr-cisco_xrv9k"}
+	kindNames          = []string{"cisco_xrv9k", "vr-xrv9k", "vr-cisco_xrv9k"}
 	defaultCredentials = nodes.NewCredentials("clab", "clab@123")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:Gi|GigabitEthernet|Te|TenGigE|TenGigabitEthernet)\s?0/0/0/(?P<port>\d+)`)
@@ -27,6 +27,9 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	scrapliPlatformName = "cisco_iosxr"
 
 	configDirName   = "config"
@@ -35,9 +38,11 @@ const (
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+	r.Register(kindNames, func() nodes.Node {
 		return new(vrXRV9K)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type vrXRV9K struct {

--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	generateable     = true
-	generateIfFormat = "eth%d"
+	generateIfFormat = "Gi0/0/0/%d"
 
 	scrapliPlatformName = "cisco_iosxr"
 

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	KindNames          = []string{"xrd", "cisco_xrd"}
+	kindNames          = []string{"xrd", "cisco_xrd"}
 	defaultCredentials = nodes.NewCredentials("clab", "clab@123")
 	xrdEnv             = map[string]string{
 		"XR_FIRST_BOOT_CONFIG": "/etc/xrd/first-boot.cfg",
@@ -44,14 +44,20 @@ var (
 )
 
 const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+
 	scrapliPlatformName = "cisco_iosxr"
 )
 
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
-	r.Register(KindNames, func() nodes.Node {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(defaultCredentials, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
 		return new(xrd)
-	}, defaultCredentials)
+	}, nrea)
 }
 
 type xrd struct {


### PR DESCRIPTION
So far generate.go contained two lists indenpendent from the nodes, that would describe nodes that (1) can be generated and (b) what the interface naming convention would be for the node kind. This will introduce seperate fields in the NodeRegistry for this information, such that the information for this sort of node generation can be defined as part of the node definition