### PR TITLE
apt and yum installs need sudo

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -37,14 +37,14 @@ It is possible to install official containerlab releases via public APT/YUM repo
     echo "deb [trusted=yes] https://apt.fury.io/netdevops/ /" | \
     sudo tee -a /etc/apt/sources.list.d/netdevops.list
 
-    apt update && apt install containerlab
+    sudo apt update && sudo apt install containerlab
     ```
 === "YUM"
     ```
     yum-config-manager --add-repo=https://yum.fury.io/netdevops/ && \
     echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/yum.fury.io_netdevops_.repo
 
-    yum install containerlab
+    sudo yum install containerlab
     ```
 === "APK"
     Download `.apk` package from [Github releases](https://github.com/srl-labs/containerlab/releases).


### PR DESCRIPTION
It doesn't make sense to have a set of instructions where part of it sudo's and the rest don't when all of it requires root. The edits reflect that by adding missing sudo's so that the copy-paste of these instructions doesn't fail because nobody should be logged in as root.