### PR TITLE
allow for ip-range definition on docker mgmt net

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -162,20 +162,28 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 			if d.mgmt.IPv4Gw != "" {
 				v4gw = d.mgmt.IPv4Gw
 			}
-			ipamConfig = append(ipamConfig, network.IPAMConfig{
+			ipamCfg := network.IPAMConfig{
 				Subnet:  d.mgmt.IPv4Subnet,
 				Gateway: v4gw,
-			})
+			}
+			if d.mgmt.IPv4Range != "" {
+				ipamCfg.IPRange = d.mgmt.IPv4Range
+			}
+			ipamConfig = append(ipamConfig, ipamCfg)
 		}
 
 		if d.mgmt.IPv6Subnet != "" {
 			if d.mgmt.IPv6Gw != "" {
 				v6gw = d.mgmt.IPv6Gw
 			}
-			ipamConfig = append(ipamConfig, network.IPAMConfig{
+			ipamCfg := network.IPAMConfig{
 				Subnet:  d.mgmt.IPv6Subnet,
 				Gateway: v6gw,
-			})
+			}
+			if d.mgmt.IPv6Range != "" {
+				ipamCfg.IPRange = d.mgmt.IPv6Range
+			}
+			ipamConfig = append(ipamConfig, ipamCfg)
 			enableIPv6 = true
 		}
 

--- a/types/types.go
+++ b/types/types.go
@@ -42,10 +42,12 @@ type MgmtNet struct {
 	Network string `yaml:"network,omitempty" json:"network,omitempty"` // container runtime network name
 	Bridge  string `yaml:"bridge,omitempty" json:"bridge,omitempty"`
 	// linux bridge backing the runtime network
-	IPv4Subnet     string `yaml:"ipv4_subnet,omitempty" json:"ipv4-subnet,omitempty"`
+	IPv4Subnet     string `yaml:"ipv4-subnet,omitempty" json:"ipv4-subnet,omitempty"`
 	IPv4Gw         string `yaml:"ipv4-gw,omitempty" json:"ipv4-gw,omitempty"`
-	IPv6Subnet     string `yaml:"ipv6_subnet,omitempty" json:"ipv6-subnet,omitempty"`
+	IPv4Range      string `yaml:"ipv4-range,omitempty" json:"ipv4-range,omitempty"`
+	IPv6Subnet     string `yaml:"ipv6-subnet,omitempty" json:"ipv6-subnet,omitempty"`
 	IPv6Gw         string `yaml:"ipv6-gw,omitempty" json:"ipv6-gw,omitempty"`
+	IPv6Range      string `yaml:"ipv6-range,omitempty" json:"ipv6-range,omitempty"`
 	MTU            string `yaml:"mtu,omitempty" json:"mtu,omitempty"`
 	ExternalAccess *bool  `yaml:"external-access,omitempty" json:"external-access,omitempty"`
 }


### PR DESCRIPTION
As mentioned in #1364 this PR will enable ip-range assignments for docker networks.
```
mgmt:
  network: lab-mgmt
  bridge: testbr
  ipv4-subnet: 192.168.100.0/24
  ipv4-gw: 192.168.100.1
  ipv4-range: 192.168.100.128/25
```