### PR TITLE
change mgmt_ipv4/6 to mgmt-ipv4/6

### DIFF
--- a/clab/test_data/topo1.yml
+++ b/clab/test_data/topo1.yml
@@ -9,11 +9,11 @@ topology:
       env:
         env1: val1
         env2: val2
-      mgmt_ipv4: 172.100.100.11
+      mgmt-ipv4: 172.100.100.11
     node2:
       kind: srl
       license: node1.lic
       user: custom
-      mgmt_ipv4: 172.100.100.12
+      mgmt-ipv4: 172.100.100.12
       labels:
         node-label: value

--- a/clab/test_data/topo10.yml
+++ b/clab/test_data/topo10.yml
@@ -9,10 +9,10 @@ topology:
       env:
         env1: val1
         env2: val2
-      mgmt_ipv4: 172.100.100.11
+      mgmt-ipv4: 172.100.100.11
     node2:
       kind: linux
-      mgmt_ipv4: 172.100.100.12
+      mgmt-ipv4: 172.100.100.12
       labels:
         node-label: value
       env-files:

--- a/clab/test_data/topo8_ansible_groups.yml
+++ b/clab/test_data/topo8_ansible_groups.yml
@@ -10,14 +10,14 @@ topology:
       env:
         env1: val1
         env2: val2
-      mgmt_ipv4: 172.100.100.11
+      mgmt-ipv4: 172.100.100.11
       labels:
         ansible-group: spine
     node2:
       kind: srl
       license: node1.lic
       user: custom
-      mgmt_ipv4: 172.100.100.12
+      mgmt-ipv4: 172.100.100.12
       labels:
         node-label: value
         ansible-group: extra_group
@@ -26,7 +26,7 @@ topology:
       kind: srl
       license: node1.lic
       user: custom
-      mgmt_ipv4: 172.100.100.13
+      mgmt-ipv4: 172.100.100.13
       labels:
         node-label: value
         ansible-group: extra_group
@@ -34,6 +34,6 @@ topology:
     node4:
       kind: linux
       image: alpine:3
-      mgmt_ipv4: 172.100.100.14
+      mgmt-ipv4: 172.100.100.14
       labels:
         ansible-no-host-var: true

--- a/docs/lab-examples/min-5clos.md
+++ b/docs/lab-examples/min-5clos.md
@@ -22,7 +22,7 @@ With this lightweight CLOS topology a user can exhibit the following scenarios:
 ## Configuration setup
 To help you get faster to the provisioning of the services on this mini fabric we added an auto-configuration script to this example.
 
-In order to make a fully deterministic lab setup we added another topology file called [setup.clos02.clab.yml][setup-topofile] where the management interfaces of each network node and clients are statically addressed with [`mgmt_ipv4/6` config option](../manual/nodes.md#mgmt_ipv4). Other than that, the topology files does not have any changes.
+In order to make a fully deterministic lab setup we added another topology file called [setup.clos02.clab.yml][setup-topofile] where the management interfaces of each network node and clients are statically addressed with [`mgmt-ipv4/6` config option](../manual/nodes.md#mgmt-ipv4). Other than that, the topology files does not have any changes.
 
 ### Prerequisites
 The configuration of the fabric elements is carried out with [`gnmic` client](https://gnmic.kmrd.dev/install/), therefore it needs to be installed on the machine where you run the lab.

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -312,7 +312,7 @@ This script is then placed somewhere on the disk, for example in the containerla
 ```yaml
   nodes:
     sros1:
-      mgmt_ipv4: [mgmt-ip]
+      mgmt-ipv4: [mgmt-ip]
       kind: vr-sros
       image: [container-image-repo]
       type: sr-1s

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -144,8 +144,8 @@ topology:
   nodes:
     n1:
       kind: srl
-      mgmt_ipv4: 172.100.100.11       # set ipv4 address on management network
-      mgmt_ipv6: 2001:172:100:100::11 # set ipv6 address on management network
+      mgmt-ipv4: 172.100.100.11       # set ipv4 address on management network
+      mgmt-ipv6: 2001:172:100:100::11 # set ipv6 address on management network
 ```
 
 Users can specify either IPv4 or IPv6 or both addresses. If one of the addresses is omitted, it will be assigned by container runtime in an arbitrary fashion.

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -410,9 +410,9 @@ label3: value3 # inherited from kinds section
 !!!note
     Both user-defined and containerlab-assigned labels also promoted to environment variables prefixed with `CLAB_LABEL_` prefix.
 
-### mgmt_ipv4
+### mgmt-ipv4
 
-To make a node to boot with a user-specified management IPv4 address, the `mgmt_ipv4` setting can be used. Note, that the static management IP address should be part of the subnet that is used within the lab.
+To make a node to boot with a user-specified management IPv4 address, the `mgmt-ipv4` setting can be used. Note, that the static management IP address should be part of the subnet that is used within the lab.
 
 Read more about user-defined management addresses [here](network.md#user-defined-addresses).
 
@@ -420,7 +420,7 @@ Read more about user-defined management addresses [here](network.md#user-defined
 nodes:
     r1:
       kind: srl
-      mgmt_ipv4: 172.20.20.100
+      mgmt-ipv4: 172.20.20.100
 ```
 
 ### mgmt_ipv6

--- a/lab-examples/clos02/setup.clos02.clab.yml
+++ b/lab-examples/clos02/setup.clos02.clab.yml
@@ -14,69 +14,69 @@ topology:
   nodes:
     leaf1:
       kind: srl
-      mgmt_ipv4: 172.100.100.2
-      mgmt_ipv6: 2001:172:100:100::2
+      mgmt-ipv4: 172.100.100.2
+      mgmt-ipv6: 2001:172:100:100::2
     leaf2:
       kind: srl
-      mgmt_ipv4: 172.100.100.3
-      mgmt_ipv6: 2001:172:100:100::3
+      mgmt-ipv4: 172.100.100.3
+      mgmt-ipv6: 2001:172:100:100::3
     leaf3:
       kind: srl
-      mgmt_ipv4: 172.100.100.4
-      mgmt_ipv6: 2001:172:100:100::4
+      mgmt-ipv4: 172.100.100.4
+      mgmt-ipv6: 2001:172:100:100::4
     leaf4:
       kind: srl
-      mgmt_ipv4: 172.100.100.5
-      mgmt_ipv6: 2001:172:100:100::5
+      mgmt-ipv4: 172.100.100.5
+      mgmt-ipv6: 2001:172:100:100::5
 
     spine1:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.6
-      mgmt_ipv6: 2001:172:100:100::6
+      mgmt-ipv4: 172.100.100.6
+      mgmt-ipv6: 2001:172:100:100::6
     spine2:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.7
-      mgmt_ipv6: 2001:172:100:100::7
+      mgmt-ipv4: 172.100.100.7
+      mgmt-ipv6: 2001:172:100:100::7
     spine3:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.8
-      mgmt_ipv6: 2001:172:100:100::8
+      mgmt-ipv4: 172.100.100.8
+      mgmt-ipv6: 2001:172:100:100::8
     spine4:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.9
-      mgmt_ipv6: 2001:172:100:100::9
+      mgmt-ipv4: 172.100.100.9
+      mgmt-ipv6: 2001:172:100:100::9
 
     superspine1:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.10
-      mgmt_ipv6: 2001:172:100:100::10
+      mgmt-ipv4: 172.100.100.10
+      mgmt-ipv6: 2001:172:100:100::10
     superspine2:
       kind: srl
       type: ixrd3
-      mgmt_ipv4: 172.100.100.11
-      mgmt_ipv6: 2001:172:100:100::11
+      mgmt-ipv4: 172.100.100.11
+      mgmt-ipv6: 2001:172:100:100::11
 
     client1:
       kind: linux
-      mgmt_ipv4: 172.100.100.12
-      mgmt_ipv6: 2001:172:100:100::12
+      mgmt-ipv4: 172.100.100.12
+      mgmt-ipv6: 2001:172:100:100::12
     client2:
       kind: linux
-      mgmt_ipv4: 172.100.100.13
-      mgmt_ipv6: 2001:172:100:100::13
+      mgmt-ipv4: 172.100.100.13
+      mgmt-ipv6: 2001:172:100:100::13
     client3:
       kind: linux
-      mgmt_ipv4: 172.100.100.14
-      mgmt_ipv6: 2001:172:100:100::14
+      mgmt-ipv4: 172.100.100.14
+      mgmt-ipv6: 2001:172:100:100::14
     client4:
       kind: linux
-      mgmt_ipv4: 172.100.100.15
-      mgmt_ipv6: 2001:172:100:100::15
+      mgmt-ipv4: 172.100.100.15
+      mgmt-ipv6: 2001:172:100:100::15
 
   links:
     - endpoints: ["leaf1:e1-1", "spine1:e1-1"]

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -237,13 +237,13 @@
                         "ignite"
                     ]
                 },
-                "mgmt_ipv4": {
+                "mgmt-ipv4": {
                     "type": "string",
                     "description": "IPv4 management address of the node (e.g. 172.10.10.11)",
                     "markdownDescription": "[IPv4 management address](https://containerlab.dev/manual/nodes/#mgmt-ipv4) of the node (e.g. 172.10.10.11)",
                     "pattern": "^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{N}\\p{L}]+)?$"
                 },
-                "mgmt_ipv6": {
+                "mgmt-ipv6": {
                     "type": "string",
                     "description": "IPv6 management address of the node (e.g. 172.10.10.11)",
                     "markdownDescription": "[IPv6 management address](https://containerlab.dev/manual/nodes/#mgmt-ipv6) of the node (e.g. 172.10.10.11)",

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -25,8 +25,8 @@ topology:
       image: nginx:stable-alpine
       ports:
         - 56180:80
-      mgmt_ipv4: 172.20.20.100
-      mgmt_ipv6: 2001:172:20:20::100
+      mgmt-ipv4: 172.20.20.100
+      mgmt-ipv6: 2001:172:20:20::100
       dns:
         servers:
           - 8.8.8.8

--- a/tests/03-basic-ceos/03-ceos01-clab.yml
+++ b/tests/03-basic-ceos/03-ceos01-clab.yml
@@ -15,7 +15,7 @@ topology:
       kind: ceos
     n2:
       kind: ceos
-      mgmt_ipv4: 172.20.20.22
+      mgmt-ipv4: 172.20.20.22
 
   links:
     - endpoints: ["n1:eth1", "n2:eth1"]

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -34,9 +34,9 @@ type NodeDefinition struct {
 	// list of port bindings
 	Ports []string `yaml:"ports,omitempty"`
 	// user-defined IPv4 address in the management network
-	MgmtIPv4 string `yaml:"mgmt_ipv4,omitempty"`
+	MgmtIPv4 string `yaml:"mgmt-ipv4,omitempty"`
 	// user-defined IPv6 address in the management network
-	MgmtIPv6 string `yaml:"mgmt_ipv6,omitempty"`
+	MgmtIPv6 string `yaml:"mgmt-ipv6,omitempty"`
 	// list of ports to publish with mysocketctl
 	Publish []string `yaml:"publish,omitempty"`
 	// environment variables


### PR DESCRIPTION
Besides changing dash to underscore for `ipv{4,6}_subnet` via #1365.
I think the `mgmt_ipv4/6` config stanza is the last remaining underscore topology setting.
I think, it would make sense to bundle this and #1365 in a single release, to have such breaking change just once.

This will in then in my view be enough to close #749