### PR TITLE
Host kernel version check for SRL

### DIFF
--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -110,7 +110,7 @@ var (
 			Funcs(gomplate.CreateFuncs(context.Background(), new(data.Data))).
 			Parse(srlConfigCmdsTpl)
 
-	SRLRequiredKernelVersion = &utils.KernelVersion{
+	requiredKernelVersion = &utils.KernelVersion{
 		Major:    4,
 		Minor:    10,
 		Revision: 0,
@@ -381,8 +381,8 @@ func (s *srl) checkKernelVersion() error {
 	}
 
 	// do the comparison
-	if !kv.GreaterOrEqual(SRLRequiredKernelVersion) {
-		log.Infof("Nokia SR Linux v23.3.1+ requires a kernel version greater than %s. Detected kernel version: %s", SRLRequiredKernelVersion, kv)
+	if !kv.GreaterOrEqual(requiredKernelVersion) {
+		log.Infof("Nokia SR Linux v23.3.1+ requires a kernel version greater than %s. Detected kernel version: %s", requiredKernelVersion, kv)
 	}
 	return nil
 }

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -372,9 +372,8 @@ func (s *srl) Ready(ctx context.Context) error {
 	}
 }
 
-// kernelVersionCheck logs a warning if the kernel has a too low version number
-// that srl starting from 23.3 required kernel > 4.10.0
-func (s *srl) kernelVersionCheck() error {
+// checkKernelVersion emits a warning if the present kernel version is lower than the required one.
+func (s *srl) checkKernelVersion() error {
 	// retrieve running kernel version
 	kv, err := utils.GetKernelVersion()
 	if err != nil {
@@ -382,15 +381,15 @@ func (s *srl) kernelVersionCheck() error {
 	}
 
 	// do the comparison
-	if !kv.IsGreaterEqual(SRLRequiredKernelVersion) {
-		log.Infof("SRL nodes from 23.3 onwards require a kernel version greater then %s. Your system is %s", SRLRequiredKernelVersion.StringMMR(), kv.StringMMR())
+	if !kv.GreaterOrEqual(SRLRequiredKernelVersion) {
+		log.Infof("Nokia SR Linux v23.3.1+ requires a kernel version greater than %s. Detected kernel version: %s", SRLRequiredKernelVersion, kv)
 	}
 	return nil
 }
 
 func (s *srl) CheckDeploymentConditions(ctx context.Context) error {
 	// perform the srl specific kernel version check
-	err := s.kernelVersionCheck()
+	err := s.checkKernelVersion()
 	if err != nil {
 		return err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -178,7 +178,8 @@ func ExpandHome(p string) string {
 
 	userId, isSet := os.LookupEnv("SUDO_UID")
 	if !isSet {
-		return curUserHomeDir
+		p = strings.Replace(p, "~", curUserHomeDir, 1)
+		return p
 	}
 
 	// lookup user to figure out Home Directory

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -51,7 +51,7 @@ type KernelVersion struct {
 
 func parseKernelVersion(v []byte) (*KernelVersion, error) {
 
-	re := regexp.MustCompile(`(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Revision>\d+)(?P<Remainder>\S+)`)
+	re := regexp.MustCompile(`(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Revision>\d+)(?P<Remainder>.+)`)
 
 	matches := re.FindSubmatch(v)
 

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -29,6 +29,7 @@ func IsKernelModuleLoaded(name string) (bool, error) {
 
 const kernelOSReleasePath = "/proc/sys/kernel/osrelease"
 
+// GetKernelVersion returns the parsed OS kernel version.
 func GetKernelVersion() (*KernelVersion, error) {
 	ver, err := os.ReadFile(kernelOSReleasePath)
 	if err != nil {
@@ -37,7 +38,7 @@ func GetKernelVersion() (*KernelVersion, error) {
 
 	log.Debugf("kernel version: %s", string(ver))
 
-	return ParseKernelVersion(ver)
+	return parseKernelVersion(ver)
 }
 
 // KernelVersion holds the parsed OS kernel version.
@@ -48,7 +49,7 @@ type KernelVersion struct {
 	Remainder string // the rest of the version string, e.g. "-amd64"
 }
 
-func ParseKernelVersion(v []byte) (*KernelVersion, error) {
+func parseKernelVersion(v []byte) (*KernelVersion, error) {
 
 	re := regexp.MustCompile(`(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Revision>\d+)(?P<Remainder>\S+)`)
 

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -2,8 +2,12 @@ package utils
 
 import (
 	"bufio"
+	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 // IsKernelModuleLoaded checks if a kernel module is loaded by parsing /proc/modules file.
@@ -20,4 +24,80 @@ func IsKernelModuleLoaded(name string) (bool, error) {
 		}
 	}
 	return false, f.Close()
+}
+
+func GetKernelVersion() (*KernelVersion, error) {
+	var uts syscall.Utsname
+	syscall.Uname(&uts)
+	return ParseKernelVersion(charsToString(uts.Release[:]))
+
+}
+
+func charsToString(chars []int8) string {
+	var sb strings.Builder
+	for _, c := range chars {
+		if c == '\x00' {
+			break
+		}
+		sb.WriteByte(byte(c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+type KernelVersion struct {
+	Major    int
+	Minor    int
+	Revision int
+	Remains  string
+}
+
+func ParseKernelVersion(v string) (*KernelVersion, error) {
+	var err error
+	r := regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(.*)`)
+
+	split := r.FindStringSubmatch(v)
+
+	if len(split) > 5 && len(split) < 4 {
+		return nil, fmt.Errorf("unable to parse %q as kernel version", v)
+	}
+
+	// remove the full string which is store in position [0]
+	split = split[1:]
+
+	versionParts := make([]int, 3)
+	for i, v := range split[:2] {
+		versionParts[i], err = strconv.Atoi(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	result := &KernelVersion{
+		Major:    versionParts[0],
+		Minor:    versionParts[1],
+		Revision: versionParts[2],
+	}
+	if len(split) == 4 {
+		result.Remains = split[3]
+	}
+	return result, nil
+}
+
+// StringMMR returns the Kernel version in <Major>.<Minor>.<Revision>
+func (kv *KernelVersion) StringMMR() string {
+	return fmt.Sprintf("%d.%d.%d", kv.Major, kv.Minor, kv.Revision)
+}
+
+func (kv *KernelVersion) IsGreaterEqual(cmpKv *KernelVersion) bool {
+	if kv.Major < cmpKv.Major {
+		return false
+	}
+	if kv.Minor < cmpKv.Minor {
+		return false
+	}
+	// this must be >= because we're implementing GreaterEqual
+	// and this is the last position
+	if kv.Revision < cmpKv.Revision {
+		return false
+	}
+	return true
 }

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -50,8 +50,8 @@ type KernelVersion struct {
 }
 
 func parseKernelVersion(v []byte) (*KernelVersion, error) {
-
-	re := regexp.MustCompile(`(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Revision>\d+)(?P<Remainder>.+)`)
+	// https: //regex101.com/r/cWqad0/1
+	re := regexp.MustCompile(`(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Revision>\d+)(?P<Remainder>.*)`)
 
 	matches := re.FindSubmatch(v)
 
@@ -74,6 +74,7 @@ func (kv *KernelVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d", kv.Major, kv.Minor, kv.Revision)
 }
 
+// GreaterOrEqual returns true if the Kernel version is greater or equal to the compared Kernel version.
 func (kv *KernelVersion) GreaterOrEqual(cmpKv *KernelVersion) bool {
 	if kv.Major < cmpKv.Major {
 		return false
@@ -86,5 +87,6 @@ func (kv *KernelVersion) GreaterOrEqual(cmpKv *KernelVersion) bool {
 	if kv.Revision < cmpKv.Revision {
 		return false
 	}
+
 	return true
 }

--- a/utils/kernel_module_test.go
+++ b/utils/kernel_module_test.go
@@ -53,7 +53,7 @@ func TestParseKernelVersion(t *testing.T) {
 		expectErr bool
 		expected  *KernelVersion
 	}{
-		{[]byte("123.45.6789 example"), false, &KernelVersion{Major: 123, Minor: 45, Revision: 6789, Remainder: "example"}},
+		{[]byte("123.45.6789 example"), false, &KernelVersion{Major: 123, Minor: 45, Revision: 6789, Remainder: " example"}},
 		{[]byte("1.2.3-abc"), false, &KernelVersion{Major: 1, Minor: 2, Revision: 3, Remainder: "-abc"}},
 		{[]byte("invalid"), true, nil},
 		{[]byte(""), true, nil},

--- a/utils/kernel_module_test.go
+++ b/utils/kernel_module_test.go
@@ -1,6 +1,10 @@
 package utils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestIsKernelModuleLoaded(t *testing.T) {
 	type args struct {
@@ -40,5 +44,54 @@ func TestIsKernelModuleLoaded(t *testing.T) {
 				t.Errorf("IsKernelModuleLoaded() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseKernelVersion(t *testing.T) {
+	tests := []struct {
+		input     []byte
+		expectErr bool
+		expected  *KernelVersion
+	}{
+		{[]byte("123.45.6789 example"), false, &KernelVersion{Major: 123, Minor: 45, Revision: 6789, Remainder: "example"}},
+		{[]byte("1.2.3-abc"), false, &KernelVersion{Major: 1, Minor: 2, Revision: 3, Remainder: "-abc"}},
+		{[]byte("invalid"), true, nil},
+		{[]byte(""), true, nil},
+	}
+
+	for _, test := range tests {
+		result, err := parseKernelVersion(test.input)
+
+		if (err != nil) != test.expectErr {
+			t.Errorf("Error expectation mismatch. Input: %s, Expected Error: %v, Actual Error: %v", test.input, test.expectErr, err)
+		}
+
+		if d := cmp.Diff(result, test.expected); d != "" {
+			t.Errorf("parseKernelVersion got = %+v, want %+v; Diff: %s", result, test.expected, d)
+		}
+	}
+}
+
+func TestKernelVersionGreaterOrEqual(t *testing.T) {
+	tests := []struct {
+		version      *KernelVersion
+		compare      *KernelVersion
+		expectResult bool
+	}{
+		{&KernelVersion{Major: 1, Minor: 2, Revision: 3}, &KernelVersion{Major: 1, Minor: 2, Revision: 3}, true},
+		{&KernelVersion{Major: 1, Minor: 2, Revision: 3}, &KernelVersion{Major: 1, Minor: 2, Revision: 2}, true},
+		{&KernelVersion{Major: 1, Minor: 2, Revision: 3}, &KernelVersion{Major: 1, Minor: 3, Revision: 3}, false},
+		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 1, Minor: 2, Revision: 3}, true},
+		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 3, Minor: 4, Revision: 5}, false},
+		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 2, Minor: 3, Revision: 5}, false},
+	}
+
+	for _, test := range tests {
+		result := test.version.GreaterOrEqual(test.compare)
+
+		if result != test.expectResult {
+			t.Errorf("Result mismatch. Version: %+v, Compare: %+v, Expected: %v, Actual: %v",
+				test.version, test.compare, test.expectResult, result)
+		}
 	}
 }


### PR DESCRIPTION
Check the host kernel version and compare it to the SRL required minimum version.
If the minimum requirement is not met, we log a warning. 