### PR TITLE
allow for zero length partial config

### DIFF
--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -192,6 +192,16 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName, use
 	var err error
 	var d *network.Driver
 
+	configContent, err := utils.ReadFileContent(configFile)
+	if err != nil {
+		return err
+	}
+
+	// check file contains content, otherwise exit early
+	if len(strings.TrimSpace(string(configContent))) == 0 {
+		return nil
+	}
+
 	for loop := true; loop; {
 		if !s.isHealthy(ctx) {
 			time.Sleep(5 * time.Second) // cool-off period


### PR DESCRIPTION
If in the course of building a lab, you want to already point to a partial config, which is being filled later on, probably with the use of the lab itself (configuring single node via cli and adapting to other nodes ...) This will prevent the call to scrapligo and return a nil error instead of right now resulting in a panic.
Which in both cases makes the deployment fail.