### PR TITLE
Allow more specific bind mounts overwrite 

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -244,7 +244,10 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 	nodeCfg.License = utils.ResolvePath(p, c.TopoPaths.TopologyFileDir())
 
 	// initialize bind mounts
-	binds := c.Config.Topology.GetNodeBinds(nodeName)
+	binds, err := c.Config.Topology.GetNodeBinds(nodeName)
+	if err != nil {
+		return nil, err
+	}
 	err = c.resolveBindPaths(binds, nodeCfg.LabDir)
 	if err != nil {
 		return nil, err

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -257,6 +257,8 @@ topology:
 
 Binds defined on multiple levels (defaults -> kind -> node) will be merged with the duplicated values removed (the lowest level takes precedence).
 
+When a bind with the same destination is defined on multiple levels, the lowest level takes precedence. This allows to override the binds defined on the higher levels.
+
 ### ports
 
 To bind the ports between the lab host and the containers the users can populate the `ports` object inside the node:

--- a/types/bind.go
+++ b/types/bind.go
@@ -48,5 +48,10 @@ func (b *Bind) Mode() string {
 
 // String returns the bind mount as a string.
 func (b *Bind) String() string {
-	return fmt.Sprintf("%s:%s:%s", b.src, b.dst, b.mode)
+	s := fmt.Sprintf("%s:%s", b.src, b.dst)
+	if b.mode != "" {
+		s += fmt.Sprintf(":%s", b.mode)
+	}
+
+	return s
 }

--- a/types/bind.go
+++ b/types/bind.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Bind represents a bind mount.
+type Bind struct {
+	src  string
+	dst  string
+	mode string
+}
+
+// NewBind creates a new bind mount.
+func NewBind(bind string) (*Bind, error) {
+	b := &Bind{}
+
+	split := strings.Split(bind, ":")
+	if len(split) < 2 || len(split) > 3 {
+		return nil, fmt.Errorf("unable to parse bind %q", bind)
+	}
+
+	b.src = split[0]
+	b.dst = split[1]
+
+	if len(split) == 3 {
+		b.mode = split[2]
+	}
+
+	return b, nil
+}
+
+// Src returns the source path of the bind mount.
+func (b *Bind) Src() string {
+	return b.src
+}
+
+// Dst returns the destination path of the bind mount.
+func (b *Bind) Dst() string {
+	return b.dst
+}
+
+// Mode returns the mode of the bind mount.
+func (b *Bind) Mode() string {
+	return b.mode
+}
+
+// String returns the bind mount as a string.
+func (b *Bind) String() string {
+	return fmt.Sprintf("%s:%s:%s", b.src, b.dst, b.mode)
+}

--- a/types/topology.go
+++ b/types/topology.go
@@ -84,7 +84,7 @@ func (t *Topology) GetNodeBinds(name string) ([]string, error) {
 					return nil, err
 				}
 				// add to the map
-				binds[b.GetDst()] = b
+				binds[b.Dst()] = b
 			}
 		}
 

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -161,10 +161,13 @@ var topologyTestSet = map[string]struct {
 	"node_kind_default": {
 		input: &Topology{
 			Defaults: &NodeDefinition{
-				Kind:  "srl",
-				User:  "user1",
-				CPU:   1,
-				Binds: []string{"x:z"},
+				Kind: "srl",
+				User: "user1",
+				CPU:  1,
+				Binds: []string{
+					"x:z",
+					"m:n", // overriden by node
+				},
 			},
 			Kinds: map[string]*NodeDefinition{
 				"srl": {
@@ -205,7 +208,10 @@ var topologyTestSet = map[string]struct {
 			},
 			Nodes: map[string]*NodeDefinition{
 				"node1": {
-					Binds: []string{"e:f"},
+					Binds: []string{
+						"e:f",
+						"newm:n",
+					},
 				},
 			},
 		},
@@ -229,6 +235,7 @@ var topologyTestSet = map[string]struct {
 					"a:b",
 					"c:d",
 					"x:z",
+					"newm:n",
 				},
 				Ports: []string{
 					"80:8080",
@@ -489,9 +496,8 @@ func TestGetNodeUser(t *testing.T) {
 }
 
 func TestGetNodeBinds(t *testing.T) {
-	for name, item := range topologyTestSet {
+	for _, item := range topologyTestSet {
 		binds, _ := item.input.GetNodeBinds("node1")
-		t.Logf("%q test item result: %v", name, binds)
 
 		// sort the slices so we can compare them
 		slices.Sort(binds)

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/exp/slices"
 )
 
 func boolptr(b bool) *bool {
@@ -489,14 +490,15 @@ func TestGetNodeUser(t *testing.T) {
 
 func TestGetNodeBinds(t *testing.T) {
 	for name, item := range topologyTestSet {
-		t.Logf("%q test item", name)
 		binds, _ := item.input.GetNodeBinds("node1")
 		t.Logf("%q test item result: %v", name, binds)
-		if !cmp.Equal(item.want["node1"].Binds, binds) {
-			t.Errorf("item %q failed", name)
-			t.Errorf("item %q exp %q", name, item.want["node1"].Binds)
-			t.Errorf("item %q got %q", name, binds)
-			t.Fail()
+
+		// sort the slices so we can compare them
+		slices.Sort(binds)
+		slices.Sort(item.want["node1"].Binds)
+
+		if d := cmp.Diff(binds, item.want["node1"].Binds); d != "" {
+			t.Fatalf("Binds resolve failed.\nGot: %q\nWant: %q\nDiff\n%s", binds, item.want["node1"].Binds, d)
 		}
 	}
 }

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -490,7 +490,7 @@ func TestGetNodeUser(t *testing.T) {
 func TestGetNodeBinds(t *testing.T) {
 	for name, item := range topologyTestSet {
 		t.Logf("%q test item", name)
-		binds := item.input.GetNodeBinds("node1")
+		binds, _ := item.input.GetNodeBinds("node1")
 		t.Logf("%q test item result: %v", name, binds)
 		if !cmp.Equal(item.want["node1"].Binds, binds) {
 			t.Errorf("item %q failed", name)

--- a/types/types.go
+++ b/types/types.go
@@ -323,39 +323,3 @@ func ParsePullPolicyValue(s string) PullPolicyValue {
 	// default to IfNotPresent
 	return PullPolicyIfNotPresent
 }
-
-type Bind struct {
-	src   string
-	dst   string
-	rwmod string
-}
-
-func NewBind(bind string) (*Bind, error) {
-	result := &Bind{}
-	split := strings.Split(bind, ":")
-	if len(split) < 2 || len(split) > 3 {
-		return nil, fmt.Errorf("unable to parse bind %q", bind)
-	}
-	result.src = split[0]
-	result.dst = split[1]
-	if len(split) == 3 {
-		result.rwmod = split[2]
-	}
-	return result, nil
-}
-
-func (b *Bind) GetSrc() string {
-	return b.src
-}
-
-func (b *Bind) GetDst() string {
-	return b.dst
-}
-
-func (b *Bind) GetRWMode() string {
-	return b.rwmod
-}
-
-func (b *Bind) String() string {
-	return fmt.Sprintf("%s:%s:%s", b.src, b.dst, b.rwmod)
-}

--- a/types/types.go
+++ b/types/types.go
@@ -323,3 +323,39 @@ func ParsePullPolicyValue(s string) PullPolicyValue {
 	// default to IfNotPresent
 	return PullPolicyIfNotPresent
 }
+
+type Bind struct {
+	src   string
+	dst   string
+	rwmod string
+}
+
+func NewBind(bind string) (*Bind, error) {
+	result := &Bind{}
+	split := strings.Split(bind, ":")
+	if len(split) < 2 || len(split) > 3 {
+		return nil, fmt.Errorf("unable to parse bind %q", bind)
+	}
+	result.src = split[0]
+	result.dst = split[1]
+	if len(split) == 3 {
+		result.rwmod = split[2]
+	}
+	return result, nil
+}
+
+func (b *Bind) GetSrc() string {
+	return b.src
+}
+
+func (b *Bind) GetDst() string {
+	return b.dst
+}
+
+func (b *Bind) GetRWMode() string {
+	return b.rwmod
+}
+
+func (b *Bind) String() string {
+	return fmt.Sprintf("%s:%s:%s", b.src, b.dst, b.rwmod)
+}


### PR DESCRIPTION
Allow bind mounts to be overwritten destination wise on more specific levels

Default -> Kind -> Node

addressing #1445