### PR TITLE
Link impairment via `tools` commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tests/out
 # ignore clab backup topo files in test directories
 clab/test_data/*.bak
 tests/**/*.bak
+**/*.clab.yml.bak

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ serve-insiders:
 serve-insiders-dirty:
 	docker run -it --rm -p 8001:8000 -v $(CURDIR):/docs ghcr.io/srl-labs/mkdocs-material-insiders:$(MKDOCS_INS_VER) serve -a 0.0.0.0:8000 --dirtyreload
 
+# alias to servce-insiders-dirty
+.PHONY: serve-docs
+serve-docs: serve-insiders-dirty
+
 .PHONY: htmltest
 htmltest:
 	docker run --rm -v $(CURDIR):/docs squidfunk/mkdocs-material:$(MKDOCS_VER) build --clean --strict

--- a/docs/manual/netem.md
+++ b/docs/manual/netem.md
@@ -1,0 +1,73 @@
+# Link Impairment
+
+Being able to introduce link impairments such as delay, jitter, and packet loss, is quite a useful feature for testing network applications. It allows testing the application behavior under different network conditions and simulate different network properties. For example, making a network link more lossy can be used to simulate a wireless or congested link, while adding delay and jitter can be used to simulate a satellite link.
+
+The Linux kernel has a built-in traffic control tool called `tc` which can be used to configure network emulation. The `tc` tool is powerful, but it can be difficult to use, especially when links you want to apply impairments to belong to a container process.
+
+To simplify the process of configuring network emulation, we are providing a small shell script that orchestrates the [`alexei-led/pumba`](https://github.com/alexei-led/pumba) tool that applies different network impairments to containeres' links.
+
+<div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:13,&quot;zoom&quot;:2,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/impairments.drawio&quot;}"></div>
+
+Link impairments can be applied to any container link, as the diagram above shows. This allows to granularly control the network conditions for each link in the topology and implement complex network impairment scenarios. One caveat with the current implementation is that users have to use another tool for adding impairments to the Linux bridges, see [Linux bridge](#linux-bridge) section for more details.
+
+## Pre-requisites
+
+In the spirit of containerlab, we try to use containerized applications whenever possible. The [`netem.sh` script](#netemsh-script) that we use to orchestrate link impairments uses containerized tools, so there are no pre-requisites to install on the host machine.
+
+### Lab setup
+
+We will demonstrate the usage of the [`netem.sh` script](#netemsh-script) on a simple topology with two Linux containers connected back-to-back over their `eth1` interfaces. The following topology file will be used:
+
+```yaml
+name: netem
+topology:
+  nodes:
+    r1:
+      kind: linux
+      image: alpine:3
+      exec:
+        - ip addr add 192.168.0.1/30 dev eth1
+    r2:
+      kind: linux
+      image: alpine:3
+      exec:
+        - ip addr add 192.168.0.2/30 dev eth1
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+```
+
+When the lab is deployed, we can ensure that `r1` can ping `r2` and the reported round-trip time corresponds to an unaffected direct link:
+
+```
+❯ docker exec -it clab-netem-r1 ping 192.168.0.2
+PING 192.168.0.2 (192.168.0.2): 56 data bytes
+64 bytes from 192.168.0.2: seq=0 ttl=64 time=0.086 ms
+64 bytes from 192.168.0.2: seq=1 ttl=64 time=0.086 ms
+64 bytes from 192.168.0.2: seq=2 ttl=64 time=0.064 ms
+^C
+--- 192.168.0.2 ping statistics ---
+3 packets transmitted, 3 packets received, 0% packet loss
+round-trip min/avg/max = 0.064/0.078/0.086 ms
+```
+
+Users are free to use any other topology for their experiments if desired.
+
+### Get the `netem.sh` script
+
+The [`netem.sh`](https://github.com/srl-labs/containerlab/blob/main/docs/manual/netem.sh) script is a wrapper around the [`pumba`](https://github.com/alexei-led/pumba) tool that allows to apply different network impairments to container links. It is meant to be customized by the users while having some basic impairments readily available.
+
+???tip "Script content"
+    ```bash
+    --8<-- "docs/manual/netem.sh"
+    ```
+
+Feel free to either copy the contents of the script to your own file or download it from the repository.
+
+```bash
+curl -LO https://raw.githubusercontent.com/srl-labs/containerlab/main/docs/manual/netem.sh
+chmod +x netem.sh
+```
+
+## Usage
+
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/manual/netem.sh
+++ b/docs/manual/netem.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# this is an example of a bash script that can be used to introduce network impairments
+
+
+set -o errexit
+set -o pipefail
+
+# change this to your own lab name (this is clab-<labname>)
+LAB_NAME="clab-netem"
+
+# default values, overridden by command-line arguments
+cmd="" # command to be executed, one of [delay]
+node=""
+interface=""
+time="100" # default time delay is 100ms
+jitter=""
+correlation=""
+distribution=""
+percent="0"
+duration="8760h" # 1 year duration by default
+
+# -----------------------------------------------------------------------------
+# Helper functions.
+# -----------------------------------------------------------------------------
+
+# usage examples
+DELAY_USAGE="Usage: ./netem.sh delay -n <container name without lab prefix> -i <inteface-name> [-t <delay in ms>] [-d <impairment duration with ms/s/m/h suffix (default is 8760h)>] [-j <jitter in ms>] [-c <correlation>] [-r <distribution>]"
+LOSS_USAGE="Usage: ./netem.sh delay -n <container name without lab prefix> -i <inteface-name> [-p <loss percent>] [-c <correlation>]"
+
+# Read command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--node)
+            node="$2"
+            shift 2
+            ;;
+        -i|--interface)
+            interface="$2"
+            shift 2
+            ;;
+        -t|--time)
+            time="$2"
+            shift 2
+            ;;
+        -j|--jitter)
+            jitter="$2"
+            shift 2
+            ;;
+        -c|--correlation)
+            correlation="$2"
+            shift 2
+            ;;
+        -r|--distribution)
+            distribution="$2"
+            shift 2
+            ;;
+        -p|--percent)
+            percent="$2"
+            shift 2
+            ;;
+        -d|--duration)
+            duration="$2"
+            shift 2
+            ;;
+        delay)
+            cmd="delay"
+            shift 1
+            ;;
+        loss)
+            cmd="loss"
+            shift 1
+            ;;
+        stop-all)
+            cmd="stop-all"
+            shift 1
+            ;;
+        *)
+            echo "Unknown flag: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# netem functions.
+# Allowed to be customized by a user.
+# -----------------------------------------------------------------------------
+
+# introduce a delay on a selected link for a selected container
+function delay {
+    check-mandatory-parameters ${DELAY_USAGE}
+
+    handle_optional_parameters
+
+    echo "Starting delay function for node \"${node}:${interface}\" with time=${time}ms ${JITTER_ECHO} ${CORRELATION_ECHO} ${DISTRIBUTION_ECHO}"
+
+    sudo docker run -d --name netem-${LAB_NAME}-${RANDOM} -it --rm -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba \
+        netem --tc-image ghcr.io/srl-labs/iproute2 --duration ${duration} --interface ${interface} \
+        delay --time ${time} \
+            ${JITTER_FLAGS} ${CORRELATION_FLAGS} ${DISTRIBUTION_FLAGS} \
+            ${LAB_NAME}-${node} > /dev/null
+}
+
+# introduce a packet loss on a selected link for a selected container
+function loss {
+    check-mandatory-parameters ${LOSS_USAGE}
+
+    handle_optional_parameters
+
+    echo "Starting loss function for node \"${node}:${interface}\" with percent=${percent}% ${CORRELATION_ECHO}"
+
+    sudo docker run --name netem-${LAB_NAME}-${RANDOM} -it --rm -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba \
+        netem --tc-image ghcr.io/srl-labs/iproute2 --duration ${duration} --interface ${interface} \
+        loss --percent ${percent} \
+            ${CORRELATION_FLAGS} \
+            ${LAB_NAME}-${node} > /dev/null
+}
+
+# remove all network emulation containers effectively stopping all link impairments
+# started by this script.
+function stop-all {
+    sudo docker ps -a -q -f name="netem-${LAB_NAME}" | xargs -n1 sudo docker stop
+}
+
+function check-mandatory-parameters {
+    if [[ -z $node ]]; then
+    echo "Error: Node is not set or empty.\nUsage: $1"
+    exit 1
+    fi
+
+    if [[ -z $interface ]]; then
+        echo "Error: Node is not set or empty.\nUsage: $1"
+        exit 1
+    fi
+}
+
+# handling optional parameters
+function handle_optional_parameters {
+    if [[ ! -z $jitter ]]; then
+        JITTER_FLAGS="--jitter ${jitter}" # flag/value to append to the command
+        JITTER_ECHO="jitter=${jitter}ms" # echo to print
+    fi
+
+    if [[ ! -z $correlation ]]; then
+        CORRELATION_FLAGS="--correlation ${correlation}"
+        CORRELATION_ECHO="correlation=${correlation}"
+    fi
+
+    if [[ ! -z $distribution ]]; then
+        DISTRIBUTION_FLAGS="--distribution ${distribution}"
+        DISTRIBUTION_ECHO="distribution=${distribution}"
+    fi
+}
+
+# invoke the command
+${cmd}
+
+
+# -----------------------------------------------------------------------------
+# Bash runner functions.
+# -----------------------------------------------------------------------------
+function help {
+  printf "%s <task> [args]\n\nTasks:\n" "${0}"
+
+  compgen -A function | grep -v "^_" | cat -n
+
+  printf "\nExtended help:\n  Each task has comments for general usage\n"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Packet capture & Wireshark: manual/wireshark.md
       - VM based routers integration: manual/vrnetlab.md
       - Node filtering: manual/node-filtering.md
+      - Link impairment: manual/netem.md
       - Publish ports: manual/published-ports.md
       - Multi-node labs: manual/multi-node.md
       - Certificate management: manual/cert.md


### PR DESCRIPTION
Hi @steiler 
I've been prototyping link impairment support by introducing a `netem.sh` script that under the hood calls `gaiaadm/pumba` container that tunes `tc` rules.

The script, that is part of this PR, has two subcommands:

* `netem.sh delay` - to tune delay, jitter
* `netem.sh loss` - to tune packet loss

The example usage is

```bash
# where r1 is a node name
# t - delay time in ms
# d - impairment duration
# j - jitter
docs/manual/netem.sh delay -n r1 -i eth1 -t 200 -d 5s -j 20
```

This works well, but as I started to play with it, I realized that it would be great to actually ditch the script and pack it under `clab tools netem` command tree:

* `tools netem delay`
* `tools netem loss`

I think for starters the commands might just call the same container as per the netem.sh script, to make it easy. Maybe it is worth adding `tc` package and do this neatly, but I am ok with using os.Exec and calling the commands.

Would you be willing to work on that?