### PR TITLE
Allow setting `eth0` interfaces manually with `network-mode:none`

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -595,9 +595,6 @@ func checkEndpoint(e string) error {
 	if len(split) != 2 {
 		return fmt.Errorf("malformed endpoint definition: %s", e)
 	}
-	if split[1] == "eth0" {
-		return fmt.Errorf("eth0 interface can't be used in the endpoint definition as it is added by docker automatically: '%s'", e)
-	}
 	return nil
 }
 

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -375,6 +375,32 @@ This is best illustrated with the following diagram:
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:14,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/containerlab.drawio&quot;}"></div>
 
+### Manual control over the management network
+
+By default containerlab creates a docker network named `clab` and attaches all the nodes to this network. This network is used as a management network for the nodes and is managed by the container runtime such as docker or podman.
+
+Container runtime is responsible for creating the `eth0` interface inside the container and attaching it to the `clab` network. This interface is used by the container to communicate with the management network. For that reason the links users create in the topology's `links` section typically do not include the `eth0` interface.
+
+However, there might be cases when users want to take control over `eth0` interface management. For example, they might want to connect `eth0` to a different network or even another container's interface. To achieve that, users can instruct container runtime to not manage the `eth0` interface and leave it to the user, using [`network-mode: none`](nodes.md#network-mode) setting.
+
+Consider the following example, where node1's management interface `eth0` is provided in the `links` section and connects to node2's `eth1` interface:
+
+```yaml
+name: e0
+
+topology:
+  nodes:
+    node1:
+      kind: linux
+      image: alpine:3
+      network-mode: none
+    node2:
+      kind: linux
+      image: alpine:3
+  links:
+    - endpoints: ["node1:eth0", "node2:eth1"]
+```
+
 ## DNS
 
 When containerlab finishes the nodes deployment, it also creates static DNS entries inside the `/etc/hosts` file so that users can access the nodes using their DNS names.

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -352,10 +352,10 @@ topology:
     entrypoint: entrypoint.sh
   kinds:
     srl:
-      cmd: entrypoint.sh
+      entrypoint: entrypoint.sh
   nodes:
     node1:
-      cmd: entrypoint.sh
+      entrypoint: entrypoint.sh
 ```
 
 ### cmd

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -6,6 +6,8 @@ package linux
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/nodes"
@@ -87,7 +89,13 @@ func (n *linux) GetImages(_ context.Context) map[string]string {
 	return images
 }
 
-// CheckInterfaceName is a noop for linux containers as they can have any names.
+// CheckInterfaceName on linux we just need to change that if eth0 is supposed to be set, the Network mode is set to "none"
 func (n *linux) CheckInterfaceName() error {
+	NodeNwMode := strings.ToLower(n.Cfg.NetworkMode)
+	for _, e := range n.Config().Endpoints {
+		if e.EndpointName == "eth0" && NodeNwMode != "none" {
+			return fmt.Errorf("eth0 is meant to be the mgmt interface injected by the container runtime. To manually inject eth0 set the 'network-mode' for the node to 'none', which allows you also assigning eth0")
+		}
+	}
 	return nil
 }

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -89,12 +89,13 @@ func (n *linux) GetImages(_ context.Context) map[string]string {
 	return images
 }
 
-// CheckInterfaceName on linux we just need to change that if eth0 is supposed to be set, the Network mode is set to "none"
+// CheckInterfaceName allows any interface name for linux nodes, but checks
+// if eth0 is only used with network-mode=none.
 func (n *linux) CheckInterfaceName() error {
-	NodeNwMode := strings.ToLower(n.Cfg.NetworkMode)
+	nm := strings.ToLower(n.Cfg.NetworkMode)
 	for _, e := range n.Config().Endpoints {
-		if e.EndpointName == "eth0" && NodeNwMode != "none" {
-			return fmt.Errorf("eth0 is meant to be the mgmt interface injected by the container runtime. To manually inject eth0 set the 'network-mode' for the node to 'none', which allows you also assigning eth0")
+		if e.EndpointName == "eth0" && nm != "none" {
+			return fmt.Errorf("eth0 interface name is not allowed for %s node when network mode is not set to none", n.Cfg.ShortName)
 		}
 	}
 	return nil

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -644,7 +644,7 @@ func (s *srl) populateHosts(ctx context.Context, nodes map[string]nodes.Node) er
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (s *srl) CheckInterfaceName() error {
-	// allow eX-X-X and eth0 interface names
+	// allow eX-X-X and mgmt0 interface names
 	ifRe := regexp.MustCompile(`e\d+-\d+(-\d+)?|mgmt0`)
 	nm := strings.ToLower(s.Cfg.NetworkMode)
 

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -57,7 +57,7 @@ set / system lldp admin-state enable
 set / system aaa authentication idle-timeout 7200
 {{/* enabling interfaces referenced as endpoints for a node (both e1-2 and e1-3-1 notations) */}}
 {{- range $ep := .Endpoints }}
-{{- if eq $ep.EndpointName "eth0" }}{{- continue }}{{- end}}
+{{- if eq $ep.EndpointName "mgmt0" }}{{- continue }}{{- end}}
 {{- $parts := ($ep.EndpointName | strings.ReplaceAll "e" "" | strings.Split "-") -}}
 set / interface ethernet-{{index $parts 0}}/{{index $parts 1}} admin-state enable
   {{- if eq (len $parts) 3 }}
@@ -645,7 +645,7 @@ func (s *srl) populateHosts(ctx context.Context, nodes map[string]nodes.Node) er
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (s *srl) CheckInterfaceName() error {
 	// allow eX-X-X and eth0 interface names
-	ifRe := regexp.MustCompile(`e\d+-\d+(-\d+)?|eth0`)
+	ifRe := regexp.MustCompile(`e\d+-\d+(-\d+)?|mgmt0`)
 	nm := strings.ToLower(s.Cfg.NetworkMode)
 
 	for _, e := range s.Config().Endpoints {
@@ -653,8 +653,8 @@ func (s *srl) CheckInterfaceName() error {
 			return fmt.Errorf("nokia sr linux interface name %q doesn't match the required pattern. SR Linux interfaces should be named as e1-1 or e1-1-1", e.EndpointName)
 		}
 
-		if e.EndpointName == "eth0" && nm != "none" {
-			return fmt.Errorf("eth0 interface name is not allowed for %s node when network mode is not set to none", s.Cfg.ShortName)
+		if e.EndpointName == "mgmt0" && nm != "none" {
+			return fmt.Errorf("mgmt0 interface name is not allowed for %s node when network mode is not set to none", s.Cfg.ShortName)
 		}
 	}
 

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -644,14 +644,17 @@ func (s *srl) populateHosts(ctx context.Context, nodes map[string]nodes.Node) er
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (s *srl) CheckInterfaceName() error {
+	// allow eX-X-X and eth0 interface names
 	ifRe := regexp.MustCompile(`e\d+-\d+(-\d+)?|eth0`)
-	NodeNwMode := strings.ToLower(s.Cfg.NetworkMode)
+	nm := strings.ToLower(s.Cfg.NetworkMode)
+
 	for _, e := range s.Config().Endpoints {
 		if !ifRe.MatchString(e.EndpointName) {
 			return fmt.Errorf("nokia sr linux interface name %q doesn't match the required pattern. SR Linux interfaces should be named as e1-1 or e1-1-1", e.EndpointName)
 		}
-		if e.EndpointName == "eth0" && NodeNwMode != "none" {
-			return fmt.Errorf("eth0 is meant to be the mgmt interface injected by the container runtime. To manually inject eth0 set the 'network-mode' for the node to 'none', which allows you also assigning eth0")
+
+		if e.EndpointName == "eth0" && nm != "none" {
+			return fmt.Errorf("eth0 interface name is not allowed for %s node when network mode is not set to none", s.Cfg.ShortName)
 		}
 	}
 

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -255,7 +255,7 @@
                     "type": "string",
                     "description": "node network mode (can only be set host, defaults to bridge)",
                     "markdownDescription": "node [network mode](https://containerlab.dev/manual/nodes/#network-mode) (can only be set host, defaults to bridge)",
-                    "pattern": "^(host)|(container:\\S+)$"
+                    "pattern": "^(host)|(container:\\S+)|(none)$"
                 },
                 "cpu": {
                     "type": "integer",


### PR DESCRIPTION
This PR lifts the eth0 restriction as requested in #1454.
We rely on the interface name check function now to check for eth0.
On `linux` and `SRL` we allow eth0 to be used in the case of their `network-mode` being set to `none`.