### PR TITLE
fix kernel version check logic

### DIFF
--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -78,9 +78,14 @@ func (kv *KernelVersion) String() string {
 func (kv *KernelVersion) GreaterOrEqual(cmpKv *KernelVersion) bool {
 	if kv.Major < cmpKv.Major {
 		return false
+	} else if kv.Major > cmpKv.Major {
+		return true
 	}
+
 	if kv.Minor < cmpKv.Minor {
 		return false
+	} else if kv.Minor > cmpKv.Minor {
+		return true
 	}
 	// this must be >= because we're implementing GreaterEqual
 	// and this is the last position

--- a/utils/kernel_module_test.go
+++ b/utils/kernel_module_test.go
@@ -82,6 +82,8 @@ func TestKernelVersionGreaterOrEqual(t *testing.T) {
 		{&KernelVersion{Major: 1, Minor: 2, Revision: 3}, &KernelVersion{Major: 1, Minor: 2, Revision: 2}, true},
 		{&KernelVersion{Major: 1, Minor: 2, Revision: 3}, &KernelVersion{Major: 1, Minor: 3, Revision: 3}, false},
 		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 1, Minor: 2, Revision: 3}, true},
+		{&KernelVersion{Major: 2, Minor: 1, Revision: 1}, &KernelVersion{Major: 1, Minor: 2, Revision: 3}, true},
+		{&KernelVersion{Major: 2, Minor: 3, Revision: 1}, &KernelVersion{Major: 2, Minor: 2, Revision: 3}, true},
 		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 3, Minor: 4, Revision: 5}, false},
 		{&KernelVersion{Major: 2, Minor: 3, Revision: 4}, &KernelVersion{Major: 2, Minor: 3, Revision: 5}, false},
 	}


### PR DESCRIPTION
Current comparison function for kernel ver check returns wrong results for cases where major version is > than required but minor is < than required (e.g. 6.0.1 will return a false result against 4.10.2).
This is the simplest fix