### PR TITLE
allow exec on host

### DIFF
--- a/docs/manual/kinds/host.md
+++ b/docs/manual/kinds/host.md
@@ -1,0 +1,21 @@
+---
+search:
+  boost: 4
+---
+
+# Host
+
+A node of kind `host` represents the containerlab host the labs are running on. It is a special node that is implicitly used when nodes have links connected to the host - see [host links](../network.md#host-links).
+
+But there is a use case when users might want to define the node of kind `host` explicitly in the topology. For example, when some commands need to be executed on the host for the lab to function.
+
+In such case, the following topology definition can be used:
+
+```yaml
+h1:
+  kind: host
+  exec:
+    - ip link set dev enp0s3 up
+```
+
+In the above example, the node `h1` is defined as a node of kind `host` and the `exec` option is used to run the command `ip link set dev enp0s3 up` in the containerlab host. Of course, the command can be any other command that is required for the lab to function.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
           - RARE/freeRtr: manual/kinds/rare-freertr.md
           - Openvswitch bridge: manual/kinds/ovs-bridge.md
           - External container: manual/kinds/ext-container.md
+          - Host: manual/kinds/host.md
       - Configuration artifacts: manual/conf-artifacts.md
       - Network wiring concepts: manual/network.md
       - Packet capture & Wireshark: manual/wireshark.md

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -53,6 +53,7 @@ func (*host) WithMgmtNet(*types.MgmtNet)                            {}
 // UpdateConfigWithRuntimeInfo is a noop for hosts.
 func (*host) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }
 
+// getOSRelease returns the OS release of the host by inspecting /etc/*-release.
 func getOSRelease() string {
 	image := "N/A"
 
@@ -64,7 +65,8 @@ func getOSRelease() string {
 	if err != nil {
 		return image
 	}
-
+	// DISTRIB_DESCRIPTION exists in lsb-release, but not os-release.
+	// the lsb-release is coming first in the glob, so it works.
 	re := regexp.MustCompile(`DISTRIB_DESCRIPTION="(.*)"`)
 
 	regexres := re.FindSubmatch(dat)

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -5,10 +5,17 @@
 package host
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"regexp"
 
-	log "github.com/sirupsen/logrus"
+	osexec "os/exec"
+
+	"github.com/srl-labs/containerlab/clab/exec"
 	cExec "github.com/srl-labs/containerlab/clab/exec"
+	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
@@ -47,31 +54,80 @@ func (*host) WithMgmtNet(*types.MgmtNet)                            {}
 // UpdateConfigWithRuntimeInfo is a noop for hosts.
 func (*host) UpdateConfigWithRuntimeInfo(_ context.Context) error { return nil }
 
+func getOSRelease() string {
+	image := "N/A"
+
+	matches, err := filepath.Glob("/etc/*-release")
+	if err != nil {
+		return image
+	}
+	dat, err := os.ReadFile(matches[0])
+	if err != nil {
+		return image
+	}
+
+	re := regexp.MustCompile(`DISTRIB_DESCRIPTION="(.*)"`)
+
+	regexres := re.FindSubmatch(dat)
+
+	return string(regexres[1])
+}
+
 // GetContainers returns a basic skeleton of a container to enable graphing of hosts kinds.
 func (*host) GetContainers(_ context.Context) ([]runtime.GenericContainer, error) {
+
+	image := getOSRelease()
+
 	return []runtime.GenericContainer{
 		{
 			Names:   []string{"Host"},
 			State:   "running",
 			ID:      "N/A",
 			ShortID: "N/A",
-			Image:   "-",
-			Status:  "running",
+			Image:   image,
+			Labels: map[string]string{
+				labels.NodeKind: kindnames[0],
+			},
+			Status: "running",
 			NetworkSettings: runtime.GenericMgmtIPs{
-				IPv4addr: "N/A",
-				IPv4pLen: 0,
-				IPv4Gw:   "N/A",
-				IPv6addr: "N/A",
-				IPv6pLen: 0,
-				IPv6Gw:   "N/A",
+				IPv4addr: "",
+				//IPv4pLen: 0,
+				IPv4Gw:   "",
+				IPv6addr: "",
+				//IPv6pLen: 0,
+				IPv6Gw: "",
 			},
 		},
 	}, nil
 }
 
-// RunExec is a noop for host kind.
-func (n *host) RunExec(_ context.Context, _ *cExec.ExecCmd) (*cExec.ExecResult, error) {
-	log.Warnf("Exec operation is not implemented for kind %q", n.Config().Kind)
+// RunExec runs commands on the container host
+func (n *host) RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
+	// retireve the command with its arguments
+	command := e.GetCmd()
 
-	return nil, cExec.ErrRunExecNotSupported
+	// execute the command along with the context
+	cmd := osexec.CommandContext(ctx, command[0], command[1:]...)
+
+	// create buffers for the output (stdout/stderr)
+	var outBuf, errBuf bytes.Buffer
+
+	// connect stdout and stderr to the buffers
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	// execute the command synchronously
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// create result struct
+	execResult := exec.NewExecResult(e)
+	// set the result fields in the exec struct
+	execResult.SetReturnCode(cmd.ProcessState.ExitCode())
+	execResult.SetStdOut(outBuf.Bytes())
+	execResult.SetStdErr(errBuf.Bytes())
+
+	return execResult, nil
 }

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -101,7 +101,7 @@ func (*host) GetContainers(_ context.Context) ([]runtime.GenericContainer, error
 }
 
 // RunExec runs commands on the container host
-func (n *host) RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
+func (*host) RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
 	// retireve the command with its arguments
 	command := e.GetCmd()
 

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -13,7 +13,6 @@ import (
 
 	osexec "os/exec"
 
-	"github.com/srl-labs/containerlab/clab/exec"
 	cExec "github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/nodes"
@@ -123,7 +122,7 @@ func (n *host) RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult
 	}
 
 	// create result struct
-	execResult := exec.NewExecResult(e)
+	execResult := cExec.NewExecResult(e)
 	// set the result fields in the exec struct
 	execResult.SetReturnCode(cmd.ProcessState.ExitCode())
 	execResult.SetStdOut(outBuf.Bytes())


### PR DESCRIPTION
Allow for exec on `host` kind.
Also fixing the display of node kind in the post deploy / inspect table / json.