### PR TITLE
feat: support falling back to docker inspect data for gleaning mgmt bridge gw address

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -256,7 +256,33 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	// this was added to allow mgmt network gw ip to be available in a startup config templation step (ceos)
 	var v4, v6 string
 	if v4, v6, err = utils.FirstLinkIPs(bridgeName); err != nil {
-		return err
+		log.Warn(
+			"failed gleaning v4 and/or v6 addresses from bridge via netlink," +
+				" falling back to docker network inspect data",
+		)
+
+		for _, ipamEntry := range netResource.IPAM.Config {
+			addr := ipamEntry.Gateway
+
+			// this is terribly janky, *but* we know docker will be only putting valid v4/v6
+			// addresses in here and we only care about differentiating between the two flavors
+			if strings.Count(addr, ".") == 3 {
+				v4 = addr
+			} else if netResource.EnableIPv6 {
+				v6 = addr
+			}
+
+			if v4 != "" && v6 != "" {
+				break
+			}
+		}
+
+		if v4 == "" && v6 == "" {
+			// didn't get address in any way -- the case of needing to inspect the docker ipam
+			// config should be less common (for dind use case basically), so we can just return
+			// the main error form checking via ip link
+			return err
+		}
 	}
 
 	d.mgmt.IPv4Gw = v4


### PR DESCRIPTION
title!

similar issue reported in discord [here](https://discord.com/channels/860500297297821756/860500297297821759/1067963224223387658) a while back. 

tl;dr -- that commit we snag the bridge address so ceos (or presumably others) can set gateway, buuuuuut if you are docker in docker (like me and my little weird launcher tool so i can run this on my mac) then the bridge is not mounted in the "launcher" container so trying to get that bridges address fails. 

we already have the output of docker inspect network from earlier on in this func, so this just falls back to attempting to iterate over the ipam section to set v4/v6 addresses. if we still dont get any we just return the original error.

tested this in my dind setup (basically mount docker sock to debian container and launch clab from there but all in docker desktop on Mac) and it worked nicely whereas before it was bombing out due to the error returned from FirstLinkIPs.

lemme know if this makes sense or any changes are needed!

