### PR TITLE
Add linux/arm64 (container image for Mac M1/M2 chip)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ env:
   GOVER: 1.20.2
   CGO_ENABLED: 0
   MKDOCS_INS_VER: 9.1.4-insiders-4.32.4-hellt
-  GORELEASER_VER: v1.11.4
+  GORELEASER_VER: v1.19.2
   PODMAN_VER: v4.4.2
 
 jobs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,13 +14,10 @@ builds:
       - -s -w -X github.com/srl-labs/containerlab/cmd.version={{.Version}} -X github.com/srl-labs/containerlab/cmd.commit={{.ShortCommit}} -X github.com/srl-labs/containerlab/cmd.date={{.Date}}
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
       - arm64
-    # removing upx compression due to https://github.com/srl-labs/containerlab/issues/1264
-    # hooks:
-    #   post:
-    #     - upx "{{ .Path }}"
 dockers:
   - goos: linux
     goarch: amd64
@@ -30,8 +27,11 @@ dockers:
       - 'ghcr.io/srl-labs/clab:{{ replace .Version "v" ""}}'
     dockerfile: goreleaser.dockerfile
 archives:
-  - replacements:
-      linux: Linux
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- .Arch }}
     files:
       - lab-examples/**/*
       - templates/**/*

--- a/runtime/all/all_with_podman.go
+++ b/runtime/all/all_with_podman.go
@@ -1,5 +1,5 @@
-//go:build linux && podman
-// +build linux,podman
+//go:build linux && podman && darwin
+// +build linux,podman,darwin
 
 package all
 

--- a/runtime/all/all_with_podman.go
+++ b/runtime/all/all_with_podman.go
@@ -1,5 +1,5 @@
-//go:build linux && podman && darwin
-// +build linux,podman,darwin
+//go:build podman
+// +build podman
 
 package all
 

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -1,5 +1,5 @@
-//go:build linux && podman
-// +build linux,podman
+//go:build podman
+// +build podman
 
 package podman
 

--- a/runtime/podman/portmaps.go
+++ b/runtime/podman/portmaps.go
@@ -1,5 +1,5 @@
-//go:build linux && podman
-// +build linux,podman
+//go:build podman
+// +build podman
 
 package podman
 

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -1,5 +1,5 @@
-//go:build linux && podman
-// +build linux,podman
+//go:build podman
+// +build podman
 
 package podman
 


### PR DESCRIPTION
fiddled a little bit with it, but seems like vishavanda/netlink is linux only (probably obviously), so it seems building darwin/arm64 is not feasible.

The only thing I see we can do here is building linux/arm64 which will natively run under docker desktop or rancher or similar using the same approach we documented today for Intel-based macs.