### PR TITLE
Do not use endpoints to deploy links

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -641,6 +641,12 @@ func (c *CLab) ResolveLinks() error {
 
 		c.Endpoints = append(c.Endpoints, l.GetEndpoints()...)
 		c.Links[i] = l
+
+		// add the link to the nodes connected with it
+		for _, ep := range l.GetEndpoints() {
+			n := c.Nodes[ep.GetNode().GetShortName()]
+			n.AddLink(l)
+		}
 	}
 
 	return nil

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -1,7 +1,6 @@
 package links
 
 import (
-	"context"
 	"fmt"
 	"net"
 
@@ -16,7 +15,6 @@ type Endpoint interface {
 	GetIfaceName() string
 	GetRandIfaceName() string
 	GetMac() net.HardwareAddr
-	Deploy(ctx context.Context) error
 	String() string
 	// GetLink retrieves the link that the endpoint is assigned to
 	GetLink() Link
@@ -25,7 +23,7 @@ type Endpoint interface {
 	// HasSameNodeAndInterface returns true if an endpoint that implements this interface
 	// has the same node and interface name as the given endpoint.
 	HasSameNodeAndInterface(ept Endpoint) bool
-	GetState() EndpointDeployState
+	// GetState() EndpointDeployState
 }
 
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.
@@ -36,7 +34,7 @@ type EndpointGeneric struct {
 	Link     Link
 	MAC      net.HardwareAddr
 	randName string
-	state    EndpointDeployState
+	// state    EndpointDeployState
 }
 
 func (e *EndpointGeneric) GetRandIfaceName() string {
@@ -51,9 +49,9 @@ func (e *EndpointGeneric) GetIfaceName() string {
 	return e.IfaceName
 }
 
-func (e *EndpointGeneric) GetState() EndpointDeployState {
-	return e.state
-}
+// func (e *EndpointGeneric) GetState() EndpointDeployState {
+// 	return e.state
+// }
 
 func (e *EndpointGeneric) GetMac() net.HardwareAddr {
 	return e.MAC
@@ -73,22 +71,13 @@ func (e *EndpointGeneric) HasSameNodeAndInterface(ept Endpoint) bool {
 	return e.Node == ept.GetNode() && e.IfaceName == ept.GetIfaceName()
 }
 
-func (e *EndpointGeneric) Deploy(ctx context.Context) error {
-	e.state = EndpointDeployStateReady
-	return e.Link.Deploy(ctx)
-}
+// func (e *EndpointGeneric) Deploy(ctx context.Context) error {
+// 	return e.Link.Deploy(ctx)
+// }
 
 func (e *EndpointGeneric) String() string {
 	return fmt.Sprintf("%s:%s", e.Node.GetShortName(), e.IfaceName)
 }
-
-type EndpointDeployState uint8
-
-const (
-	EndpointDeployStateNotReady = iota
-	EndpointDeployStateReady
-	EndpointDeployStateDeployed
-)
 
 // CheckEndpointUniqueness checks that the given endpoint appears only once for the node
 // it is assigned to.

--- a/links/endpoint_raw.go
+++ b/links/endpoint_raw.go
@@ -67,10 +67,7 @@ func (er *EndpointRaw) Resolve(params *ResolveParams, l Link) (Endpoint, error) 
 	}
 
 	// also add the endpoint to the node
-	err := node.AddEndpoint(e)
-	if err != nil {
-		return nil, err
-	}
+	node.AddEndpoint(e)
 
 	return e, nil
 }

--- a/links/link.go
+++ b/links/link.go
@@ -12,6 +12,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type LinkDeploymentState uint8
+
+const (
+	LinkDeploymentStateNotReady = iota
+	LinkDeploymentStateReady
+	LinkDeploymentStateDeployed
+)
+
 // LinkCommonParams represents the common parameters for all link types.
 type LinkCommonParams struct {
 	MTU    int                    `yaml:"mtu,omitempty"`
@@ -264,8 +272,9 @@ type Node interface {
 	// In case of a bridge node (ovs or regular linux bridge) it will take the interface and make the bridge
 	// the master of the interface and bring the interface up.
 	AddNetlinkLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error
+	AddLink(l Link)
 	// AddEndpoint adds the Endpoint to the node
-	AddEndpoint(e Endpoint) error
+	AddEndpoint(e Endpoint)
 	GetLinkEndpointType() LinkEndpointType
 	GetShortName() string
 	GetEndpoints() []Endpoint

--- a/links/link_host.go
+++ b/links/link_host.go
@@ -125,7 +125,7 @@ func (l *LinkHost) GetEndpoints() []Endpoint {
 		l.Endpoint,
 		&EndpointHost{
 			EndpointGeneric: EndpointGeneric{
-				state:     EndpointDeployStateDeployed,
+				// state:     EndpointDeployStateDeployed,
 				Node:      GetFakeHostLinkNode(),
 				IfaceName: l.HostInterface,
 				Link:      l,
@@ -164,9 +164,12 @@ func (g *GenericLinkNode) ExecFunction(f func(ns.NetNS) error) error {
 	return netns.Do(f)
 }
 
-func (g *GenericLinkNode) AddEndpoint(e Endpoint) error {
+func (g *GenericLinkNode) AddLink(l Link) {
+
+}
+
+func (g *GenericLinkNode) AddEndpoint(e Endpoint) {
 	g.endpoints = append(g.endpoints, e)
-	return nil
 }
 
 func (g *GenericLinkNode) GetShortName() string {

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -37,18 +37,15 @@ func (r *LinkMgmtNetRaw) Resolve(params *ResolveParams) (Link, error) {
 
 	bridgeEp := &EndpointBridge{
 		EndpointGeneric: EndpointGeneric{
-			Node:      fakeMgmtBridgeNode,
-			state:     EndpointDeployStateDeployed,
+			Node: fakeMgmtBridgeNode,
+			// state:     EndpointDeployStateDeployed,
 			IfaceName: r.HostInterface,
 			Link:      link,
 		},
 	}
 
 	// add endpoint to fake mgmt bridge node
-	err := fakeMgmtBridgeNode.AddEndpoint(bridgeEp)
-	if err != nil {
-		return nil, err
-	}
+	fakeMgmtBridgeNode.AddEndpoint(bridgeEp)
 
 	// resolve and populate the endpoint
 	contEp, err := r.Endpoint.Resolve(params, link)

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -42,17 +42,27 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 }
 
 // AddEndpoint mocks base method.
-func (m *MockNode) AddEndpoint(e links.Endpoint) error {
+func (m *MockNode) AddEndpoint(e links.Endpoint) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddEndpoint", e)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "AddEndpoint", e)
 }
 
 // AddEndpoint indicates an expected call of AddEndpoint.
 func (mr *MockNodeMockRecorder) AddEndpoint(e interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockNode)(nil).AddEndpoint), e)
+}
+
+// AddLink mocks base method.
+func (m *MockNode) AddLink(l links.Link) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddLink", l)
+}
+
+// AddLink indicates an expected call of AddLink.
+func (mr *MockNodeMockRecorder) AddLink(l interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLink", reflect.TypeOf((*MockNode)(nil).AddLink), l)
 }
 
 // AddNetlinkLinkToContainer mocks base method.

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -38,6 +38,8 @@ type DefaultNode struct {
 	// OverwriteNode stores the interface used to overwrite methods defined
 	// for DefaultNode, so that particular nodes can provide custom implementations.
 	OverwriteNode NodeOverwrites
+	// List of links that reference the node.
+	Links []links.Link
 	// List of link endpoints that are connected to the node.
 	Endpoints []links.Endpoint
 }
@@ -439,9 +441,12 @@ func (d *DefaultNode) ExecFunction(f func(ns.NetNS) error) error {
 	return netns.Do(f)
 }
 
-func (d *DefaultNode) AddEndpoint(e links.Endpoint) error {
+func (d *DefaultNode) AddLink(l links.Link) {
+	d.Links = append(d.Links, l)
+}
+
+func (d *DefaultNode) AddEndpoint(e links.Endpoint) {
 	d.Endpoints = append(d.Endpoints, e)
-	return nil
 }
 
 func (d *DefaultNode) GetEndpoints() []links.Endpoint {
@@ -458,13 +463,14 @@ func (d *DefaultNode) GetShortName() string {
 	return d.Cfg.ShortName
 }
 
-// DeployLinks deploys links for a node by calling Deploy on each endpoint of a node.
+// DeployLinks deploys links associated with the node.
 func (d *DefaultNode) DeployLinks(ctx context.Context) error {
-	for _, ep := range d.Endpoints {
-		err := ep.Deploy(ctx)
+	for _, l := range d.Links {
+		err := l.Deploy(ctx)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -93,7 +93,8 @@ type Node interface {
 	// Adds the given link to the Node. After adding the Link to the node,
 	// the given function f is called within the Nodes namespace.
 	AddNetlinkLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error
-	AddEndpoint(e links.Endpoint) error
+	AddLink(l links.Link)
+	AddEndpoint(e links.Endpoint)
 	GetEndpoints() []links.Endpoint
 	GetLinkEndpointType() links.LinkEndpointType
 	GetShortName() string


### PR DESCRIPTION
@steiler When reviewing #1475 I noticed the indirection you used to deploy links
you called (endpoint).Deploy, which called associated (link).Deploy.

I find this indirection unnecessary, and propose to deploy links directly. For that I store []Link under the node implementation so that we can call (link).Deploy without touching endpoints.

Check this PR, if you're ok with it, I will push it to the existing PR.