### PR TITLE
add "How to start Containerlab on ARM"

### DIFF
--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -16,6 +16,7 @@ IgnoreURLs:
   - https://twitter.com/*
   - mysocket.io # remove mysocket.io links until we rework to border0.com
   - https://supportcenter.checkpoint.com/ # started to fail, meh.
+  - https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -16,7 +16,7 @@ IgnoreURLs:
   - https://twitter.com/*
   - mysocket.io # remove mysocket.io links until we rework to border0.com
   - https://supportcenter.checkpoint.com/ # started to fail, meh.
-  - https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack
+  - https://marketplace.visualstudio.com/*
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,6 +5,7 @@ hide:
 Containerlab is distributed as a Linux deb/rpm package and can be installed on any Debian- or RHEL-like distributive in a matter of a few seconds.
 
 ### Pre-requisites
+
 The following requirements must be satisfied to let containerlab tool run successfully:
 
 * A user should have `sudo` privileges to run containerlab.
@@ -12,6 +13,7 @@ The following requirements must be satisfied to let containerlab tool run succes
 * Load container images (e.g. Nokia SR Linux, Arista cEOS) that are not downloadable from a container registry. Containerlab will try to pull images at runtime if they do not exist locally.
 
 ### Install script
+
 Containerlab can be installed using the [installation script](https://github.com/srl-labs/containerlab/blob/main/get.sh) which detects the operating system type and installs the relevant package:
 
 !!! note
@@ -30,6 +32,7 @@ bash -c "$(wget -qO - https://get.containerlab.dev)"
 ```
 
 ### Package managers
+
 It is possible to install official containerlab releases via public APT/YUM repository.
 
 === "APT"
@@ -70,6 +73,7 @@ It is possible to install official containerlab releases via public APT/YUM repo
 The package installer will put the `containerlab` binary in the `/usr/bin` directory as well as create the `/usr/bin/clab -> /usr/bin/containerlab` symlink. The symlink allows the users to save on typing when they use containerlab: `clab <command>`.
 
 ### Container
+
 Containerlab is also available in a container packaging. The latest containerlab release can be pulled with:
 
 ```
@@ -107,6 +111,7 @@ Within the started container you can use the same `containerlab deploy/destroy/i
     ```
 
 ### Manual installation
+
 If the linux distributive can't install deb/rpm packages, containerlab can be installed from the archive:
 
 ```bash
@@ -128,6 +133,7 @@ mv /etc/containerlab/containerlab /usr/bin && chmod a+x /usr/bin/containerlab
 ```
 
 ### Windows Subsystem Linux (WSL)
+
 Containerlab [runs](https://twitter.com/ntdvps/status/1380915270328401922) on WSL, but you need to [install docker-ce](https://docs.docker.com/engine/install/) inside the WSL2 linux system instead of using Docker Desktop[^3].
 
 If you are running Ubuntu 20.04 as your WSL2 machine, you can run [this script](https://gist.github.com/hellt/e8095c1719a3ea0051165ff282d2b62a) to install docker-ce.
@@ -145,6 +151,7 @@ Once installed, issue `sudo service docker start` to start the docker service in
     It appears to be that next versions of WSL2 kernels will support KVM.
 
 ### Mac OS
+
 Running containerlab on Mac OS is possible[^4] by means of a separate docker image with containerlab inside.
 
 !!!warning
@@ -171,7 +178,7 @@ The first command in the snippet above sets the working directory which you inte
     1. It is best to create a directory under the `~/some/path` unless you know what to do[^5]
     2. vrnetlab based nodes will not be able to start, since Docker VM does not support virtualization.
     3. Docker Desktop for Mac introduced cgroups v2 support in 4.3.0 version; to support the images that require cgroups v1 follow [these instructions](https://github.com/docker/for-mac/issues/6073).
-    4. Docker Desktop relies on a LinuxKit based HyperKit VM. Unfortunately, it is shipped with a minimalist kernel, and some modules such as VRF are disabled by default. Follow [these instructions](https://medium.com/@notsinge/making-your-own-linuxkit-with-docker-for-mac-5c1234170fb1) to rebuild it with more modules. 
+    4. Docker Desktop relies on a LinuxKit based HyperKit VM. Unfortunately, it is shipped with a minimalist kernel, and some modules such as VRF are disabled by default. Follow [these instructions](https://medium.com/@notsinge/making-your-own-linuxkit-with-docker-for-mac-5c1234170fb1) to rebuild it with more modules.
 
 When the container is started, you will have a bash shell opened with the directory contents mounted from the Mac OS. There you can use `containerlab` commands right away.
 
@@ -294,8 +301,8 @@ RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v ${_CLAB_VERSION} \
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "clab-for-arm",
-	"build": {
+    "name": "clab-for-arm",
+    "build": {
         "dockerfile": "Dockerfile",
         "args": {
             "_CLAB_VERSION": "0.43.0"
@@ -322,14 +329,14 @@ RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v ${_CLAB_VERSION} \
 }
 ```
 
-Once the devcontiner is defined as described above:
+Once the devcontainer is defined as described above:
 
-- Open the devcontainer in VSCode
-- Import the required images for your cLab inside the container (if you are using Docker-in-Docker option)
-- Start you Containerlab
-
+* Open the devcontainer in VSCode
+* Import the required images for your cLab inside the container (if you are using Docker-in-Docker option)
+* Start you Containerlab
 
 ### Upgrade
+
 To upgrade `containerlab` to the latest available version issue the following command[^1]:
 
 ```
@@ -341,6 +348,7 @@ This command will fetch the installation script and will upgrade the tool to its
 or leverage `apt`/`yum` utilities if containerlab repo was added as explained in the [Package managers](#package-managers) section.
 
 ### From source
+
 To build containerlab from source:
 
 === "with go build"
@@ -353,6 +361,7 @@ To build containerlab from source:
     ```
 
 ### Uninstall
+
 To uninstall containerlab when it was installed via installation script or packages:
 
 === "Debian-based system"
@@ -366,8 +375,8 @@ To uninstall containerlab when it was installed via installation script or packa
 === "Manual removal"
     Containerlab binary is located at `/usr/bin/containerlab`. In addition to the binary, containerlab directory with static files may be found at `/etc/containerlab`.
 
-
 ### SELinux
+
 When SELinux set to enforced mode containerlab binary might fail to execute with `Segmentation fault (core dumped)` error. This might be because containerlab binary is compressed with [upx](https://upx.github.io/) and selinux prevents it from being decompressed by default.
 
 To fix this:

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,8 +148,7 @@ Once installed, issue `sudo service docker start` to start the docker service in
 Running containerlab on Mac OS is possible[^4] by means of a separate docker image with containerlab inside.
 
 !!!warning
-    ARM-based Macs (M1/2) are not supported, and no binaries are generated for this platform. This is mainly due to the lack of network images built for arm64 architecture as of now.  
-    Nevertheless, it is technically possible to run Containerlab on ARM-based MacBook. Check [How to start Containerlab on ARM-based MacBook](#how-to-start-containerlab-on-arm-based-macbook) for details.
+    ARM-based Macs (M1/2) are not supported, and no binaries are generated for this platform. This is mainly due to the lack of network images built for arm64 architecture as of now. Nevertheless, it is technically possible to run Containerlab on ARM-based MacBook. Check [How to start Containerlab on ARM-based MacBook](#how-to-start-containerlab-on-arm-based-macbook) for details.
 
 To use this container use the following command:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -155,7 +155,7 @@ Once installed, issue `sudo service docker start` to start the docker service in
 Running containerlab on Mac OS is possible[^4] by means of a separate docker image with containerlab inside.
 
 !!!warning
-    ARM-based Macs (M1/2) are not supported, and no binaries are generated for this platform. This is mainly due to the lack of network images built for arm64 architecture as of now. Nevertheless, it is technically possible to run Containerlab on ARM-based MacBook. Check [How to start Containerlab on ARM-based MacBook](#how-to-start-containerlab-on-arm-based-macbook) for details.
+    ARM-based Macs (M1/2) are not supported, and no binaries are generated for this platform. This is mainly due to the lack of network images built for arm64 architecture as of now. Nevertheless, it is technically possible to run Containerlab on ARM-based MacBook. Check [How to start Containerlab on ARM-based MacBook](#containerlab-on-arm-based-macs) for details.
 
 To use this container use the following command:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,14 +37,14 @@ It is possible to install official containerlab releases via public APT/YUM repo
 
 === "APT"
     ```bash
-    echo "deb [trusted=yes] https://apt.fury.io/netdevops/ /" | \
+    echo "deb [trusted=yes] <https://apt.fury.io/netdevops/> /" | \
     sudo tee -a /etc/apt/sources.list.d/netdevops.list
 
     sudo apt update && sudo apt install containerlab
     ```
 === "YUM"
     ```
-    yum-config-manager --add-repo=https://yum.fury.io/netdevops/ && \
+    yum-config-manager --add-repo=<https://yum.fury.io/netdevops/> && \
     echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/yum.fury.io_netdevops_.repo
 
     sudo yum install containerlab
@@ -254,11 +254,9 @@ When the container is started, you will have a bash shell opened with the direct
     +---+----------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
     ```
 
-### How to start Containerlab on ARM-based MacBook
+#### Containerlab on ARM-based Macs
 
-> While techically possible this solution requires further testing once arm64 network images are available.
-
-The easiest option to run Containerlab on M1/M2 laptop is to build container locally. We'll provide an example of custom [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) that can be opened in [VSCode](https://code.visualstudio.com) with [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed.
+The easiest option to run Containerlab on ARM-based M1/M2 Macs is to build a docker-in-docker container. We'll provide an example of a custom [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) that can be opened in [VSCode](https://code.visualstudio.com) with [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed.
 
 Create `.devcontainer` directory in the root of the Containerlab repository with the following content:
 
@@ -268,66 +266,65 @@ Create `.devcontainer` directory in the root of the Containerlab repository with
 |- Dockerfile
 ```
 
-`Dockerfile`:
+=== "Dockerfile"
 
-```Dockerfile
-# The devcontainer will be based on Python 3.9
-# The base container already has entrypoint, vscode user account, etc. out of the box
-FROM mcr.microsoft.com/devcontainers/python:0-3.9-bullseye
+    ```Dockerfile
+    # The devcontainer will be based on Python 3.9
+    # The base container already has entrypoint, vscode user account, etc. out of the box
+    FROM mcr.microsoft.com/devcontainers/python:0-3.9-bullseye
 
-# containelab version will be set in devcontainer.json
-ARG _CLAB_VERSION
+    # containelab version will be set in devcontainer.json
+    ARG _CLAB_VERSION
 
-# install some basic tools inside the container
-# adjust this list based on your demands
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    sshpass \
-    curl \
-    iputils-ping \
-    htop \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && apt-get clean
+    # install some basic tools inside the container
+    # adjust this list based on your demands
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends \
+        sshpass \
+        curl \
+        iputils-ping \
+        htop \
+        && rm -rf /var/lib/apt/lists/* \
+        && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+        && apt-get clean
 
-# install preferred version of the containerlab
-RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v ${_CLAB_VERSION} \
-    && pip3 install --user yamllint
-```
+    # install preferred version of the containerlab
+    RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v ${_CLAB_VERSION} \
+        && pip3 install --user yamllint
+    ```
+=== "devcontainer.json"
 
-`devcontainer.json`:
-
-```json
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/python
-{
-    "name": "clab-for-arm",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            "_CLAB_VERSION": "0.43.0"
-        }
-    },
-    "features": {
-        // the Containerlab will run as docker-in-docker
-        // it is also possible to use docker-outside-docker feature
-        "ghcr.io/devcontainers/features/docker-in-docker:2.2.0": {
-            "version": "latest"
-        }
-    },
-    // add any required extensions that must be pre-installed in devcontainer
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                // various tools
-                "tuxtina.json2yaml",
-                "vscode-icons-team.vscode-icons",
-                "mutantdino.resourcemonitor"
-            ]
+    ```json
+    // For format details, see https://aka.ms/devcontainer.json. For config options, see the
+    // README at: https://github.com/devcontainers/templates/tree/main/src/python
+    {
+        "name": "clab-for-arm",
+        "build": {
+            "dockerfile": "Dockerfile",
+            "args": {
+                "_CLAB_VERSION": "0.43.0"
+            }
+        },
+        "features": {
+            // Containerlab will run in a docker-in-docker container
+            // it is also possible to use docker-outside-docker feature
+            "ghcr.io/devcontainers/features/docker-in-docker:2.2.0": {
+                "version": "latest"
+            }
+        },
+        // add any required extensions that must be pre-installed in the devcontainer
+        "customizations": {
+            "vscode": {
+                "extensions": [
+                    // various tools
+                    "tuxtina.json2yaml",
+                    "vscode-icons-team.vscode-icons",
+                    "mutantdino.resourcemonitor"
+                ]
+            }
         }
     }
-}
-```
+    ```
 
 Once the devcontainer is defined as described above:
 


### PR DESCRIPTION
Fixes #1473 

Thia PR adds a short documentation section explaining how to run Containerlab on ARM-based desktop in a devcontainer.
Open for comments and suggestions.