### PR TITLE
List OVS bridges to allow for OF version >1.0

### DIFF
--- a/docs/rn/0.44.md
+++ b/docs/rn/0.44.md
@@ -49,3 +49,4 @@ Read more about this feature in the [Certificates Management](../manual/cert.md#
 
 * fixing CLAB_INTFS env var #1547
 * fixing node filtering functionality #1549
+* fixing ovs bridges and openflow 1.3 #1539

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -56,11 +56,11 @@ func (n *ovs) CheckDeploymentConditions(_ context.Context) error {
 	)
 
 	// We were previously doing c.VSwitch.Get.Bridge() but it doesn't work
-	// when the bridge has a propotocol version higher than 1.0
+	// when the bridge has a protocol version higher than 1.0
 	// So listing the bridges is safer
 	bridges, err := c.VSwitch.ListBridges()
 	if err != nil {
-		return fmt.Errorf("error while looking for ovs bridge %q: %v", n.Cfg.ShortName, err)
+		return fmt.Errorf("error while listing ovs bridges: %v", err)
 	}
 	if !slices.Contains(bridges, n.Cfg.ShortName) {
 		return fmt.Errorf("could not find ovs bridge %q", n.Cfg.ShortName)

--- a/nodes/ovs/ovs.go
+++ b/nodes/ovs/ovs.go
@@ -12,6 +12,7 @@ import (
 	goOvs "github.com/digitalocean/go-openvswitch/ovs"
 	log "github.com/sirupsen/logrus"
 	cExec "github.com/srl-labs/containerlab/clab/exec"
+	"github.com/srl-labs/containerlab/internal/slices"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/nodes/state"
@@ -54,7 +55,14 @@ func (n *ovs) CheckDeploymentConditions(_ context.Context) error {
 		goOvs.Sudo(),
 	)
 
-	if _, err := c.VSwitch.Get.Bridge(n.Cfg.ShortName); err != nil {
+	// We were previously doing c.VSwitch.Get.Bridge() but it doesn't work
+	// when the bridge has a propotocol version higher than 1.0
+	// So listing the bridges is safer
+	bridges, err := c.VSwitch.ListBridges()
+	if err != nil {
+		return fmt.Errorf("error while looking for ovs bridge %q: %v", n.Cfg.ShortName, err)
+	}
+	if !slices.Contains(bridges, n.Cfg.ShortName) {
 		return fmt.Errorf("could not find ovs bridge %q", n.Cfg.ShortName)
 	}
 


### PR DESCRIPTION
There is a problem with the OVS library being used when retrieving a bridge. But since we just need to know if the bridge exists or not, and we dont actually need any details about it, then I changed it to list the bridges. 

This now works with bridges that are created with `ovs-vsctl set bridge s1 protocols=openflow13`