### PR TITLE
Count clab intfs at the right time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ oci-push: build-with-podman
 	@echo "With the following pull command you get a containerlab binary at your working directory. To use this downloaded binary - ./containerlab deploy.... Make sure not forget to add ./ prefix in order to use the downloaded binary and not the globally installed containerlab!"
 	@echo 'If https proxy is configured in your environment, pass the proxies via --env HTTPS_PROXY="<proxy-address>" flag of the docker run command.'
 # push to ttl.sh
-	docker run --rm -v $(CURDIR)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/clab-$(COMMIT_HASH):1d ./containerlab
-	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/clab-$(COMMIT_HASH):1d"
+#	docker run --rm -v $(CURDIR)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/clab-$(COMMIT_HASH):1d ./containerlab
+#	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/clab-$(COMMIT_HASH):1d"
 # push to ghcr.io
 	@echo ""
 	docker run --rm -v $(CURDIR)/bin:/workspace -v $${HOME}/.docker/config.json:/root/.docker/config.json ghcr.io/oras-project/oras:v0.12.0 push ghcr.io/srl-labs/clab-oci:$(COMMIT_HASH) ./containerlab

--- a/clab/config.go
+++ b/clab/config.go
@@ -125,9 +125,6 @@ func (c *CLab) parseTopology() error {
 		}
 	}
 
-	// set any containerlab defaults after we've parsed the input
-	c.setDefaults()
-
 	return nil
 }
 
@@ -531,14 +528,15 @@ func (c *CLab) resolveBindPaths(binds []string, nodedir string) error {
 	return nil
 }
 
-// sets defaults after the topology has been parsed.
-func (c *CLab) setDefaults() {
+// setClabIntfsEnvVar sets CLAB_INTFS env var for each node
+// which holds the number of interfaces a node expects to have (without mgmt interfaces)
+func (c *CLab) SetClabIntfsEnvVar() {
 	for _, n := range c.Nodes {
 		// Injecting the env var with expected number of links
-		numLinks := map[string]string{
+		numIntfs := map[string]string{
 			types.CLAB_ENV_INTFS: fmt.Sprintf("%d", len(n.GetEndpoints())),
 		}
-		n.Config().Env = utils.MergeStringMaps(n.Config().Env, numLinks)
+		n.Config().Env = utils.MergeStringMaps(n.Config().Env, numIntfs)
 	}
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -119,6 +119,8 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	c.SetClabIntfsEnvVar()
+
 	setFlags(c.Config)
 	log.Debugf("lab Conf: %+v", c.Config)
 

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -83,6 +83,23 @@ Exec command with json output and filtering
     # check if output contains the json value from the /test.json file
     Should Contain    ${output.stdout}    is cool
 
+Ensure CLAB_INTFS env var is set
+    [Documentation]
+    ...    This test ensures that the CLAB_INTFS environment variable is set in the container
+    ...    and that it contains the correct number of interfaces.
+    ${output} =    Process.Run Process
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'ash -c "echo $CLAB_INTFS"'
+    ...    shell=True
+    Log    ${output.stdout}
+    Log    ${output.stderr}
+    Should Be Equal As Integers    ${output.rc}    0
+    # l1 node has 3 interfaces defined in the lab topology
+    # log outputs to stderr, and thus we check for 3 interfaces there
+    # may be worth to change this to stdout in the future
+    # we literally check if the string stdout:\n3 is present in the output, as this is how
+    # the result is printed today.
+    Should Contain    ${output.stderr}    stdout:\\n3
+
 Inspect ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}


### PR DESCRIPTION
In 0.43+ the clab_intfs were not counted, as the enpodints were empty.
Moved this after links are resolved.