### PR TITLE
adding support for vJunos-switch

### DIFF
--- a/clab/register.go
+++ b/clab/register.go
@@ -33,6 +33,7 @@ import (
 	vr_vmx "github.com/srl-labs/containerlab/nodes/vr_vmx"
 	vr_vqfx "github.com/srl-labs/containerlab/nodes/vr_vqfx"
 	vr_vsrx "github.com/srl-labs/containerlab/nodes/vr_vsrx"
+	vr_vjunosswitch "github.com/srl-labs/containerlab/nodes/vr_vjunosswitch"
 	vr_xrv "github.com/srl-labs/containerlab/nodes/vr_xrv"
 	vr_xrv9k "github.com/srl-labs/containerlab/nodes/vr_xrv9k"
 	xrd "github.com/srl-labs/containerlab/nodes/xrd"
@@ -65,6 +66,7 @@ func (c *CLab) RegisterNodes() {
 	vr_vmx.Register(c.Reg)
 	vr_vsrx.Register(c.Reg)
 	vr_vqfx.Register(c.Reg)
+	vr_vjunosswitch.Register(c.Reg)
 	vr_xrv.Register(c.Reg)
 	vr_xrv9k.Register(c.Reg)
 	xrd.Register(c.Reg)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -38,8 +38,8 @@ var interfaceFormat = map[string]string{
 }
 
 var supportedKinds = []string{
-	"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros",
-	"vr-vmx", "vr-vsrx", "vr-vqfx", "vr-xrv9k", "vr-veos", "xrd", "rare",
+	"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros","vr-vmx", "vr-vsrx", 
+	"vr-vqfx", "vr-vjunosswitch", "vr-xrv9k", "vr-veos", "xrd", "rare",
 }
 
 const (

--- a/docs/lab-examples/srl-vjunos-switch.md
+++ b/docs/lab-examples/srl-vjunos-switch.md
@@ -1,0 +1,25 @@
+|                               |                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| **Description**               | A Nokia SR Linux connected back-to-back with Juniper vJunos-switch                                       |
+| **Components**                | [Nokia SR Linux][srl], [Juniper vJunos-switch][vjunos]          |
+| **Resource requirements**[^1] | :fontawesome-solid-microchip: 4 <br/>:fontawesome-solid-memory: 8 GB                     |
+| **Topology file**             | [srlvjunos01.clab.yml][topofile]                                                            |
+| **Name**                      | srlvjunos01                                                                                 |
+| **Version information**[^2]   | `containerlab:0.45.0`, `srlinux:23.7.1`, `vjunos-switch:23.2R1.14`, `docker-ce:23.0.3` |
+
+## Description
+
+A lab consists of an SR Linux node connected with Juniper vJunos-switch via three point-to-point ethernet links. Both nodes are also connected with their management interfaces to the `clab` docker network.
+
+## Use cases
+
+The nodes are provisioned with a basic interface configuration for three interfaces they are connected with. Pings between the nodes should work out of the box using all three interfaces.
+
+[srl]: ../manual/kinds/srl.md
+[vjunos]: ../manual/kinds/vr-vjunosswitch.md
+[topofile]: https://github.com/srl-labs/containerlab/tree/main/lab-examples/srlvjunos01/srlvjunos01.clab.yml
+
+[^1]: Resource requirements are provisional. Consult with the installation guides for additional information.
+[^2]: The lab has been validated using these versions of the required tools/components. Using versions other than stated might lead to a non-operational setup process.
+
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>

--- a/docs/manual/kinds/vr-vjunosswitch.md
+++ b/docs/manual/kinds/vr-vjunosswitch.md
@@ -1,0 +1,83 @@
+---
+search:
+  boost: 4
+---
+# Juniper vJunos-switch
+
+[Juniper vJunos-switch](https://support.juniper.net/support/downloads/?p=vjunos) is a virtualized EX9214 switch identified with `vr-vjunosswitch` or `vr-juniper_vjunosswitch` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a Qemu VM packaged in a docker container format.
+
+vr-vjunosswitch nodes launched with containerlab come up pre-provisioned with SSH, SNMP, NETCONF and gNMI services enabled.
+
+## Managing vr-vjunosswitch nodes
+
+!!!note
+    Containers with vJunos-switch inside will take ~5min to fully boot.  
+    You can monitor the progress with `docker logs -f <container-name>`.
+
+Juniper vJunos-switch node launched with containerlab can be managed via the following interfaces:
+
+=== "bash"
+    to connect to a `bash` shell of a running vr-vjunosswitch container:
+    ```bash
+    docker exec -it <container-name/id> bash
+    ```
+=== "CLI via SSH"
+    to connect to the vJunos-switch CLI
+    ```bash
+    ssh admin@<container-name/id>
+    ```
+=== "NETCONF"
+    NETCONF server is running over port 830
+    ```bash
+    ssh admin@<container-name> -p 830 -s netconf
+    ```
+
+!!!info
+    Default user credentials: `admin:admin@123`
+
+## Interfaces mapping
+
+vr-vjunosswitch container can have up to 11 interfaces and uses the following mapping rules:
+
+* `eth0` - management interface connected to the containerlab management network
+* `eth1` - first data interface, mapped to a first data port of vJunos-Switch VM
+* `eth2+` - second and subsequent data interface
+
+When containerlab launches vr-vjunosswitch node, it will assign IPv4/6 address to the `eth0` interface. These addresses can be used to reach the management plane of the router.
+
+Data interfaces `eth1+` need to be configured with IP addressing manually using CLI/management protocols or via a startup-config text file.
+
+## Features and options
+
+### Node configuration
+
+vr-vjunosswitch nodes come up with a basic configuration supplied by a mountable configuration disk to the main VM image. Users, management interfaces, and protocols such as SSH and NETCONF are configured.
+
+#### Startup configuration
+
+It is possible to make vJunos-switch nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: vr-vjunosswitch
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.
+
+## Lab examples
+
+The following labs feature the vr-vjunosswitch node:
+
+* [SR Linux and Juniper vJunos-Switch](../../../../tree/main/lab-examples/srlvjunos01)
+
+## Known issues and limitations
+
+* vJunos-Switch requires Linux kernel 4.17+
+* To check the boot log, use `docker logs -f <node-name>`.
+
+[^1]: https://github.com/hellt/vrnetlab/pull/138

--- a/docs/manual/kinds/vr-vjunosswitch.md
+++ b/docs/manual/kinds/vr-vjunosswitch.md
@@ -73,11 +73,11 @@ Configuration is applied after the node is started, thus it can contain partial 
 
 The following labs feature the vr-vjunosswitch node:
 
-* [SR Linux and Juniper vJunos-Switch](../../../../tree/main/lab-examples/srlvjunos01)
+* [SR Linux and Juniper vJunos-switch](../../../../main/lab-examples/srlvjunos01)
 
 ## Known issues and limitations
 
-* vJunos-Switch requires Linux kernel 4.17+
+* vJunos-switch requires Linux kernel 4.17+
 * To check the boot log, use `docker logs -f <node-name>`.
 
 [^1]: https://github.com/hellt/vrnetlab/pull/138

--- a/docs/manual/kinds/vr-vjunosswitch.md
+++ b/docs/manual/kinds/vr-vjunosswitch.md
@@ -8,6 +8,10 @@ search:
 
 vr-vjunosswitch nodes launched with containerlab come up pre-provisioned with SSH, SNMP, NETCONF and gNMI services enabled.
 
+## How to obtain the image
+
+The qcow2 image can be downloaded from [Juniper website](https://support.juniper.net/support/downloads/?p=vjunos) and built with [vrnetlab](../vrnetlab.md).
+
 ## Managing vr-vjunosswitch nodes
 
 !!!note
@@ -73,11 +77,9 @@ Configuration is applied after the node is started, thus it can contain partial 
 
 The following labs feature the vr-vjunosswitch node:
 
-* [SR Linux and Juniper vJunos-switch](../../../../main/lab-examples/srlvjunos01)
+* [SR Linux and Juniper vJunos-switch](lab-examples/srlvjunos01.md)
 
 ## Known issues and limitations
 
 * vJunos-switch requires Linux kernel 4.17+
 * To check the boot log, use `docker logs -f <node-name>`.
-
-[^1]: https://github.com/hellt/vrnetlab/pull/138

--- a/docs/manual/kinds/vr-vjunosswitch.md
+++ b/docs/manual/kinds/vr-vjunosswitch.md
@@ -15,7 +15,7 @@ The qcow2 image can be downloaded from [Juniper website](https://support.juniper
 ## Managing vr-vjunosswitch nodes
 
 !!!note
-    Containers with vJunos-switch inside will take ~5min to fully boot.  
+    Containers with vJunos-switch inside will take ~15min to fully boot.  
     You can monitor the progress with `docker logs -f <container-name>`.
 
 Juniper vJunos-switch node launched with containerlab can be managed via the following interfaces:
@@ -77,7 +77,7 @@ Configuration is applied after the node is started, thus it can contain partial 
 
 The following labs feature the vr-vjunosswitch node:
 
-* [SR Linux and Juniper vJunos-switch](lab-examples/srlvjunos01.md)
+* [SR Linux and Juniper vJunos-switch](../../lab-examples/srl-vjunos-switch.md)
 
 ## Known issues and limitations
 

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -47,6 +47,7 @@ The following table provides a link between the version combinations:
 | `0.34.0`         | [`0.8.2`](https://github.com/hellt/vrnetlab/releases/tag/v0.8.2)   | startup-config support for PANOS, ISA support for Nokia VSR-I and MGMT VRF for VMX                                                                       |
 |                  | [`0.9.0`](https://github.com/hellt/vrnetlab/releases/tag/v0.9.0)   | Support for IPInfusion OcNOS with vrnetlab                                                                                                               |
 | `0.41.0`         | [`0.11.0`](https://github.com/hellt/vrnetlab/releases/tag/v0.11.0) | Added support for Juniper vSRX3.0 via [`vr-vsrx`](kinds/vr-vsrx.md) kind                                                                                 |
+| `0.45.0`         | [`0.12.0`](https://github.com/hellt/vrnetlab/releases/tag/v0.12.0) | Added support for Juniper vJunos-switch via [`vr-juniper_vjunosswitch`](kinds/vr-vjunosswitch.md) kind                                                   |
 
 ### Building vrnetlab images
 

--- a/lab-examples/srlvjunos01/srl.cli
+++ b/lab-examples/srlvjunos01/srl.cli
@@ -1,44 +1,39 @@
-enter candidate
-set / interface ethernet-1/1 admin-state enable
-set / interface ethernet-1/1 subinterface 0
-set / interface ethernet-1/1 subinterface 0 ipv4
-set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.0.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/1.0
-set / interface ethernet-1/2 admin-state enable
-set / interface ethernet-1/2 subinterface 0
-set / interface ethernet-1/2 subinterface 0 ipv4
-set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/2 subinterface 0 ipv4 address 192.168.1.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/2.0
-set / interface ethernet-1/3 admin-state enable
-set / interface ethernet-1/3 subinterface 0
-set / interface ethernet-1/3 subinterface 0 ipv4
-set / interface ethernet-1/3 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/3 subinterface 0 ipv4 address 192.168.2.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/3.0
-set / interface ethernet-1/4 admin-state enable
-set / interface ethernet-1/4 subinterface 0
-set / interface ethernet-1/4 subinterface 0 ipv4
-set / interface ethernet-1/4 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/4 subinterface 0 ipv4 address 192.168.3.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/4.0
-set / interface ethernet-1/5 admin-state enable
-set / interface ethernet-1/5 subinterface 0
-set / interface ethernet-1/5 subinterface 0 ipv4
-set / interface ethernet-1/5 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/5 subinterface 0 ipv4 address 192.168.4.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/5.0
-set / interface ethernet-1/6 admin-state enable
-set / interface ethernet-1/6 subinterface 0
-set / interface ethernet-1/6 subinterface 0 ipv4
-set / interface ethernet-1/6 subinterface 0 ipv4 admin-state enable
-set / interface ethernet-1/6 subinterface 0 ipv4 address 192.168.5.2/24
-set / network-instance default
-set / network-instance default interface ethernet-1/6.0
-commit now
+interface ethernet-1/1 {
+    admin-state enable
+    subinterface 0 {
+        ipv4 {
+            admin-state enable
+            address 192.168.0.2/24 {
+            }
+        }
+    }
+}
+interface ethernet-1/2 {
+    admin-state enable
+    subinterface 0 {
+        ipv4 {
+            admin-state enable
+            address 192.168.1.2/24 {
+            }
+        }
+    }
+}
+interface ethernet-1/3 {
+    admin-state enable
+    subinterface 0 {
+        ipv4 {
+            admin-state enable
+            address 192.168.2.2/24 {
+            }
+        }
+    }
+}
+
+network-instance default {
+    interface ethernet-1/1.0 {
+    }
+    interface ethernet-1/2.0 {
+    }
+    interface ethernet-1/3.0 {
+    }
+}

--- a/lab-examples/srlvjunos01/srl.cli
+++ b/lab-examples/srlvjunos01/srl.cli
@@ -1,0 +1,44 @@
+enter candidate
+set / interface ethernet-1/1 admin-state enable
+set / interface ethernet-1/1 subinterface 0
+set / interface ethernet-1/1 subinterface 0 ipv4
+set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/1 subinterface 0 ipv4 address 192.168.0.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/1.0
+set / interface ethernet-1/2 admin-state enable
+set / interface ethernet-1/2 subinterface 0
+set / interface ethernet-1/2 subinterface 0 ipv4
+set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/2 subinterface 0 ipv4 address 192.168.1.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/2.0
+set / interface ethernet-1/3 admin-state enable
+set / interface ethernet-1/3 subinterface 0
+set / interface ethernet-1/3 subinterface 0 ipv4
+set / interface ethernet-1/3 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/3 subinterface 0 ipv4 address 192.168.2.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/3.0
+set / interface ethernet-1/4 admin-state enable
+set / interface ethernet-1/4 subinterface 0
+set / interface ethernet-1/4 subinterface 0 ipv4
+set / interface ethernet-1/4 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/4 subinterface 0 ipv4 address 192.168.3.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/4.0
+set / interface ethernet-1/5 admin-state enable
+set / interface ethernet-1/5 subinterface 0
+set / interface ethernet-1/5 subinterface 0 ipv4
+set / interface ethernet-1/5 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/5 subinterface 0 ipv4 address 192.168.4.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/5.0
+set / interface ethernet-1/6 admin-state enable
+set / interface ethernet-1/6 subinterface 0
+set / interface ethernet-1/6 subinterface 0 ipv4
+set / interface ethernet-1/6 subinterface 0 ipv4 admin-state enable
+set / interface ethernet-1/6 subinterface 0 ipv4 address 192.168.5.2/24
+set / network-instance default
+set / network-instance default interface ethernet-1/6.0
+commit now

--- a/lab-examples/srlvjunos01/srlvjunos01.clab.yml
+++ b/lab-examples/srlvjunos01/srlvjunos01.clab.yml
@@ -1,0 +1,22 @@
+name: srlvjunos01
+
+topology:
+  nodes:
+    n1:
+      kind: srl
+      image: ghcr.io/nokia/srlinux
+      startup-config: srl.cli
+
+    vswitch0:
+      kind: vr-vjunosswitch
+      image: vrnetlab/vr-vjunosswitch:23.2R1.14
+      startup-config: vjunos.cfg
+
+  links:
+    - endpoints: ["n1:e1-1", "vswitch0:eth1"]
+    - endpoints: ["n1:e1-2", "vswitch0:eth2"]
+    - endpoints: ["n1:e1-3", "vswitch0:eth3"]
+    - endpoints: ["n1:e1-4", "vswitch0:eth4"]
+    - endpoints: ["n1:e1-5", "vswitch0:eth5"]
+    - endpoints: ["n1:e1-6", "vswitch0:eth6"]
+

--- a/lab-examples/srlvjunos01/srlvjunos01.clab.yml
+++ b/lab-examples/srlvjunos01/srlvjunos01.clab.yml
@@ -4,11 +4,11 @@ topology:
   nodes:
     n1:
       kind: srl
-      image: ghcr.io/nokia/srlinux
+      image: ghcr.io/nokia/srlinux:23.7.1
       startup-config: srl.cli
 
     vswitch0:
-      kind: vr-vjunosswitch
+      kind: vr-juniper_vjunosswitch
       image: vrnetlab/vr-vjunosswitch:23.2R1.14
       startup-config: vjunos.cfg
 
@@ -16,7 +16,3 @@ topology:
     - endpoints: ["n1:e1-1", "vswitch0:eth1"]
     - endpoints: ["n1:e1-2", "vswitch0:eth2"]
     - endpoints: ["n1:e1-3", "vswitch0:eth3"]
-    - endpoints: ["n1:e1-4", "vswitch0:eth4"]
-    - endpoints: ["n1:e1-5", "vswitch0:eth5"]
-    - endpoints: ["n1:e1-6", "vswitch0:eth6"]
-

--- a/lab-examples/srlvjunos01/srlvjunos01.clab.yml
+++ b/lab-examples/srlvjunos01/srlvjunos01.clab.yml
@@ -2,17 +2,17 @@ name: srlvjunos01
 
 topology:
   nodes:
-    n1:
+    srl:
       kind: srl
       image: ghcr.io/nokia/srlinux:23.7.1
       startup-config: srl.cli
 
-    vswitch0:
+    vswitch:
       kind: vr-juniper_vjunosswitch
-      image: vrnetlab/vr-vjunosswitch:23.2R1.14
+      image: registry.srlinux.dev/pub/vr-vjunosswitch:23.2R1.14
       startup-config: vjunos.cfg
 
   links:
-    - endpoints: ["n1:e1-1", "vswitch0:eth1"]
-    - endpoints: ["n1:e1-2", "vswitch0:eth2"]
-    - endpoints: ["n1:e1-3", "vswitch0:eth3"]
+    - endpoints: ["srl:e1-1", "vswitch:eth1"]
+    - endpoints: ["srl:e1-2", "vswitch:eth2"]
+    - endpoints: ["srl:e1-3", "vswitch:eth3"]

--- a/lab-examples/srlvjunos01/vjunos.cfg
+++ b/lab-examples/srlvjunos01/vjunos.cfg
@@ -1,5 +1,23 @@
-configure
-set interfaces ge-0/0/0 unit 0 family inet address 192.168.0.1/24
-set interfaces ge-0/0/1 unit 0 family inet address 192.168.1.1/24
-set interfaces ge-0/0/2 unit 0 family inet address 192.168.2.1/24
-commit
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 192.168.0.1/24;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 192.168.1.1/24;
+            }
+        }
+    }
+    ge-0/0/2 {
+        unit 0 {
+            family inet {
+                address 192.168.2.1/24;
+            }                           
+        }
+    }
+}

--- a/lab-examples/srlvjunos01/vjunos.cfg
+++ b/lab-examples/srlvjunos01/vjunos.cfg
@@ -1,0 +1,8 @@
+configure
+set interfaces ge-0/0/0 unit 0 family inet address 192.168.0.1/24
+set interfaces ge-0/0/1 unit 0 family inet address 192.168.1.1/24
+set interfaces ge-0/0/2 unit 0 family inet address 192.168.2.1/24
+set interfaces ge-0/0/3 unit 0 family inet address 192.168.3.1/24
+set interfaces ge-0/0/4 unit 0 family inet address 192.168.4.1/24
+set interfaces ge-0/0/5 unit 0 family inet address 192.168.5.1/24
+commit

--- a/lab-examples/srlvjunos01/vjunos.cfg
+++ b/lab-examples/srlvjunos01/vjunos.cfg
@@ -2,7 +2,4 @@ configure
 set interfaces ge-0/0/0 unit 0 family inet address 192.168.0.1/24
 set interfaces ge-0/0/1 unit 0 family inet address 192.168.1.1/24
 set interfaces ge-0/0/2 unit 0 family inet address 192.168.2.1/24
-set interfaces ge-0/0/3 unit 0 family inet address 192.168.3.1/24
-set interfaces ge-0/0/4 unit 0 family inet address 192.168.4.1/24
-set interfaces ge-0/0/5 unit 0 family inet address 192.168.5.1/24
 commit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
           - Juniper vMX: manual/kinds/vr-vmx.md
           - Juniper vQFX: manual/kinds/vr-vqfx.md
           - Juniper vSRX: manual/kinds/vr-vsrx.md
+          - Juniper vJunos-switch: manual/kinds/vr-vjunosswitch.md
           - Cisco XRd: manual/kinds/xrd.md
           - Cisco XRv9k: manual/kinds/vr-xrv9k.md
           - Cisco XRv: manual/kinds/vr-xrv.md
@@ -90,6 +91,7 @@ nav:
       - Nokia SR Linux and Cisco XRv9k: lab-examples/vr-xrv9k.md
       - Nokia SR Linux and Cisco XRv: lab-examples/vr-xrv.md
       - Nokia SR Linux and FRR: lab-examples/srl-frr.md
+      - Nokia SR Linux and Juniper vJunos-switch: lab-examples/srl-vjunos-switch.md
       - FRR: lab-examples/frr01.md
       - Cumulus Linux and FRR: lab-examples/cvx01.md
       - Cumulus Linux (docker runtime) and Host: lab-examples/cvx02.md

--- a/nodes/vr_vjunosswitch/vr-vjunosswitch.go
+++ b/nodes/vr_vjunosswitch/vr-vjunosswitch.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vr_vjunosswitch
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/netconf"
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindnames          = []string{"vr-vjunosswitch", "vr-juniper_vjunosswitch"}
+	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
+)
+
+const (
+	scrapliPlatformName = "juniper_junos"
+
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
+		return new(vrVJUNOSSWITCH)
+	}, defaultCredentials)
+}
+
+type vrVJUNOSSWITCH struct {
+	nodes.DefaultNode
+}
+
+func (n *vrVJUNOSSWITCH) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init DefaultNode
+	n.DefaultNode = *nodes.NewDefaultNode(n)
+	// set virtualization requirement
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+	// env vars are used to set launch.py arguments in vrnetlab container
+	defEnv := map[string]string{
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
+		"CONNECTION_MODE":    nodes.VrDefConnMode,
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+	}
+	n.Cfg.Env = utils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	// mount config dir to support startup-config functionality
+	n.Cfg.Binds = append(n.Cfg.Binds, fmt.Sprint(path.Join(n.Cfg.LabDir, configDirName), ":/config"))
+
+	if n.Cfg.Env["CONNECTION_MODE"] == "macvtap" {
+		// mount dev dir to enable macvtap
+		n.Cfg.Binds = append(n.Cfg.Binds, "/dev:/dev")
+	}
+
+	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), n.Cfg.ShortName, n.Cfg.Env["CONNECTION_MODE"])
+
+	return nil
+}
+
+func (n *vrVJUNOSSWITCH) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
+	utils.CreateDirectory(n.Cfg.LabDir, 0777)
+	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
+	if err != nil {
+		return nil
+	}
+	return nodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
+}
+
+func (n *vrVJUNOSSWITCH) SaveConfig(_ context.Context) error {
+	err := netconf.SaveConfig(n.Cfg.LongName,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
+		scrapliPlatformName,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("saved %s running configuration to startup configuration file\n", n.Cfg.ShortName)
+	return nil
+}
+
+// CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
+func (n *vrVJUNOSSWITCH) CheckInterfaceName() error {
+	return nodes.GenericVMInterfaceCheck(n.Cfg.ShortName, n.Endpoints)
+}

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -55,6 +55,8 @@
                         "vr-juniper_vqfx",
                         "vr-vsrx",
                         "vr-juniper_vsrx",
+                        "vr-vjunosswitch",
+                        "vr-juniper_vjunosswitch",                      
                         "vr-xrv",
                         "vr-cisco_xrv",
                         "vr-xrv9k",
@@ -710,6 +712,12 @@
                         "vr-vsrx": {
                             "$ref": "#/definitions/node-config"
                         },
+                        "vr-juniper_vjunosswitch": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "vr-vjunosswitch": {
+                            "$ref": "#/definitions/node-config"
+                        },                      
                         "vr-aruba_aoscx": {
                             "$ref": "#/definitions/node-config"
                         },


### PR DESCRIPTION
This PR goes in hand with https://github.com/hellt/vrnetlab/pull/138 for adding support for Juniper's vJunos-switch, a virtual instance of an EX2914. I added the below file I used to test as a lab-example 

```yaml
name: srlvjunos01

topology:
  nodes:
    n1:
      kind: srl
      image: ghcr.io/nokia/srlinux
      startup-config: srl.cli

    vswitch0:
      kind: vr-vjunosswitch
      image: vrnetlab/vr-vjunosswitch:23.2R1.14
      startup-config: vjunos.cfg

  links:
    - endpoints: ["n1:e1-1", "vswitch0:eth1"]
    - endpoints: ["n1:e1-2", "vswitch0:eth2"]
    - endpoints: ["n1:e1-3", "vswitch0:eth3"]
    - endpoints: ["n1:e1-4", "vswitch0:eth4"]
    - endpoints: ["n1:e1-5", "vswitch0:eth5"]
    - endpoints: ["n1:e1-6", "vswitch0:eth6"]
```

Apologies for the double PR