### PR TITLE
Allow 1 to 2 digits for the day of month in certificate dates

### DIFF
--- a/tests/01-smoke/10-ca-parameter.robot
+++ b/tests/01-smoke/10-ca-parameter.robot
@@ -107,7 +107,7 @@ Get Certificate Date
     [Arguments]    ${certificate_output}    ${type}
     ${date} =    Get Regexp Matches
     ...    ${certificate_output}
-    ...    Not ${type}\\W*: (\\w{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4} \\w{3})
+    ...    Not ${type}\\W*: (\\w{3}\\W+\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} \\w{3})
     ...    1
     [Return]    ${date}[0]
 


### PR DESCRIPTION
Tests are broken, since in the regex that checks the validity dates of certificates, we expect the day of the month to be a 2 digit number. actual it must be {1,2} as visible here with also one or two whitespaces (simplified this to +)
```
internal-ca lab CA
        Validity
            Not Before: Aug 31 12:16:02 2023 GMT
            Not After : Sep  1 13:16:02 2023 GMT
```