### PR TITLE
Node Reboot PoC

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -277,6 +277,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// execute commands specified for nodes with `exec` node parameter
 	execCollection := exec.NewExecCollection()
+	first := true
 	for _, n := range c.Nodes {
 		for _, e := range n.Config().Exec {
 			exec, err := exec.NewExecCmdFromString(e)
@@ -291,6 +292,10 @@ func deployFn(_ *cobra.Command, _ []string) error {
 			}
 
 			execCollection.Add(n.Config().ShortName, res)
+		}
+		if first {
+			first = false
+			n.Restart(ctx)
 		}
 	}
 

--- a/links/parkingnetns.go
+++ b/links/parkingnetns.go
@@ -1,0 +1,65 @@
+package links
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netns"
+)
+
+// ParkingNetNs represents a simple NetworkNamespace.
+// It is created when nodes are meant to be restarted.
+// Prior to the restart interfaces will be relocated
+// to the ParkingNetNs and after the reboot is completed,
+// interfaces get shifted back.
+type ParkingNetNs struct {
+	netNsFd int
+	name    string
+}
+
+func NewParkingNetNs(name string) (*ParkingNetNs, error) {
+	// store the actual namespace handle
+	baseNetNs, err := netns.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	// create a "parking" namespace for the network interfaces
+	rebootNs, err := netns.NewNamed(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// revert back to the inital network namespace
+	err = netns.Set(baseNetNs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ParkingNetNs{
+		netNsFd: int(rebootNs),
+		name:    name,
+	}, nil
+}
+
+func (p *ParkingNetNs) Delete() error {
+	return netns.DeleteNamed(p.name)
+}
+
+func (p *ParkingNetNs) GetNetNs() (ns.NetNS, error) {
+	return ns.GetNS(fmt.Sprintf("/proc/self/fd/%d", p.netNsFd))
+}
+
+func (p *ParkingNetNs) GetFd() int {
+	return p.netNsFd
+}
+
+func (p *ParkingNetNs) ExecFunction(f func(ns.NetNS) error) error {
+	// retrieve the namespace handle
+	netns, err := p.GetNetNs()
+	if err != nil {
+		return err
+	}
+	// execute the given function
+	return netns.Do(f)
+}

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -352,6 +352,20 @@ func (mr *MockNodeMockRecorder) PreDeploy(ctx, params interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreDeploy", reflect.TypeOf((*MockNode)(nil).PreDeploy), ctx, params)
 }
 
+// Restart mocks base method.
+func (m *MockNode) Restart(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Restart", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Restart indicates an expected call of Restart.
+func (mr *MockNodeMockRecorder) Restart(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*MockNode)(nil).Restart), ctx)
+}
+
 // RunExec mocks base method.
 func (m *MockNode) RunExec(ctx context.Context, execCmd *exec.ExecCmd) (*exec.ExecResult, error) {
 	m.ctrl.T.Helper()

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -106,6 +106,7 @@ type Node interface {
 	// ExecFunction executes the given function within the nodes network namespace
 	ExecFunction(func(ns.NetNS) error) error
 	GetState() state.NodeState
+	Restart(ctx context.Context) error
 }
 
 type NodeOption func(Node)


### PR DESCRIPTION
This is PoC Code which allows nodes to be rebooted.

There is no real command exposed so far. When deploying a topology, clab will take one node from the topology and reboot it. After the regular deployment process.
This is to test reboot functionality with different kinds.