### PR TITLE
Fill in the 'Country' for generated certificates

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -163,7 +163,7 @@ jobs:
           echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
           curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
           sudo apt update
-          sudo apt install -y podman=4:4.6.2-0ubuntu22.04+obs81.2
+          sudo apt install -y podman
           sudo systemctl start podman
       - uses: actions/setup-python@v4
         with:
@@ -331,7 +331,7 @@ jobs:
           echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
           curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
           sudo apt update
-          sudo apt install -y podman=4:4.6.2-0ubuntu22.04+obs81.2
+          sudo apt install -y podman
           sudo systemctl start podman
 
       - uses: actions/setup-python@v4

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -352,6 +352,7 @@ func certificateAuthoritySetup(c *clab.CLab) error {
 	// define the attributes used to generate the CA Cert
 	caCertInput := &cert.CACSRInput{
 		CommonName:   c.Config.Name + " lab CA",
+		Country:      "US",
 		Expiry:       validityDuration,
 		Organization: "containerlab",
 		KeySize:      keySize,

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -400,6 +400,7 @@ func (d *DefaultNode) LoadOrGenerateCertificate(certInfra *cert.Cert, topoName s
 			CommonName:   nodeConfig.ShortName + "." + topoName + ".io",
 			Hosts:        hosts,
 			Organization: "containerlab",
+			Country:      "US", // don't leave this empty, must be 2 letters
 			KeySize:      d.Cfg.Certificate.KeySize,
 			Expiry:       d.Cfg.Certificate.ValidityDuration,
 		}

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -395,12 +395,11 @@ func (d *DefaultNode) LoadOrGenerateCertificate(certInfra *cert.Cert, topoName s
 		}
 		hosts = append(hosts, nodeConfig.SANs...)
 
-		// collect cert details
 		certInput := &cert.NodeCSRInput{
 			CommonName:   nodeConfig.ShortName + "." + topoName + ".io",
 			Hosts:        hosts,
 			Organization: "containerlab",
-			Country:      "US", // don't leave this empty, must be 2 letters
+			Country:      "US",
 			KeySize:      d.Cfg.Certificate.KeySize,
 			Expiry:       d.Cfg.Certificate.ValidityDuration,
 		}

--- a/tests/01-smoke/10-ca-parameter.robot
+++ b/tests/01-smoke/10-ca-parameter.robot
@@ -42,8 +42,8 @@ Review Root Certificate
     ...    openssl x509 -in ${ca-cert-file} -text
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    Issuer: C = , L = , O = containerlab, OU = , CN = ${lab-name} lab CA
-    Should Contain    ${output}    Subject: C = , L = , O = containerlab, OU = , CN = ${lab-name} lab CA
+    Should Contain    ${output}    Issuer: C = US, L = , O = containerlab, OU = , CN = ${lab-name} lab CA
+    Should Contain    ${output}    Subject: C = US, L = , O = containerlab, OU = , CN = ${lab-name} lab CA
     Should Contain    ${output}    Public-Key: (${ca-keysize} bit)
 
 Node l1 cert and key files should exist
@@ -64,7 +64,7 @@ Review Node l1 Certificate
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    CN = l1.${lab-name}.io
-    Should Contain    ${output}    Issuer: C = , L = , O = containerlab, OU = , CN = ${lab-name} lab CA
+    Should Contain    ${output}    Issuer: C = US, L = , O = containerlab, OU = , CN = ${lab-name} lab CA
     Should Contain    ${output}    Public-Key: (${l1-keysize} bit)
 
 Review Node l2 Certificate
@@ -73,7 +73,7 @@ Review Node l2 Certificate
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    CN = l2.${lab-name}.io
-    Should Contain    ${output}    Issuer: C = , L = , O = containerlab, OU = , CN = ${lab-name} lab CA
+    Should Contain    ${output}    Issuer: C = US, L = , O = containerlab, OU = , CN = ${lab-name} lab CA
     Should Contain    ${output}    Public-Key: (${l2-keysize} bit)
 
 Verfiy node cert l1 with CA Cert
@@ -109,7 +109,7 @@ Get Certificate Date
     ...    ${certificate_output}
     ...    Not ${type}\\W*: (\\w{3}\\W+\\d{1,2} \\d{2}:\\d{2}:\\d{2} \\d{4} \\w{3})
     ...    1
-    [Return]    ${date}[0]
+    RETURN    ${date}[0]
 
 Check Certificat Validity Duration
     [Arguments]    ${certificate_output}    ${expected_duration}


### PR DESCRIPTION
Some users have reported errors from certain tools when the country is not a valid 2-letter string