### PR TITLE
fix: use "vx-<iface>" name for host interface name of vxlan tunnels

### DIFF
--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -50,7 +50,7 @@ func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(params *ResolveParams) (*Li
 
 	lhr := &LinkHostRaw{
 		LinkCommonParams: lr.LinkCommonParams,
-		HostInterface:    fmt.Sprintf("ve-%s_%s", lr.Endpoint.Node, lr.Endpoint.Iface),
+		HostInterface:    fmt.Sprintf("vx-%s", lr.Endpoint.Iface),
 		Endpoint: &EndpointRaw{
 			Node:  lr.Endpoint.Node,
 			Iface: lr.Endpoint.Iface,


### PR DESCRIPTION
per chat w/ @hellt  -- this "fixes" a c9s thing but as im not sure about all the changes in vxlan bits lately im not very confident that this doesnt break anything else :) 