### PR TITLE
Fixing MacVlan interface provisioning

### DIFF
--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -175,9 +175,10 @@ func (l *LinkMacVlan) Deploy(ctx context.Context) error {
 	// build Netlink Macvlan struct
 	link := &netlink.Macvlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:        l.NodeEndpoint.GetRandIfaceName(),
-			ParentIndex: parentInterface.Attrs().Index,
-			MTU:         l.MTU,
+			Name:         l.NodeEndpoint.GetRandIfaceName(),
+			ParentIndex:  parentInterface.Attrs().Index,
+			MTU:          l.MTU,
+			HardwareAddr: l.NodeEndpoint.GetMac(),
 		},
 		Mode: mode,
 	}

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -56,6 +56,7 @@ func macVlanLinkFromBrief(lb *LinkBriefRaw, specialEPIndex int) (*LinkMacVlanRaw
 }
 
 func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
+	var err error
 	// filtered true means the link is in the filter provided by a user
 	// aka it should be resolved/created/deployed
 	filtered := isInFilter(params, []*EndpointRaw{r.Endpoint})
@@ -63,18 +64,13 @@ func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
 		return nil, nil
 	}
 
+	// create the MacVlan Link
 	link := &LinkMacVlan{
 		LinkCommonParams: r.LinkCommonParams,
 	}
-	ep := &EndpointMacVlan{
+	// create the host side MacVlan Endpoint
+	link.HostEndpoint = &EndpointMacVlan{
 		EndpointGeneric: *NewEndpointGeneric(GetHostLinkNode(), r.HostInterface, link),
-	}
-	link.HostEndpoint = ep
-
-	var err error
-	ep.MAC, err = utils.GenMac(ClabOUI)
-	if err != nil {
-		return nil, err
 	}
 
 	// parse the MacVlanMode
@@ -90,23 +86,95 @@ func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
 		return nil, err
 	}
 
-	// add endpoint links to nodes
-	link.HostEndpoint.GetNode().AddLink(link)
-	link.NodeEndpoint.GetNode().AddLink(link)
-
-	// set default link mtu if MTU is unset
-	if link.MTU == 0 {
-		link.MTU = DefaultLinkMTU
+	// propagate the parent interface MTU to the link
+	// because the macvlan interface MTU is inherited from
+	// its parent interface
+	link.MTU, err = link.GetParentInterfaceMtu()
+	if err != nil {
+		return nil, err
 	}
+
+	// add endpoint links to nodes
+	link.NodeEndpoint.GetNode().AddLink(link)
 
 	return link, nil
 }
 
 type LinkMacVlan struct {
 	LinkCommonParams
-	HostEndpoint Endpoint
+	HostEndpoint *EndpointMacVlan
 	NodeEndpoint Endpoint
 	Mode         MacVlanMode
+}
+
+func (*LinkMacVlan) GetType() LinkType {
+	return LinkTypeMacVLan
+}
+
+func (l *LinkMacVlan) GetParentInterfaceMtu() (int, error) {
+	hostLink, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
+	if err != nil {
+		return 0, err
+	}
+	return hostLink.Attrs().MTU, nil
+}
+
+func (l *LinkMacVlan) Deploy(ctx context.Context) error {
+	// lookup the parent host interface
+	parentInterface, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Creating MACVLAN link: %s <--> %s", l.HostEndpoint, l.NodeEndpoint)
+
+	// build Netlink Macvlan struct
+	link := &netlink.Macvlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        l.NodeEndpoint.GetRandIfaceName(),
+			ParentIndex: parentInterface.Attrs().Index,
+		},
+		Mode: l.Mode.ToNetlinkMode(),
+	}
+	// add the link in the Host NetNS
+	err = netlink.LinkAdd(link)
+	if err != nil {
+		return err
+	}
+
+	// retrieve the Link by name
+	mvInterface, err := utils.LinkByNameOrAlias(l.NodeEndpoint.GetRandIfaceName())
+	if err != nil {
+		return fmt.Errorf("failed to lookup %q: %v", l.NodeEndpoint.GetRandIfaceName(), err)
+	}
+
+	// add the link to the Node Namespace
+	err = l.NodeEndpoint.GetNode().AddLinkToContainer(ctx, mvInterface,
+		SetNameMACAndUpInterface(mvInterface, l.NodeEndpoint))
+	return err
+}
+
+func (l *LinkMacVlan) Remove(_ context.Context) error {
+	// check Deployment state, if the Link was already
+	// removed via e.g. the peer node
+	if l.DeploymentState == LinkDeploymentStateRemoved {
+		return nil
+	}
+	// trigger link removal via the NodeEndpoint
+	err := l.NodeEndpoint.Remove()
+	if err != nil {
+		log.Debug(err)
+	}
+	// adjust the Deployment status to reflect the removal
+	l.DeploymentState = LinkDeploymentStateRemoved
+	return nil
+}
+
+func (l *LinkMacVlan) GetEndpoints() []Endpoint {
+	return []Endpoint{
+		l.NodeEndpoint,
+		l.HostEndpoint,
+	}
 }
 
 type MacVlanMode string
@@ -137,31 +205,11 @@ func MacVlanModeParse(s string) (MacVlanMode, error) {
 	return "", fmt.Errorf("unknown MacVlanMode %q", s)
 }
 
-func (*LinkMacVlan) GetType() LinkType {
-	return LinkTypeMacVLan
-}
-
-func (l *LinkMacVlan) GetParentInterfaceMtu() (int, error) {
-	hostLink, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
-	if err != nil {
-		return 0, err
-	}
-	return hostLink.Attrs().MTU, nil
-}
-
-func (l *LinkMacVlan) Deploy(ctx context.Context) error {
-	// lookup the parent host interface
-	parentInterface, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Creating MACVLAN link: %s <--> %s", l.HostEndpoint, l.NodeEndpoint)
-
-	// set MacVlanMode
-	mode := netlink.MACVLAN_MODE_BRIDGE
-	switch l.Mode {
+func (m MacVlanMode) ToNetlinkMode() netlink.MacvlanMode {
+	var mode netlink.MacvlanMode
+	switch m {
 	case MacVlanModeBridge:
+		mode = netlink.MACVLAN_MODE_BRIDGE
 	case MacVlanModePassthru:
 		mode = netlink.MACVLAN_MODE_PASSTHRU
 	case MacVlanModeVepa:
@@ -171,50 +219,5 @@ func (l *LinkMacVlan) Deploy(ctx context.Context) error {
 	case MacVlanModeSource:
 		mode = netlink.MACVLAN_MODE_SOURCE
 	}
-
-	// build Netlink Macvlan struct
-	link := &netlink.Macvlan{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:         l.NodeEndpoint.GetRandIfaceName(),
-			ParentIndex:  parentInterface.Attrs().Index,
-			MTU:          l.MTU,
-			HardwareAddr: l.NodeEndpoint.GetMac(),
-		},
-		Mode: mode,
-	}
-	// add the link in the Host NetNS
-	err = netlink.LinkAdd(link)
-	if err != nil {
-		return err
-	}
-
-	// retrieve the Link by name
-	mvInterface, err := utils.LinkByNameOrAlias(l.NodeEndpoint.GetRandIfaceName())
-	if err != nil {
-		return fmt.Errorf("failed to lookup %q: %v", l.NodeEndpoint.GetRandIfaceName(), err)
-	}
-
-	// add the link to the Node Namespace
-	err = l.NodeEndpoint.GetNode().AddLinkToContainer(ctx, mvInterface,
-		SetNameMACAndUpInterface(mvInterface, l.NodeEndpoint))
-	return err
-}
-
-func (l *LinkMacVlan) Remove(_ context.Context) error {
-	if l.DeploymentState == LinkDeploymentStateRemoved {
-		return nil
-	}
-	err := l.NodeEndpoint.Remove()
-	if err != nil {
-		log.Debug(err)
-	}
-	l.DeploymentState = LinkDeploymentStateRemoved
-	return nil
-}
-
-func (l *LinkMacVlan) GetEndpoints() []Endpoint {
-	return []Endpoint{
-		l.NodeEndpoint,
-		l.HostEndpoint,
-	}
+	return mode
 }

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -89,7 +89,7 @@ func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
 	// propagate the parent interface MTU to the link
 	// because the macvlan interface MTU is inherited from
 	// its parent interface
-	link.MTU, err = link.GetParentInterfaceMtu()
+	link.MTU, err = link.GetParentInterfaceMTU()
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (*LinkMacVlan) GetType() LinkType {
 	return LinkTypeMacVLan
 }
 
-func (l *LinkMacVlan) GetParentInterfaceMtu() (int, error) {
+func (l *LinkMacVlan) GetParentInterfaceMTU() (int, error) {
 	hostLink, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
 	if err != nil {
 		return 0, err

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -18,7 +18,6 @@ topology:
       exec:
         - echo this_is_an_exec_test
         - cat /etc/os-release
-        - apk add iproute2
       cpu: 1.5
       memory: 1G
       mgmt_ipv4: 172.20.20.99 # test deprecated mgmt_ipv4 still works
@@ -70,4 +69,3 @@ topology:
         node: l2
         interface: eth5
         mac: 02:00:00:00:00:05
-    - endpoints: ["l1:eth4", "macvlan:${host_link:=ens3}"]

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -18,6 +18,7 @@ topology:
       exec:
         - echo this_is_an_exec_test
         - cat /etc/os-release
+        - apk add iproute2
       cpu: 1.5
       memory: 1G
       mgmt_ipv4: 172.20.20.99 # test deprecated mgmt_ipv4 still works
@@ -69,3 +70,4 @@ topology:
         node: l2
         interface: eth5
         mac: 02:00:00:00:00:05
+    - endpoints: ["l1:eth4", "macvlan:${host_link:=ens3}"]

--- a/tests/01-smoke/14-macvlan.robot
+++ b/tests/01-smoke/14-macvlan.robot
@@ -9,11 +9,11 @@ Suite Teardown      Run Keyword    Teardown
 
 
 *** Variables ***
-${lab-name}         2-linux-nodes
-${topo}             ${CURDIR}/01-linux-nodes.clab.yml
+${lab-name}         macvlan
+${topo}             ${CURDIR}/macvlan.clab.yml
 ${runtime}          docker
 # interface inside l1 node that should be macvlan
-${macvlan-iface}    eth4
+${macvlan-iface}    eth1
 
 
 *** Test Cases ***

--- a/tests/01-smoke/14-macvlan.robot
+++ b/tests/01-smoke/14-macvlan.robot
@@ -40,7 +40,7 @@ Deploy ${lab-name} lab
 
 Check macvlan interface on l1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E docker exec -it clab-${lab-name}-l1 ip -d link show ${macvlan-iface}
+    ...    sudo -E docker exec clab-${lab-name}-l1 ip -d link show ${macvlan-iface}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP

--- a/tests/01-smoke/14-macvlan.robot
+++ b/tests/01-smoke/14-macvlan.robot
@@ -1,0 +1,58 @@
+*** Settings ***
+Library             OperatingSystem
+Library             String
+Library             Process
+Resource            ../common.robot
+
+Suite Setup         Setup
+Suite Teardown      Run Keyword    Teardown
+
+
+*** Variables ***
+${lab-name}         2-linux-nodes
+${topo}             ${CURDIR}/01-linux-nodes.clab.yml
+${runtime}          docker
+# interface inside l1 node that should be macvlan
+${macvlan-iface}    eth4
+
+
+*** Test Cases ***
+Find parent interface
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip -j route get 8.8.8.8 | jq -r .[].dev
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+    Set Suite Variable    ${parent}    ${output}
+
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip -j l show ${parent} | jq -r .[].mtu
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+    Set Suite Variable    ${parent_mtu}    ${output}
+
+Deploy ${lab-name} lab
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E host_link=${parent} ${CLAB_BIN} --runtime ${runtime} deploy -c -t ${topo}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Check macvlan interface on l1
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E docker exec -it clab-${lab-name}-l1 ip -d link show ${macvlan-iface}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    state UP
+    Should Contain    ${output}    macvlan mode bridge
+    Should Contain    ${output}    mtu ${parent_mtu}
+
+
+*** Keywords ***
+Teardown
+    # destroy all labs
+    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -a
+
+Setup
+    # skipping this test suite for podman for now
+    Skip If    '${runtime}' == 'podman'

--- a/tests/01-smoke/macvlan.clab.yml
+++ b/tests/01-smoke/macvlan.clab.yml
@@ -1,0 +1,16 @@
+# Copyright 2023 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: macvlan
+
+topology:
+  nodes:
+    l1:
+      kind: linux
+      image: alpine:3
+      exec:
+        - apk add iproute2
+
+  links:
+    - endpoints: ["l1:eth1", "macvlan:${host_link:=ens3}"]


### PR DESCRIPTION
MacVlan interfaces are dependent on an existing parent Interface.
This parent interface defines the MTU of the derived MacVlan interface.

This PR now avoids setting the MTU for MacVlan interfaces but instead queries the parent interface in the resolve phase and adjusts the internal MTU value of the MacVlan interface accordingly, such that on configuration generation, this value can be propagated to the nodes config.

Fixing #1633