### PR TITLE
Generate SSH config

### DIFF
--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -17,7 +17,7 @@ type tmplSshConfigData struct {
 // thats handed to the template engine
 type tmplSshConfigDataNode struct {
 	Name     string
-	HostName string
+	Hostname string
 	Username string
 }
 
@@ -57,7 +57,7 @@ func (c *CLab) DeploySSHConfig() error {
 		NodeRegistryEntry := c.Reg.Kind(n.Config().Kind)
 		nodeData := tmplSshConfigDataNode{
 			Name:     n.Config().LongName,
-			HostName: n.Config().LongName,
+			Hostname: n.Config().LongName,
 			Username: NodeRegistryEntry.Credentials().GetUsername(),
 		}
 		tmplData.Nodes = append(tmplData.Nodes, nodeData)

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -42,8 +42,8 @@ func (c *CLab) RemoveSSHConfig() error {
 	return os.Remove(filename)
 }
 
-// DeploySSHConfig deploys the lab specific ssh config file
-func (c *CLab) DeploySSHConfig() error {
+// AddSSHConfig adds the lab specific ssh config file
+func (c *CLab) AddSSHConfig() error {
 	// create the struct that holds the template input data
 	tmplData := &SSHConfigDataTmpl{
 		TopologyName: c.Config.Name,

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -25,7 +25,9 @@ const tmplSshConfig = `# Containerlab SSH Config for the {{ .TopologyName }} lab
 
 {{- range  .Nodes }}
 Host {{ .Name }}
+	{{-  if ne .Username ""}}
 	User {{ .Username }}
+	{{- end }}
 	StrictHostKeyChecking=no 
 	UserKnownHostsFile=/dev/null
 {{ end }}`
@@ -36,8 +38,12 @@ const sshConfigFileTmpl = "/etc/ssh/ssh_config.d/clab-%s.conf"
 // RemoveSSHConfig removes the lab specific ssh config file
 func (c *CLab) RemoveSSHConfig() error {
 	filename := fmt.Sprintf(sshConfigFileTmpl, c.Config.Name)
-
-	return os.Remove(filename)
+	err := os.Remove(filename)
+	// if there is an error, thats not "Not Exists", then return it
+	if err != nil && err != os.ErrNotExist {
+		return err
+	}
+	return nil
 }
 
 // AddSSHConfig adds the lab specific ssh config file.

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -6,22 +6,22 @@ import (
 	"text/template"
 )
 
-// tmplSshConfigData is the top-level data structure for the
+// SSHConfigDataTmpl is the top-level data structure for the
 // sshconfig template
-type tmplSshConfigData struct {
-	Nodes        []tmplSshConfigDataNode
+type SSHConfigDataTmpl struct {
+	Nodes        []SSHConfigDataNodeTmpl
 	TopologyName string
 }
 
-// tmplSshConfigDataNode is the per node structure
+// SSHConfigDataNodeTmpl is the per node structure
 // thats handed to the template engine
-type tmplSshConfigDataNode struct {
+type SSHConfigDataNodeTmpl struct {
 	Name     string
 	Hostname string
 	Username string
 }
 
-// tmplSshConfig is the SSH config template itself
+// tmplSshConfig is the SSH config template
 const tmplSshConfig = `# Clab SSH Config for topology {{ .TopologyName }}
 
 {{- range  .Nodes }}
@@ -45,9 +45,9 @@ func (c *CLab) RemoveSSHConfig() error {
 // DeploySSHConfig deploys the lab specific ssh config file
 func (c *CLab) DeploySSHConfig() error {
 	// create the struct that holds the template input data
-	tmplData := &tmplSshConfigData{
+	tmplData := &SSHConfigDataTmpl{
 		TopologyName: c.Config.Name,
-		Nodes:        make([]tmplSshConfigDataNode, 0, len(c.Nodes)),
+		Nodes:        make([]SSHConfigDataNodeTmpl, 0, len(c.Nodes)),
 	}
 
 	// add the data for all nodes to the template input
@@ -55,7 +55,7 @@ func (c *CLab) DeploySSHConfig() error {
 		// get the Kind from the KindRegistry and and extract
 		// the kind registered Username from there
 		NodeRegistryEntry := c.Reg.Kind(n.Config().Kind)
-		nodeData := tmplSshConfigDataNode{
+		nodeData := SSHConfigDataNodeTmpl{
 			Name:     n.Config().LongName,
 			Hostname: n.Config().LongName,
 			Username: NodeRegistryEntry.Credentials().GetUsername(),

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -1,0 +1,72 @@
+package clab
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+)
+
+type tmplSshConfigDataNode struct {
+	Name     string
+	HostName string
+	Username string
+}
+
+type tmplSshConfigData struct {
+	Nodes        []tmplSshConfigDataNode
+	TopologyName string
+}
+
+const tmplSshConfig = `# Clab SSH Config for topology {{ .TopologyName }}
+
+{{- range  .Nodes }}
+Host {{ .Name }}
+	Hostname {{ .HostName }}
+	User {{ .Username }}
+	StrictHostKeyChecking=no 
+	UserKnownHostsFile=/dev/null
+{{ end }}`
+
+const sshConfigFileTmpl = "/etc/ssh/ssh_config.d/clab-%s.conf"
+
+func (c *CLab) DestroySSHConfig() error {
+	filename := fmt.Sprintf(sshConfigFileTmpl, c.Config.Name)
+	return os.Remove(filename)
+}
+
+func (c *CLab) DeploySSHConfig() error {
+	tmplData := &tmplSshConfigData{
+		TopologyName: c.Config.Name,
+		Nodes:        make([]tmplSshConfigDataNode, 0, len(c.Nodes)),
+	}
+
+	for _, n := range c.Nodes {
+		// get the Kind from the KindRegistry and and extract
+		// the kind registered Username from there
+		NodeRegistryEntry := c.Reg.Kind(n.Config().Kind)
+		nodeData := tmplSshConfigDataNode{
+			Name:     n.Config().LongName,
+			HostName: n.Config().LongName,
+			Username: NodeRegistryEntry.Credentials().GetUsername(),
+		}
+		tmplData.Nodes = append(tmplData.Nodes, nodeData)
+	}
+
+	t, err := template.New("sshconfig").Parse(tmplSshConfig)
+	if err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf(sshConfigFileTmpl, c.Config.Name)
+
+	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = t.Execute(f, tmplData)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -6,17 +6,22 @@ import (
 	"text/template"
 )
 
+// tmplSshConfigData is the top-level data structure for the
+// sshconfig template
+type tmplSshConfigData struct {
+	Nodes        []tmplSshConfigDataNode
+	TopologyName string
+}
+
+// tmplSshConfigDataNode is the per node structure
+// thats handed to the template engine
 type tmplSshConfigDataNode struct {
 	Name     string
 	HostName string
 	Username string
 }
 
-type tmplSshConfigData struct {
-	Nodes        []tmplSshConfigDataNode
-	TopologyName string
-}
-
+// tmplSshConfig is the SSH config template itself
 const tmplSshConfig = `# Clab SSH Config for topology {{ .TopologyName }}
 
 {{- range  .Nodes }}
@@ -27,19 +32,25 @@ Host {{ .Name }}
 	UserKnownHostsFile=/dev/null
 {{ end }}`
 
+// sshConfigFileTmpl is the sprintf based string, representing the
+// sshconfig filename. It just requres the labname as the fmt.Sprintf argument
 const sshConfigFileTmpl = "/etc/ssh/ssh_config.d/clab-%s.conf"
 
-func (c *CLab) DestroySSHConfig() error {
+// RemoveSSHConfig removes the lab specific ssh config file
+func (c *CLab) RemoveSSHConfig() error {
 	filename := fmt.Sprintf(sshConfigFileTmpl, c.Config.Name)
 	return os.Remove(filename)
 }
 
+// DeploySSHConfig deploys the lab specific ssh config file
 func (c *CLab) DeploySSHConfig() error {
+	// create the struct that holds the template input data
 	tmplData := &tmplSshConfigData{
 		TopologyName: c.Config.Name,
 		Nodes:        make([]tmplSshConfigDataNode, 0, len(c.Nodes)),
 	}
 
+	// add the data for all nodes to the template input
 	for _, n := range c.Nodes {
 		// get the Kind from the KindRegistry and and extract
 		// the kind registered Username from there
@@ -52,18 +63,23 @@ func (c *CLab) DeploySSHConfig() error {
 		tmplData.Nodes = append(tmplData.Nodes, nodeData)
 	}
 
+	// parse the template
 	t, err := template.New("sshconfig").Parse(tmplSshConfig)
 	if err != nil {
 		return err
 	}
 
+	// completly resolve the output filename with the topology name
 	filename := fmt.Sprintf(sshConfigFileTmpl, c.Config.Name)
 
+	// open the output file, creating if it does not exist, truncate it otherwise
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}
 
+	// execute the template and write the result
+	// to the open file
 	err = t.Execute(f, tmplData)
 	if err != nil {
 		return err

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -275,6 +275,12 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		log.Errorf("failed to create hosts file: %v", err)
 	}
 
+	log.Info("Adding ssh config for containerlab nodes")
+	err = c.DeploySSHConfig()
+	if err != nil {
+		log.Errorf("failed to create ssh config file: %v", err)
+	}
+
 	// execute commands specified for nodes with `exec` node parameter
 	execCollection := exec.NewExecCollection()
 	for _, n := range c.Nodes {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -276,7 +276,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	}
 
 	log.Info("Adding ssh config for containerlab nodes")
-	err = c.AddSSHConfig()
+	err = c.AddSSHConfig(c.TopoPaths)
 	if err != nil {
 		log.Errorf("failed to create ssh config file: %v", err)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -276,7 +276,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	}
 
 	log.Info("Adding ssh config for containerlab nodes")
-	err = c.DeploySSHConfig()
+	err = c.AddSSHConfig()
 	if err != nil {
 		log.Errorf("failed to create ssh config file: %v", err)
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -211,6 +211,12 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 		return fmt.Errorf("error while trying to clean up the hosts file: %w", err)
 	}
 
+	log.Info("Removing ssh config for containerlab nodes")
+	err = c.DestroySSHConfig()
+	if err != nil {
+		log.Errorf("failed to remove ssh config file: %v", err)
+	}
+
 	// delete lab management network
 	if c.Config.Mgmt.Network != "bridge" && !keepMgmtNet {
 		log.Debugf("Calling DeleteNet method. *CLab.Config.Mgmt value is: %+v", c.Config.Mgmt)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -212,7 +212,7 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 	}
 
 	log.Info("Removing ssh config for containerlab nodes")
-	err = c.DestroySSHConfig()
+	err = c.RemoveSSHConfig()
 	if err != nil {
 		log.Errorf("failed to remove ssh config file: %v", err)
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -212,7 +212,7 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 	}
 
 	log.Info("Removing ssh config for containerlab nodes")
-	err = c.RemoveSSHConfig()
+	err = c.RemoveSSHConfig(c.TopoPaths)
 	if err != nil {
 		log.Errorf("failed to remove ssh config file: %v", err)
 	}

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -1,6 +1,7 @@
 To accommodate for smooth transition from lab deployment to subsequent automation activities, containerlab generates inventory files for different automation tools.
 
 ## Ansible
+
 Ansible inventory is generated automatically for every lab. The inventory file can be found in the lab directory under the `ansible-inventory.yml` name.
 
 Lab nodes are grouped under their kinds in the inventory so that the users can selectively choose the right group of nodes in the playbooks.
@@ -47,6 +48,7 @@ Lab nodes are grouped under their kinds in the inventory so that the users can s
     ```
 
 ## Removing `ansible_host` var
+
 If you want to use a plugin[^1] that doesn't play well with the `ansible_host` variable injected by containerlab in the inventory file, you can leverage the `ansible-no-host-var` label. The label can be set on per-node, kind, or default levels; if set, containerlab will not generate the `ansible_host` variable in the inventory for the nodes with that label.  
 Note that without the `ansible_host` variable, the connection plugin will use the `inventory_hostname` and resolve the name accordingly if network reachability is needed.
 
@@ -72,6 +74,7 @@ Note that without the `ansible_host` variable, the connection plugin will use th
     ```
 
 ## User-defined groups
+
 Users can enforce custom grouping of nodes in the inventory by adding the `ansible-inventory` label to the node definition:
 
 ```yaml
@@ -109,16 +112,17 @@ As a result of this configuration, the generated inventory will look like this:
 ```
 
 ## Topology Data
+
 Every time a user runs a `deploy` command, containerlab automatically exports information about the topology into `topology-data.json` file in the lab directory. Schema of exported data is determined based on a Go template specified in `--export-template` parameter, or a default template `/etc/containerlab/templates/export/auto.tmpl`, if the parameter is not provided.
 
 Containerlab internal data that is submitted for export via the template, has the following structure:
 
 ```golang
 type TopologyExport struct {
-	Name        string                       `json:"name"`                  // Containerlab topology name
-	Type        string                       `json:"type"`                  // Always 'clab'
-	Clab        *CLab                        `json:"clab,omitempty"`        // Data parsed from a topology definitions yaml file
-	NodeConfigs map[string]*types.NodeConfig `json:"nodeconfigs,omitempty"` // Definitions of nodes expanded with dynamically created data
+ Name        string                       `json:"name"`                  // Containerlab topology name
+ Type        string                       `json:"type"`                  // Always 'clab'
+ Clab        *CLab                        `json:"clab,omitempty"`        // Data parsed from a topology definitions yaml file
+ NodeConfigs map[string]*types.NodeConfig `json:"nodeconfigs,omitempty"` // Definitions of nodes expanded with dynamically created data
 }
 ```
 
@@ -237,5 +241,45 @@ Example of exported data when using default `auto.tmpl` template:
       ]
     }
     ```
+
+## SSH Config
+
+To simplify SSH access to the nodes started by Containerlab an SSH config file is generated per each deployed lab. The config file instructs SSH clients to not warn users about the changed host keys and also sets the username to the one known by Containerlab:
+
+```title="/etc/ssh/ssh_config.d/clab-<lab-name>.conf"
+# Containerlab SSH Config for the srl lab
+Host clab-srl-srl
+  User admin
+  StrictHostKeyChecking=no 
+  UserKnownHostsFile=/dev/null
+```
+
+Now you can SSH to the nodes without being prompted to accept the host key and even omitting the username.
+
+```srl
+❯ ssh clab-srl-srl
+Warning: Permanently added 'clab-srl-srl' (ED25519) to the list of known hosts.
+................................................................
+:                  Welcome to Nokia SR Linux!                  :
+:              Open Network OS for the NetOps era.             :
+:                                                              :
+:    This is a freely distributed official container image.    :
+:                      Use it - Share it                       :
+:                                                              :
+: Get started: https://learn.srlinux.dev                       :
+: Container:   https://go.srlinux.dev/container-image          :
+: Docs:        https://doc.srlinux.dev/23-7                    :
+: Rel. notes:  https://doc.srlinux.dev/rn23-7-1                :
+: YANG:        https://yang.srlinux.dev/release/v23.7.1        :
+: Discord:     https://go.srlinux.dev/discord                  :
+: Contact:     https://go.srlinux.dev/contact-sales            :
+................................................................
+
+Using configuration file(s): []
+Welcome to the srlinux CLI.
+Type 'help' (and press <ENTER>) if you need any help using this.
+--{ running }--[  ]--
+A:srl#
+```
 
 [^1]: For example [Ansible Docker connection](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_connection.html) plugin.

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -111,6 +111,7 @@ func (t *TopoPaths) SetExternalCaFiles(certFile, keyFile string) error {
 	return nil
 }
 
+// SSHConfigPath returns the topology dependent ssh config file name
 func (t *TopoPaths) SSHConfigPath() string {
 	return fmt.Sprintf(sshConfigFilePathTmpl, t.topoName)
 }

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -23,6 +23,7 @@ const (
 	CertFileSuffix            = ".pem"
 	KeyFileSuffix             = ".key"
 	CSRFileSuffix             = ".csr"
+	sshConfigFilePathTmpl     = "/etc/ssh/ssh_config.d/clab-%s.conf"
 )
 
 // clabTmpDir is the directory where clab stores temporary and/or downloaded files.
@@ -108,6 +109,10 @@ func (t *TopoPaths) SetExternalCaFiles(certFile, keyFile string) error {
 	t.externalCAKeyFile = keyFile
 
 	return nil
+}
+
+func (t *TopoPaths) SSHConfigPath() string {
+	return fmt.Sprintf(sshConfigFilePathTmpl, t.topoName)
 }
 
 // TLSBaseDir returns the path of the TLS directory structure.


### PR DESCRIPTION
Generate SSH config that:
- Set the Username for the nodes
- Set StrictHostKeyChecking=no
- Set UserKnownHostsFile=/dev/null

Been thinking of using wildcard match, but in case the prefix of nodes is set to ""
```
name: MyTopoName 
prefix: ""
```
The Names would not have a prefix name of "clab-<labname>" anymore. So going with individual entries is the best option.

Implementing #1659 