### PR TITLE
chown labdir

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -306,6 +306,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	// log new version availability info if ready
 	newVerNotification(vCh)
 
+	err = utils.RecursiveAdjustUIDAndGUID(c.TopoPaths.TopologyLabDir())
+	if err != nil {
+		log.Infof("error adjusting LabDir permissions: %v. Continuing anyways", err)
+	}
+
 	// print table summary
 	return printContainerInspect(containers, deployFormat)
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -300,4 +301,44 @@ func FileLines(path, commentStr string) ([]string, error) {
 	}
 
 	return lines, nil
+}
+
+// RecursiveAdjustUIDAndGUID tries to changes the UID and GID
+// of the given path recursively to value taken from
+// SUDO_UID and SUDO_GID. Which should reflect be the non-root
+// user that called clab via sudo.
+func RecursiveAdjustUIDAndGUID(fsPath string) error {
+	userId, isSet := os.LookupEnv("SUDO_UID")
+	if !isSet {
+		return fmt.Errorf("unable to adjust UID and GUI for %q. SUDO_UID not set", fsPath)
+	}
+	groupId, isSet := os.LookupEnv("SUDO_GID")
+	if !isSet {
+		return fmt.Errorf("unable to retrieve GID. will only adjust UID for %q", fsPath)
+	}
+
+	intUserId, err := strconv.Atoi(userId)
+	if err != nil {
+		return fmt.Errorf("unable to convert SUDO_UID %q to int", userId)
+	}
+	intGroupId, err := strconv.Atoi(groupId)
+	if err != nil {
+		return fmt.Errorf("unable to convert SUDO_GID %q to int", groupId)
+	}
+
+	err = chownR(fsPath, intUserId, intGroupId)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// chownR function to recursively change User and Group
+func chownR(path string, uid, gid int) error {
+	return filepath.Walk(path, func(name string, info os.FileInfo, err error) error {
+		if err == nil {
+			err = os.Chown(name, uid, gid)
+		}
+		return err
+	})
 }


### PR DESCRIPTION
As a final step of the deployment ownership of the lab dir are adjusted to <SUDO_UID>:<SUDO_GID>.
Which will help when cleaning up labs. These days a `sudo rm <labdir> ...` is needed. With this PR no sudo is required anymore.