### PR TITLE
Support for SSH Public Key Provisioning for vr-sros

### DIFF
--- a/nodes/vr_sros/DefCfg.go.tpl
+++ b/nodes/vr_sros/DefCfg.go.tpl
@@ -1,0 +1,9 @@
+{{/* this is a template for sros public key config for ssh admin user access */}}
+
+{{ range $index, $key := .SSHPubKeysRSA }}
+/configure system security user-params local-user user "admin" public-keys rsa rsa-key {{ add $index 1 }} key-value {{ $key }}
+{{ end }}
+
+{{ range $index, $key := .SSHPubKeysECDSA }}
+/configure system security user-params local-user user "admin" public-keys ecdsa ecdsa-key {{ add $index +1 }} key-value {{ $key }}
+{{ end }}

--- a/nodes/vr_sros/sshkey.go
+++ b/nodes/vr_sros/sshkey.go
@@ -14,8 +14,6 @@ func (s *vrSROS) filterSSHPubKeys(sshKeyAlgo []string) []string {
 
 	for _, k := range s.sshPubKeys {
 		if slices.Contains(sshKeyAlgo, k.Type()) {
-			//switch k.Type() {
-			//case slices.Contains(sshKeyAlgo):
 
 			keyType := k.Type()
 			keyString := string(ssh.MarshalAuthorizedKey(k))

--- a/nodes/vr_sros/sshkey.go
+++ b/nodes/vr_sros/sshkey.go
@@ -1,0 +1,36 @@
+package vr_sros
+
+import (
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// filterSSHPubKeys removes non-rsa keys from n.sshPubKeys until srl adds support for them.
+func (s *vrSROS) filterSSHPubKeys(sshKeyAlgo string) []string {
+
+	keyValues := []string{}
+
+	for _, k := range s.sshPubKeys {
+		switch k.Type() {
+		case sshKeyAlgo:
+
+			keyType := k.Type()
+			keyString := string(ssh.MarshalAuthorizedKey(k))
+
+			// Remove the key type prefix
+			keyString = strings.TrimPrefix(keyString, keyType+" ")
+
+			// Remove the suffix (usually a comment or username)
+			parts := strings.Fields(keyString)
+			if len(parts) > 1 {
+				keyString = parts[0]
+			}
+
+			keyValues = append(keyValues, keyString)
+
+		}
+	}
+
+	return keyValues
+}

--- a/nodes/vr_sros/sshkey.go
+++ b/nodes/vr_sros/sshkey.go
@@ -1,19 +1,21 @@
 package vr_sros
 
 import (
+	"slices"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
 )
 
 // filterSSHPubKeys removes non-rsa keys from n.sshPubKeys until srl adds support for them.
-func (s *vrSROS) filterSSHPubKeys(sshKeyAlgo string) []string {
+func (s *vrSROS) filterSSHPubKeys(sshKeyAlgo []string) []string {
 
 	keyValues := []string{}
 
 	for _, k := range s.sshPubKeys {
-		switch k.Type() {
-		case sshKeyAlgo:
+		if slices.Contains(sshKeyAlgo, k.Type()) {
+			//switch k.Type() {
+			//case slices.Contains(sshKeyAlgo):
 
 			keyType := k.Type()
 			keyString := string(ssh.MarshalAuthorizedKey(k))

--- a/nodes/vr_sros/sshkey.go
+++ b/nodes/vr_sros/sshkey.go
@@ -1,13 +1,13 @@
 package vr_sros
 
 import (
-	"slices"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/slices"
 )
 
-// filterSSHPubKeys removes non-rsa keys from n.sshPubKeys until srl adds support for them.
+// filterSSHPubKeys provides extracted key values based on key-algo for usage in vrSROS configuration
 func (s *vrSROS) filterSSHPubKeys(sshKeyAlgo []string) []string {
 
 	keyValues := []string{}

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -164,8 +164,6 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) erro
 		return err
 	}
 
-	print(buf.String())
-
 	err = s.applyDefaultConfig(ctx, s.Cfg.MgmtIPv4Address, scrapliPlatformName,
 		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(),
 		buf.String(),

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -142,10 +142,15 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) erro
 	// tplData holds data used in templating of the default config snippet
 	tplData := vrSROSTemplateData{}
 
+	// creating a list of ECDSA Key Types
+	rsaKeyTypes := []string{"ssh-rsa"}
+	ecdsaKeyTypes := []string{"ssh-ed25519", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521"}
+	//ecdsaKeyTypes := "\"ecdsa-sha2-nistp256\", \"ecdsa-sha2-nistp384\", \"ecdsa-sha2-nistp521\", \"ssh-ed25519\""
+
 	// checking on existence of SSH Public Keys and populating tplData
 	if len(s.sshPubKeys) > 0 {
-		tplData.SSHPubKeysRSA = s.filterSSHPubKeys("ssh-rsa")
-		tplData.SSHPubKeysECDSA = s.filterSSHPubKeys("ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521, ssh-ed25519")
+		tplData.SSHPubKeysRSA = s.filterSSHPubKeys(rsaKeyTypes)
+		tplData.SSHPubKeysECDSA = s.filterSSHPubKeys(ecdsaKeyTypes)
 	}
 
 	t, err := template.New("DefCfg").Funcs(gomplate.CreateFuncs(context.Background(), new(data.Data))).Parse(vrSrosConfigCmdsTpl)

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -145,7 +145,6 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) erro
 	// creating a list of ECDSA Key Types
 	rsaKeyTypes := []string{"ssh-rsa"}
 	ecdsaKeyTypes := []string{"ssh-ed25519", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521"}
-	//ecdsaKeyTypes := "\"ecdsa-sha2-nistp256\", \"ecdsa-sha2-nistp384\", \"ecdsa-sha2-nistp521\", \"ssh-ed25519\""
 
 	// checking on existence of SSH Public Keys and populating tplData
 	if len(s.sshPubKeys) > 0 {


### PR DESCRIPTION
Added support to automatically provision SSH public keys into vr-sros nodes. 
Used the embed function to store my config command template in a dedicated external file. I liked this approach better than to specify the commands directly in the vr-sros.go file. 

I created a dedicated function for the health check/readiness probe. 

I would like to improve sessions handling a bit though. I would prefer to re-use the same session for the readiness probe, the applyPartialConfig and the applyDefaultConfig functions. Although it works as is, I would be also happy about a pointer on how to improve this. 