### PR TITLE
Adjust labdir acls

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -158,7 +158,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
 	if err != nil {
-		return err
+		log.Errorf("error adjusting Labdir ACLs: %v", err)
 	}
 
 	// create an empty ansible inventory file that will get populated later
@@ -310,11 +310,6 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// log new version availability info if ready
 	newVerNotification(vCh)
-
-	// err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
-	// if err != nil {
-	// 	return err
-	// }
 
 	// print table summary
 	return printContainerInspect(containers, deployFormat)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -155,10 +155,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	log.Info("Creating lab directory: ", c.TopoPaths.TopologyLabDir())
 	utils.CreateDirectory(c.TopoPaths.TopologyLabDir(), 0755)
-
+	// adjust ACL for Labdir such that SUDO_UID Users will
+	// also have access to lab directory files
 	err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
 	if err != nil {
-		log.Errorf("error adjusting Labdir ACLs: %v", err)
+		log.Infof("unable to adjusting Labdir ACLs: %v", err)
 	}
 
 	// create an empty ansible inventory file that will get populated later

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -159,7 +159,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	// also have access to lab directory files
 	err = utils.AdjustFileACLs(c.TopoPaths.TopologyLabDir())
 	if err != nil {
-		log.Infof("unable to adjusting Labdir ACLs: %v", err)
+		log.Infof("unable to adjust Labdir file ACLs: %v", err)
 	}
 
 	// create an empty ansible inventory file that will get populated later

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -156,6 +156,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	log.Info("Creating lab directory: ", c.TopoPaths.TopologyLabDir())
 	utils.CreateDirectory(c.TopoPaths.TopologyLabDir(), 0755)
 
+	err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
+	if err != nil {
+		return err
+	}
+
 	// create an empty ansible inventory file that will get populated later
 	// we create it here first, so that bind mounts of ansible-inventory.yml file could work
 	ansibleInvFPath := c.TopoPaths.AnsibleInventoryFileAbsPath()
@@ -305,6 +310,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 
 	// log new version availability info if ready
 	newVerNotification(vCh)
+
+	// err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
+	// if err != nil {
+	// 	return err
+	// }
 
 	// print table summary
 	return printContainerInspect(containers, deployFormat)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -157,7 +157,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	utils.CreateDirectory(c.TopoPaths.TopologyLabDir(), 0755)
 	// adjust ACL for Labdir such that SUDO_UID Users will
 	// also have access to lab directory files
-	err = utils.AdjustACL(c.TopoPaths.TopologyLabDir())
+	err = utils.AdjustFileACLs(c.TopoPaths.TopologyLabDir())
 	if err != nil {
 		log.Infof("unable to adjusting Labdir ACLs: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/scrapli/scrapligo v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
-	github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793
+	github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8
 	github.com/stretchr/testify v1.8.4
 	github.com/tklauser/numcpus v0.6.1
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/scrapli/scrapligo v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
+	github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793
 	github.com/stretchr/testify v1.8.4
 	github.com/tklauser/numcpus v0.6.1
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/scrapli/scrapligo v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
-	github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8
+	github.com/steiler/acls v0.1.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tklauser/numcpus v0.6.1
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/go.sum
+++ b/go.sum
@@ -2682,6 +2682,8 @@ github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793 h1:lY8SggLL0JyttzcNEI
 github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8 h1:RqP82h2DREJxj7AJbT0k7z2Jye6lweij5s14PUHic1o=
 github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
+github.com/steiler/acls v0.1.0 h1:fKVnEJ7ebghq2Ed5N1cU9fZrCCRj4xVRPrP7OswaRX8=
+github.com/steiler/acls v0.1.0/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/go.sum
+++ b/go.sum
@@ -2680,6 +2680,8 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOH
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793 h1:lY8SggLL0JyttzcNEIRzbywKiKcIlVlF7ZPwTthG9eA=
 github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
+github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8 h1:RqP82h2DREJxj7AJbT0k7z2Jye6lweij5s14PUHic1o=
+github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/go.sum
+++ b/go.sum
@@ -2678,6 +2678,8 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
+github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793 h1:lY8SggLL0JyttzcNEIRzbywKiKcIlVlF7ZPwTthG9eA=
+github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/utils/file.go
+++ b/utils/file.go
@@ -349,8 +349,11 @@ func NewHTTPClient() *http.Client {
 	return &http.Client{Transport: tr}
 }
 
+// AdjustACL takes the given fs path, tries to load
+// the access acl of that path and adjusts it by adding
+// rwx for the SUDO_UID and r-x for the SUDO_GID group.
 func AdjustACL(fsPath string) error {
-
+	// load UID and GID from the env vars
 	userId, isSet := os.LookupEnv("SUDO_UID")
 	if !isSet {
 		return fmt.Errorf("unable to adjust UID and GUI for %q. SUDO_UID not set", fsPath)
@@ -360,6 +363,7 @@ func AdjustACL(fsPath string) error {
 		return fmt.Errorf("unable to retrieve GID. will only adjust UID for %q", fsPath)
 	}
 
+	// convert string IDs to ints
 	intUserId, err := strconv.Atoi(userId)
 	if err != nil {
 		return fmt.Errorf("unable to convert SUDO_UID %q to int", userId)
@@ -378,7 +382,7 @@ func AdjustACL(fsPath string) error {
 	}
 
 	// add an entry for the group
-	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_GROUP, uint32(intGroupId), 7))
+	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_GROUP, uint32(intGroupId), 5))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We adjust the Lab Dir ACL to be `rwx` by the `SUDO_UID` and `SUDO_GID`.
We also adjust the Default ACL such that all the subsequently created files and folders do inherit the default entries.