### PR TITLE
Allow referencing topologies from http(s) locations

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -138,7 +138,7 @@ func WithTopoPath(path, varsFile string) ClabOption {
 				return err
 			}
 		// if the path is not a local file and a URL, download the file and store it in the tmp dir
-		case !utils.FileOrDirExists(path) && utils.IsHttpURL(path):
+		case !utils.FileOrDirExists(path) && utils.IsHttpURL(path, true):
 			file, err = c.downloadTopoFile(path)
 			if err != nil {
 				return err

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -138,7 +138,7 @@ func WithTopoPath(path, varsFile string) ClabOption {
 				return err
 			}
 		// if the path is not a local file and a URL, download the file and store it in the tmp dir
-		case !utils.FileExists(path) && utils.IsHttpURL(path):
+		case !utils.FileOrDirExists(path) && utils.IsHttpURL(path):
 			file, err = c.downloadTopoFile(path)
 			if err != nil {
 				return err

--- a/clab/config.go
+++ b/clab/config.go
@@ -522,7 +522,7 @@ func (c *CLab) resolveBindPaths(binds []string, nodedir string) error {
 	return nil
 }
 
-// setClabIntfsEnvVar sets CLAB_INTFS env var for each node
+// SetClabIntfsEnvVar sets CLAB_INTFS env var for each node
 // which holds the number of interfaces a node expects to have (without mgmt interfaces).
 func (c *CLab) SetClabIntfsEnvVar() {
 	for _, n := range c.Nodes {

--- a/clab/config.go
+++ b/clab/config.go
@@ -264,7 +264,7 @@ func (c *CLab) processStartupConfig(nodeCfg *types.NodeConfig) error {
 	// it contains at least one newline
 	isEmbeddedConfig := strings.Count(p, "\n") >= 1
 	// downloadable config starts with http(s)://
-	isDownloadableConfig := utils.IsHttpUri(p)
+	isDownloadableConfig := utils.IsHttpURL(p)
 
 	if isEmbeddedConfig || isDownloadableConfig {
 		// both embedded and downloadable configs are require clab tmp dir to be created

--- a/clab/config.go
+++ b/clab/config.go
@@ -264,7 +264,7 @@ func (c *CLab) processStartupConfig(nodeCfg *types.NodeConfig) error {
 	// it contains at least one newline
 	isEmbeddedConfig := strings.Count(p, "\n") >= 1
 	// downloadable config starts with http(s)://
-	isDownloadableConfig := utils.IsHttpURL(p)
+	isDownloadableConfig := utils.IsHttpURL(p, false)
 
 	if isEmbeddedConfig || isDownloadableConfig {
 		// both embedded and downloadable configs are require clab tmp dir to be created

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,7 @@ func getTopoFilePath(cmd *cobra.Command) error {
 			if err != nil {
 				return err
 			}
-		case utils.IsHttpURL(topo):
+		case utils.IsHttpURL(topo, true):
 			// canonize the passed topo as URL by adding https schema if it was missing
 			if !strings.HasPrefix(topo, "http://") && !strings.HasPrefix(topo, "https://") {
 				topo = "https://" + topo

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,7 @@ func getTopoFilePath(cmd *cobra.Command) error {
 
 	var err error
 	// perform topology clone/fetch if the topo file is not available locally
-	if !utils.FileExists(topo) {
+	if !utils.FileOrDirExists(topo) {
 		switch {
 		case git.IsGitHubOrGitLabURL(topo) || git.IsGitHubShortURL(topo):
 			topo, err = processGitTopoFile(topo)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,5 @@ func processGitTopoFile(topo string) (string, error) {
 		return "", err
 	}
 
-	// once the repo is cloned the topo file is emptied
-	// to ensure that auto find functionality can kick in
 	return repo.GetFilename(), err
 }

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -26,6 +26,8 @@ It is possible to read the topology file from stdin by passing `-` as a value to
 
 ##### Remote topology files
 
+###### Git
+
 To simplify the deployment of labs that are stored in remote version control systems, containerlab supports the use of remote topology files for GitHub.com and GitLab.com hosted projects.
 
 By specifying a URL to a repository or a `.clab.yml` file in a repository, containerlab will automatically clone[^1] the repository in your current directory and deploy it. If the URL points to a `.clab.yml` file, containerlab will clone the repository and deploy the lab defined in the file.
@@ -49,6 +51,19 @@ Subsequent lab operations (such as destroy) must use the filesystem path to the 
     <video width="100%" controls>
         <source src="https://gitlab.com/rdodin/pics/-/wikis/uploads/5f0a7579f85c7d6af1fe05c254f42bb5/remote-labs2.mp4" type="video/mp4">
     </video>
+
+###### HTTP(S)
+
+Labs can be deployed from remote HTTP(S) URLs as well. These labs should be self-contained and not reference any external resources, like startup-config files, licenses, binds, etc.
+
+The following URL formats are supported:
+
+| Type                           | Example                                                             | Description                                           |
+| ------------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------- |
+| Link to raw github gist        | https://gist.githubusercontent.com/hellt/abc/raw/def/linux.clab.yml | A file is downloaded to a temp directory and launched |
+| Link to a short schemaless URL | srlinux.dev/clab-srl                                                | A file is downloaded to a temp directory and launched |
+
+Containerlab distinct HTTP URLs from GitHub/GitLab by checking if github.com or gitlab.com is present in the URL. If not, it will treat the URL as a plain HTTP(S) URL.
 
 #### name
 
@@ -118,7 +133,7 @@ Read more about [node filtering](../manual/node-filtering.md) in the documentati
 
 ### Environment variables
 
-#### CLAB_RUNTIME
+#### `CLAB_RUNTIME`
 
 Default value of "runtime" key for nodes, same as global `--runtime | -r` flag described above.
 Affects all containerlab commands in the same way, not just `deploy`.
@@ -127,7 +142,7 @@ Intended to be set in environments where non-default container runtime should be
 
 Example command-line usage: `CLAB_RUNTIME=podman containerlab deploy`
 
-#### CLAB_VERSION_CHECK
+#### `CLAB_VERSION_CHECK`
 
 Can be set to "disable" value to prevent deploy command making a network request to check new version to report if one is available.
 
@@ -135,7 +150,7 @@ Useful when running in an automated environments with restricted network access.
 
 Example command-line usage: `CLAB_VERSION_CHECK=disable containerlab deploy`
 
-#### CLAB_LABDIR_BASE
+#### `CLAB_LABDIR_BASE`
 
 To change the [lab directory](../manual/conf-artifacts.md#identifying-a-lab-directory) location, set `CLAB_LABDIR_BASE` environment variable accordingly. It denotes the base directory in which the lab directory will be created.
 

--- a/docs/htmltest-w-github.yml
+++ b/docs/htmltest-w-github.yml
@@ -16,6 +16,7 @@ IgnoreURLs:
   - https://linkedin.com/in
   - https://www.linkedin.com/in
   - mysocket.io # remove mysocket.io links until we rework to border0.com
+  - https://gist.githubusercontent.com/hellt/abc/raw/def/linux.clab.yml # test link used in docs
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -17,6 +17,7 @@ IgnoreURLs:
   - mysocket.io # remove mysocket.io links until we rework to border0.com
   - https://supportcenter.checkpoint.com/ # started to fail, meh.
   - https://marketplace.visualstudio.com/*
+  - https://gist.githubusercontent.com/hellt/abc/raw/def/linux.clab.yml # test link used in docs
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,6 +99,9 @@ containerlab deploy # (1)!
 1. `deploy` command will automatically lookup a file matching the `*.clab.y*ml` patter to select it.  
   If you have several files and want to pick a specific one, use `--topo <path>` flag.
 
+!!!tip "Remote topology files"
+    Containerlab allows to deploy labs from files located in remote Git repositories and/or HTTP URLs. Check out deploy command [documentation](cmd/deploy.md#remote-topology-files) for more details.
+
 After a couple of seconds you will see the summary of the deployed nodes:
 
 ```

--- a/git/github.go
+++ b/git/github.go
@@ -98,5 +98,16 @@ type GitHubRepo struct {
 // IsGitHubShortURL returns true for github-friendly short urls
 // such as srl-labs/containerlab.
 func IsGitHubShortURL(s string) bool {
-	return strings.Count(s, "/") == 1 && !strings.HasPrefix(s, "http")
+	split := strings.Split(s, "/")
+	// only 2 elements are allowed
+	if len(split) != 2 {
+		return false
+	}
+
+	// dot is not allowed in the project owner
+	if strings.Contains(split[0], ".") {
+		return false
+	}
+
+	return true
 }

--- a/git/github.go
+++ b/git/github.go
@@ -94,3 +94,9 @@ func IsGitHubURL(url *neturl.URL) bool {
 type GitHubRepo struct {
 	GitRepoStruct
 }
+
+// IsGitHubShortURL returns true for github-friendly short urls
+// such as srl-labs/containerlab.
+func IsGitHubShortURL(s string) bool {
+	return strings.Count(s, "/") == 1 && !strings.HasPrefix(s, "http")
+}

--- a/git/github_test.go
+++ b/git/github_test.go
@@ -230,3 +230,36 @@ func TestIsGitHubURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGitHubShortURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "Valid Short URL",
+			url:  "user/repo",
+			want: true,
+		},
+		{
+			name: "Invalid Short URL - More than one slash",
+			url:  "user/repo/extra",
+			want: false,
+		},
+		{
+			name: "Invalid Short URL - Starts with http",
+			url:  "http://user/repo",
+			want: false,
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGitHubShortURL(tt.url); got != tt.want {
+				t.Errorf("IsGitHubShortURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/git/github_test.go
+++ b/git/github_test.go
@@ -252,7 +252,11 @@ func TestIsGitHubShortURL(t *testing.T) {
 			url:  "http://user/repo",
 			want: false,
 		},
-		// Add more test cases as needed
+		{
+			name: "normal url in short form",
+			url:  "srlinux.dev/clab-srl",
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/git/repo.go
+++ b/git/repo.go
@@ -80,3 +80,13 @@ func NewRepo(urlPath string) (GitRepo, error) {
 
 	return r, err
 }
+
+// IsGitHubOrGitLabURL checks if the url is a github or gitlab url.
+func IsGitHubOrGitLabURL(u string) bool {
+	_url, err := url.ParseRequestURI(u)
+	if err != nil {
+		return false
+	}
+
+	return IsGitHubURL(_url) || IsGitLabURL(_url)
+}

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -252,7 +252,7 @@ func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error 
 		for _, fullpath := range agents {
 			basename := filepath.Base(fullpath)
 			// if it is a url extract filename from url or content-disposition header
-			if utils.IsHttpURL(fullpath) {
+			if utils.IsHttpURL(fullpath, false) {
 				basename = utils.FilenameForURL(fullpath)
 			}
 			// enforce yml extension

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -252,7 +252,7 @@ func (s *srl) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error 
 		for _, fullpath := range agents {
 			basename := filepath.Base(fullpath)
 			// if it is a url extract filename from url or content-disposition header
-			if utils.IsHttpUri(fullpath) {
+			if utils.IsHttpURL(fullpath) {
 				basename = utils.FilenameForURL(fullpath)
 			}
 			// enforce yml extension

--- a/tests/01-smoke/12-cloned-lab.robot
+++ b/tests/01-smoke/12-cloned-lab.robot
@@ -15,6 +15,7 @@ ${lab2-url}             https://github.com/hellt/clab-test-repo/tree/branch1
 ${lab1-gitlab-url}      https://github.com/hellt/clab-test-repo
 ${lab1-gitlab-url2}     https://github.com/hellt/clab-test-repo/blob/main/lab1.clab.yml
 ${lab2-gitlab-url}      https://github.com/hellt/clab-test-repo/tree/branch1
+${http-lab-url}         https://gist.githubusercontent.com/hellt/66a5d8fca7bf526b46adae9008a5e04b/raw/034a542c3fbb17333afd20e6e7d21869fee6aeb5/linux.clab.yml
 ${runtime}              docker
 
 
@@ -121,6 +122,21 @@ Test lab1 with short github url
 
     # check that node3 was filtered and not present in the lab output
     Should Contain    ${output.stdout}    clab-lab1-node1
+
+    Cleanup
+
+Test lab1 downloaded from https url
+    ${output} =    Process.Run Process
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${http-lab-url}
+    ...    shell=True
+
+    Log    ${output.stdout}
+    Log    ${output.stderr}
+
+    Should Be Equal As Integers    ${output.rc}    0
+
+    # check that node3 was filtered and not present in the lab output
+    Should Contain    ${output.stdout}    clab-alpine-l1
 
     Cleanup
 

--- a/utils/file.go
+++ b/utils/file.go
@@ -37,6 +37,13 @@ func FileExists(filename string) bool {
 	return !f.IsDir()
 }
 
+// FileOrDirExists returns true if a file or dir referenced by path exists & accessible.
+func FileOrDirExists(filename string) bool {
+	f, err := os.Stat(filename)
+
+	return err == nil && f != nil
+}
+
 // CopyFile copies a file from src to dst. If src and dst files exist, and are
 // the same, then return success. Otherwise, copy the file contents from src to dst.
 // mode is the desired target file permissions, e.g. "0644".

--- a/utils/file.go
+++ b/utils/file.go
@@ -324,3 +324,28 @@ func NewHTTPClient() *http.Client {
 
 	return &http.Client{Transport: tr}
 }
+
+// DownloadFile downloads a file from `src` url and saves it to `dst` path.
+// `dst` must exist.
+func DownloadFile(src, dst string) error {
+	client := NewHTTPClient()
+
+	resp, err := client.Get(src)
+	if err != nil || resp.StatusCode != 200 {
+		return fmt.Errorf("%w: %s", errHTTPFetch, src)
+	}
+
+	defer resp.Body.Close() // skipcq: GO-S2307
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(dst, body, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -85,25 +85,30 @@ func TestFileLines(t *testing.T) {
 	}
 }
 
-func TestIsGitHubShortURL(t *testing.T) {
+func TestIsHttpURL(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
 		want bool
 	}{
 		{
-			name: "Valid Short URL",
-			url:  "user/repo",
+			name: "Valid HTTP URL",
+			url:  "http://example.com",
 			want: true,
 		},
 		{
-			name: "Invalid Short URL - More than one slash",
-			url:  "user/repo/extra",
-			want: false,
+			name: "Valid HTTPS URL",
+			url:  "https://example.com",
+			want: true,
 		},
 		{
-			name: "Invalid Short URL - Starts with http",
-			url:  "http://user/repo",
+			name: "Valid URL without scheme",
+			url:  "srlinux.dev/clab-srl",
+			want: true,
+		},
+		{
+			name: "Invalid URL",
+			url:  "/foo/bar",
 			want: false,
 		},
 		// Add more test cases as needed
@@ -111,8 +116,8 @@ func TestIsGitHubShortURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsGitHubShortURL(tt.url); got != tt.want {
-				t.Errorf("IsGitHubShortURL() = %v, want %v", got, tt.want)
+			if got := IsHttpURL(tt.url); got != tt.want {
+				t.Errorf("IsHttpUri() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -87,36 +87,52 @@ func TestFileLines(t *testing.T) {
 
 func TestIsHttpURL(t *testing.T) {
 	tests := []struct {
-		name string
-		url  string
-		want bool
+		name            string
+		url             string
+		allowSchemaless bool
+		want            bool
 	}{
 		{
-			name: "Valid HTTP URL",
-			url:  "http://example.com",
-			want: true,
+			name:            "Valid HTTP URL",
+			url:             "http://example.com",
+			allowSchemaless: false,
+			want:            true,
 		},
 		{
-			name: "Valid HTTPS URL",
-			url:  "https://example.com",
-			want: true,
+			name:            "Valid HTTPS URL",
+			url:             "https://example.com",
+			allowSchemaless: false,
+			want:            true,
 		},
 		{
-			name: "Valid URL without scheme",
-			url:  "srlinux.dev/clab-srl",
-			want: true,
+			name:            "Valid URL without scheme",
+			url:             "srlinux.dev/clab-srl",
+			allowSchemaless: true,
+			want:            true,
 		},
 		{
-			name: "Invalid URL",
-			url:  "/foo/bar",
-			want: false,
+			name:            "Valid URL without scheme and schemaless not allowed",
+			url:             "srlinux.dev/clab-srl",
+			allowSchemaless: false,
+			want:            false,
 		},
-		// Add more test cases as needed
+		{
+			name:            "Invalid URL",
+			url:             "/foo/bar",
+			allowSchemaless: false,
+			want:            false,
+		},
+		{
+			name:            "stdin symbol '-'",
+			url:             "-",
+			allowSchemaless: false,
+			want:            false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsHttpURL(tt.url); got != tt.want {
+			if got := IsHttpURL(tt.url, tt.allowSchemaless); got != tt.want {
 				t.Errorf("IsHttpUri() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
In addition to be able to provide git URLs for `clab deploy` command this PR adds ability for clab to handle HTTP(S) URLs, such as:

```
clab dep -c -t https://gist.githubusercontent.com/hellt/66a5d8fca7bf526b46adae9008a5e04b/raw/034a542c3fbb17333afd20e6e7d21869fee6aeb5/linux.clab.yml
```

This feature is tailored to the self-container labs which has everything they need in the topo file itself. Since such files can be located outside of git repositories we add handling of HTTP(s) locations.

for example this is now the way to quickly start a single srl node:

```
clab dep -c -t srlinux.dev/clab-srl
```

