### PR TITLE
Do not attempt creating ssh config files if `ssh_config.d` doesn't exist

### DIFF
--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -2,8 +2,10 @@ package clab
 
 import (
 	"os"
+	"path"
 	"text/template"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/types"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -46,6 +48,12 @@ func (c *CLab) RemoveSSHConfig(topoPaths *types.TopoPaths) error {
 
 // AddSSHConfig adds the lab specific ssh config file.
 func (c *CLab) AddSSHConfig() error {
+	sshConfigDir := path.Dir(c.TopoPaths.SSHConfigPath())
+	if !utils.FileOrDirExists(sshConfigDir) {
+		log.Debugf("ssh config directory %s does not exist, skipping ssh config generation", sshConfigDir)
+		return nil
+	}
+
 	tmpl := &SSHConfigTmpl{
 		TopologyName: c.Config.Name,
 		Nodes:        make([]SSHConfigNodeTmpl, 0, len(c.Nodes)),
@@ -68,7 +76,7 @@ func (c *CLab) AddSSHConfig() error {
 		return err
 	}
 
-	f, err := utils.CreateFileWithPath(c.TopoPaths.SSHConfigPath())
+	f, err := os.Create(c.TopoPaths.SSHConfigPath())
 	if err != nil {
 		return err
 	}

--- a/clab/sshconfig.go
+++ b/clab/sshconfig.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 
 	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
 )
 
 // SSHConfigTmpl is the top-level data structure for the
@@ -44,7 +45,7 @@ func (c *CLab) RemoveSSHConfig(topoPaths *types.TopoPaths) error {
 }
 
 // AddSSHConfig adds the lab specific ssh config file.
-func (c *CLab) AddSSHConfig(topoPaths *types.TopoPaths) error {
+func (c *CLab) AddSSHConfig() error {
 	tmpl := &SSHConfigTmpl{
 		TopologyName: c.Config.Name,
 		Nodes:        make([]SSHConfigNodeTmpl, 0, len(c.Nodes)),
@@ -67,7 +68,7 @@ func (c *CLab) AddSSHConfig(topoPaths *types.TopoPaths) error {
 		return err
 	}
 
-	f, err := os.Create(topoPaths.SSHConfigPath())
+	f, err := utils.CreateFileWithPath(c.TopoPaths.SSHConfigPath())
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -282,7 +282,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	}
 
 	log.Info("Adding ssh config for containerlab nodes")
-	err = c.AddSSHConfig(c.TopoPaths)
+	err = c.AddSSHConfig()
 	if err != nil {
 		log.Errorf("failed to create ssh config file: %v", err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -2678,10 +2678,6 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
-github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793 h1:lY8SggLL0JyttzcNEIRzbywKiKcIlVlF7ZPwTthG9eA=
-github.com/steiler/acls v0.0.0-20231106135104-9c34ae82c793/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
-github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8 h1:RqP82h2DREJxj7AJbT0k7z2Jye6lweij5s14PUHic1o=
-github.com/steiler/acls v0.0.0-20231106152733-bb3d5d7b05c8/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/steiler/acls v0.1.0 h1:fKVnEJ7ebghq2Ed5N1cU9fZrCCRj4xVRPrP7OswaRX8=
 github.com/steiler/acls v0.1.0/go.mod h1:kS9/GuHDS4t2YmY2ijbaK3m1iU4+BgRZS7GoDTC9BfY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=

--- a/utils/file.go
+++ b/utils/file.go
@@ -407,3 +407,16 @@ func AdjustFileACLs(fsPath string) error {
 
 	return a.Apply(fsPath, acls.PosixACLDefault)
 }
+
+// CreateFileWithPath creates a file by the given path
+// and creates the directories if needed.
+func CreateFileWithPath(path string) (*os.File, error) {
+	// create directories if needed, since we promise to create the file
+	// if it doesn't exist
+	err := os.MkdirAll(filepath.Dir(path), 0754)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Create(path)
+}

--- a/utils/file.go
+++ b/utils/file.go
@@ -407,16 +407,3 @@ func AdjustFileACLs(fsPath string) error {
 
 	return a.Apply(fsPath, acls.PosixACLDefault)
 }
-
-// CreateFileWithPath creates a file by the given path
-// and creates the directories if needed.
-func CreateFileWithPath(path string) (*os.File, error) {
-	// create directories if needed, since we promise to create the file
-	// if it doesn't exist
-	err := os.MkdirAll(filepath.Dir(path), 0754)
-	if err != nil {
-		return nil, err
-	}
-
-	return os.Create(path)
-}


### PR DESCRIPTION
reported by a user:

```
INFO[0025] Adding containerlab host entries to /etc/hosts file 
INFO[0025] Adding ssh config for containerlab nodes     
ERRO[0025] failed to create ssh config file: open /etc/ssh/ssh_config.d/clab-srl01.conf: no such file or directory 
```

this means the path did not exist and this PR ensures the path exists.
It might be that the OS user runs or OpenSSH there won't honor the newly created path either, but it seems still safe to create the path 