### PR TITLE
Further adjust directory permissions for topology definition repository

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,6 +170,13 @@ func processGitTopoFile(topo string) (string, error) {
 		return "", err
 	}
 
+	// adjust permissions for the checked out repo
+	// it would belong to root/root otherwise
+	err = utils.RecursiveAdjustUIDAndGUID(repo.GetName())
+	if err != nil {
+		log.Errorf("error adjusting repository permissions %v. Continuing anyways", err)
+	}
+
 	// prepare the path with the repo based path
 	path := filepath.Join(repo.GetPath()...)
 	// prepend that path with the repo base directory

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,7 +172,7 @@ func processGitTopoFile(topo string) (string, error) {
 
 	// adjust permissions for the checked out repo
 	// it would belong to root/root otherwise
-	err = utils.RecursiveAdjustUIDAndGUID(repo.GetName())
+	err = utils.SetUIDAndGID(repo.GetName())
 	if err != nil {
 		log.Errorf("error adjusting repository permissions %v. Continuing anyways", err)
 	}


### PR DESCRIPTION
Two things change here.
1. I'm re-introducing `utils.RecursiveAdjustUIDAndGUID(...)` this is needed, since the commandline git implementation is picky about file/folder ownership. If you want to inspect a clab cloned topology, prior to this PR you will be greated with the following message:

```
fatal: detected dubious ownership in repository at '/home/mava/projects/containerlab3/srl-telemetry-lab'
To add an exception for this directory, call:

        git config --global --add safe.directory /home/mava/projects/containerlab3/srl-telemetry-lab

```
  Unfortunately this is not resolvable via ACLs. Hence we also change the actual ownership of the topology repo dir.

2. The `AdjustFileACLs(...)` function is adding the `SUDO_UID` and `SUDO_GID` with rwx to the directory it is called with (lab and topology repo). But it did not adjust the MASK acl entry. This entry is a general per ACL entry, that defines the maximum permission that can be granted via the ACL in general. So having a user with rwx but a MASK of just `r--`. The user will only gain `r--`. It is basically an AND on the permissions. 
We will now also set the mask to `rwx` to allow gaining all the right via the acls.