### PR TITLE
Destroy all: retrieve labdir from container labels

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -53,7 +53,7 @@ type Config struct {
 func (c *CLab) parseTopology() error {
 	log.Infof("Parsing & checking topology file: %s", c.TopoPaths.TopologyFilenameBase())
 
-	err := c.TopoPaths.SetLabDir(c.Config.Name)
+	err := c.TopoPaths.SetLabDirByPrefix(c.Config.Name)
 	if err != nil {
 		return err
 	}

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -74,8 +74,16 @@ func (t *TopoPaths) SetTopologyFilePath(topologyFile string) error {
 	return nil
 }
 
-// SetLabDir sets the labDir foldername (no abs path, but the last element) usually the topology name.
-func (t *TopoPaths) SetLabDir(topologyName string) (err error) {
+func (t *TopoPaths) SetLabDir(p string) (err error) {
+	if !utils.DirExists(p) {
+		return fmt.Errorf("folder %s does not exist or is not accessible", p)
+	}
+	t.labDir = p
+	return nil
+}
+
+// SetLabDirByPrefix sets the labDir foldername (no abs path, but the last element) usually the topology name.
+func (t *TopoPaths) SetLabDirByPrefix(topologyName string) (err error) {
 	t.topoName = topologyName
 	// if "CLAB_LABDIR_BASE" Env Var is set, use that dir as a base
 	// for the labDir, otherwise use PWD.

--- a/utils/file.go
+++ b/utils/file.go
@@ -48,6 +48,13 @@ func FileOrDirExists(filename string) bool {
 	return err == nil && f != nil
 }
 
+// DirExists returns true if a dir referenced by path exists & accessible.
+func DirExists(filename string) bool {
+	f, err := os.Stat(filename)
+
+	return err == nil && f != nil && f.IsDir()
+}
+
 // CopyFile copies a file from src to dst. If src and dst files exist, and are
 // the same, then return success. Otherwise, copy the file contents from src to dst.
 // mode is the desired target file permissions, e.g. "0644".


### PR DESCRIPTION
We where always expecting the labdir to be a subdir of the actual pwd. With this PR we will query the labels and deduce the labdir from the "containerlab" label.