### PR TITLE
Update Border0 FKA Mysocketio Commands + Docs

### DIFF
--- a/border0_api/border0_test.go
+++ b/border0_api/border0_test.go
@@ -55,7 +55,7 @@ func TestLogin(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-			if err := Login(ctx, tt.args.email, tt.args.password); (err != nil) != tt.wantErr {
+			if err := Login(ctx, tt.args.email, tt.args.password, false); (err != nil) != tt.wantErr {
 				t.Errorf("Login() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/cmd/border0.go
+++ b/cmd/border0.go
@@ -14,15 +14,28 @@ import (
 var (
 	border0Email    string
 	border0Password string
+
+	border0DisableBrowser bool
 )
 
 func init() {
 	toolsCmd.AddCommand(border0Cmd)
 
 	border0Cmd.AddCommand(border0LoginCmd)
+
+	border0LoginCmd.Flags().BoolVarP(&border0DisableBrowser, "disable-browser", "b", false, "Disable opening the browser")
+
+	// Programmatic user authentication for the Border0 service was deprecated on 11/2023,
+	// so we hide the email and password flags though we keep them around for backwards
+	// compatibility because some containerlabs users have been allowlisted for programmatic
+	// authentication. Note that as of 12/2023 no new allowlist requests are considered by
+	// Border0. Instead Border0 users who wish to integrate with containerlabs will need to
+	// use Border0 "admin tokens" i.e. service identities. For info on how to create tokens,
+	// see https://docs.border0.com/docs/creating-access-token
 	border0LoginCmd.Flags().StringVarP(&border0Email, "email", "e", "", "Email address")
 	border0LoginCmd.Flags().StringVarP(&border0Password, "password", "p", "", "Password")
-	_ = border0LoginCmd.MarkFlagRequired("email")
+	border0LoginCmd.Flags().MarkHidden("email")
+	border0LoginCmd.Flags().MarkHidden("password")
 }
 
 // border0Cmd represents the border0 command container.
@@ -40,6 +53,6 @@ var border0LoginCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		return border0_api.Login(ctx, border0Email, border0Password)
+		return border0_api.Login(ctx, border0Email, border0Password, border0DisableBrowser)
 	},
 }

--- a/docs/cmd/tools/border0/login.md
+++ b/docs/cmd/tools/border0/login.md
@@ -12,23 +12,19 @@ The token is saved as `$PWD/.border0_token` file.
 
 ### Flags
 
-#### email
-With mandatory `--email | -e` flag user sets an email address used to register with border0.com service
-
-#### password
-The `--password | -p` sets the password for a user. If flag is not set, the prompt will appear on the terminal to allow for safe enter of the password.
+#### disable-browser
+The `--disable-browser | -b` prevents the command from attempting to open the browser in order to complete authentication with Border0. If the flag is set, the command will simply print the URL which you must navigate to, whether in the same device or a different device, in order to complete authentication.
 
 ### Examples
 
 ```bash
-# Login with password entered from the prompt
-containerlab tools border0.com login -e myemail@dot.com
-Password:
-INFO[0000] Written border0.com token to a file /root/containerlab/.border0_token
+containerlab tools border0 login
 
-# Login with password passed as a flag
-containerlab tools border0.com login -e myemail@dot.com -p Pa$$word
-Password:
+Please navigate to the URL below in order to complete the login process:
+https://portal.border0.com/login?device_identifier=IjM1OTJkZGVmLTgzNTMtNDU4Yy04NjNkLTk1OTdhYjY0ZjFiOSI.ZW6BRw.Z9XlL0CtL7HkKTDX7GSp28d9mG0
+
+Login successful
+
 INFO[0000] Written border0.com token to a file /root/containerlab/.border0_token
 ```
 

--- a/docs/cmd/tools/mysocketio/login.md
+++ b/docs/cmd/tools/mysocketio/login.md
@@ -12,23 +12,19 @@ The token is saved as `$PWD/.mysocketio_token` file.
 
 ### Flags
 
-#### email
-With mandatory `--email | -e` flag user sets an email address used to register with mysocketio service
-
-#### password
-The `--password | -p` sets the password for a user. If flag is not set, the prompt will appear on the terminal to allow for safe enter of the password.
+#### disable-browser
+The `--disable-browser | -b` prevents the command from attempting to open the browser in order to complete authentication with Border0. If the flag is set, the command will simply print the URL which you must navigate to, whether in the same device or a different device, in order to complete authentication.
 
 ### Examples
 
 ```bash
-# Login with password entered from the prompt
-containerlab tools mysocketio login -e myemail@dot.com
-Password:
-INFO[0000] Written mysocketio token to a file /root/containerlab/.mysocketio_token
+containerlab tools mysocketio login
 
-# Login with password passed as a flag
-containerlab tools mysocketio login -e myemail@dot.com -p Pa$$word
-Password:
+Please navigate to the URL below in order to complete the login process:
+https://portal.border0.com/login?device_identifier=IjM1OTJkZGVmLTgzNTMtNDU4Yy04NjNkLTk1OTdhYjY0ZjFiOSI.ZW6BRw.Z9XlL0CtL7HkKTDX7GSp28d9mG0
+
+Login successful
+
 INFO[0000] Written mysocketio token to a file /root/containerlab/.mysocketio_token
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/common v0.57.0
 	github.com/containers/podman/v4 v4.8.0
@@ -15,6 +16,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/florianl/go-tc v0.4.2
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.4.0
@@ -33,6 +35,7 @@ require (
 	github.com/pmorjan/kmod v1.1.0
 	github.com/scrapli/scrapligo v1.2.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.8.0
 	github.com/steiler/acls v0.1.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -926,6 +926,8 @@ github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee h1:BnPxIde0gjtTnc9Er7cxvBk8DHLWhEux0SxayC8dP6I=
 github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -1601,6 +1603,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -2652,6 +2655,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2AQ=
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=


### PR DESCRIPTION
## Update Border0 FKA Mysocketio Commands + Docs

As of November 2023, Border0 deprecated programmatic authentication. This changes the code and the corresponding documentation to use their OAuth2.0 "Device Authorization Code" flow.

The code for the flow mostly comes from the Border0 CLI's source code directly: https://github.com/borderzero/border0-cli/blob/main/cmd/login.go#L42

Except its made to use utility functions present in this code base.