### PR TITLE
Prevent cleanup on CTRL-C

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -385,7 +385,7 @@ func setupCTRLCHandler(cancel context.CancelFunc) {
 		log.Errorf("Caught CTRL-C. Stopping deployment!")
 		cancel()
 
-		// when interrupted, destroy the interrupted lab deployment with cleanup
+		// when interrupted, destroy the interrupted lab deployment
 		cleanup = false
 		if err := destroyFn(destroyCmd, []string{}); err != nil {
 			log.Errorf("Failed to destroy lab: %v", err)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -382,7 +382,7 @@ func setupCTRLCHandler(cancel context.CancelFunc) {
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sig
-		log.Errorf("Caught CTRL-C. Stopping deployment and cleaning up!")
+		log.Errorf("Caught CTRL-C. Stopping deployment!")
 		cancel()
 
 		// when interrupted, destroy the interrupted lab deployment with cleanup

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -386,7 +386,7 @@ func setupCTRLCHandler(cancel context.CancelFunc) {
 		cancel()
 
 		// when interrupted, destroy the interrupted lab deployment with cleanup
-		cleanup = true
+		cleanup = false
 		if err := destroyFn(destroyCmd, []string{}); err != nil {
 			log.Errorf("Failed to destroy lab: %v", err)
 		}


### PR DESCRIPTION
Adjust deploy -> ctrl-c to not cleanup as requested in #1761 