### PR TITLE
SRL: Populate NodeConfig with generated System MAC for it to show up in the json data export

### DIFF
--- a/nodes/srl/macaddr.go
+++ b/nodes/srl/macaddr.go
@@ -26,6 +26,9 @@ func genMac(cfg *types.NodeConfig) mac {
 	// labs up to 256 nodes are supported, behaviour is undefined when more nodes are defined
 	m := fmt.Sprintf("%s:%02x:00:00:00", macPrefix, cfg.Index%256)
 
+	// set system Mac in NodeConfig
+	cfg.MacAddress = m
+
 	return mac{
 		MAC: m,
 	}


### PR DESCRIPTION
Set the generated SRL system Mac in the Nodeconfig for the json export