### PR TITLE
ixia-c lab-example fix

### DIFF
--- a/lab-examples/ixiac01/ixiac01.clab.yml
+++ b/lab-examples/ixiac01/ixiac01.clab.yml
@@ -6,8 +6,8 @@ topology:
       kind: keysight_ixia-c-one
       image: ghcr.io/open-traffic-generator/ixia-c-one:0.0.1-2755
       exec:
-        - "./ifcfg add eth1 10.1.1.1 24"
-        - "./ifcfg add eth2 10.2.2.1 24"
+        - "ip addr add 10.1.1.1/24 dev eth1"
+        - "ip addr add 10.2.2.1/24 dev eth2"
     srl:
       kind: srl
       image: ghcr.io/nokia/srlinux

--- a/lab-examples/ixiac01/srl.cfg
+++ b/lab-examples/ixiac01/srl.cfg
@@ -1,5 +1,6 @@
 set /interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
 set /interface ethernet-1/1 subinterface 0 ipv4 address 10.1.1.2/24
+set /interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set /interface ethernet-1/2 subinterface 0 ipv4 address 10.2.2.2/24
 set /network-instance default interface ethernet-1/1.0
 set /network-instance default interface ethernet-1/2.0


### PR DESCRIPTION
Fixes:

1. Updated the command to add IP address to ixia-c node for both eth1 and eth2 interfaces.

previous error:
ERRO[0083] Failed to execute command "./ifcfg add eth1 10.1.1.1 24" on the node "ixia-c". rc=1,
ERRO[0083] Failed to execute command "./ifcfg add eth2 10.2.2.1 24" on the node "ixia-c". rc=1,

2.  Updated the SRLinux Ethernet-1/2 config by enabling it.
