### PR TITLE
added Ansible variables to the generated inventory

### DIFF
--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -17,12 +17,25 @@ import (
 //go:embed inventory_ansible.go.tpl
 var ansibleInvT string
 
+// AnsibleInventoryNode represents the data structure used to generate the ansible inventory file.
+// It embeds the NodeConfig struct and adds the Username and Password fields extracted from
+// the node registry.
+type AnsibleInventoryNode struct {
+	*types.NodeConfig
+
+	Username string
+	Password string
+
+	NetworkOS   string
+	AnsibleConn string
+}
+
 // AnsibleInventory represents the data structure used to generate the ansible inventory file.
 type AnsibleInventory struct {
 	// clab nodes aggregated by their kind
-	Nodes map[string][]*types.NodeConfig
+	Nodes map[string][]*AnsibleInventoryNode
 	// clab nodes aggregated by user-defined groups
-	Groups map[string][]*types.NodeConfig
+	Groups map[string][]*AnsibleInventoryNode
 }
 
 // GenerateInventories generate various inventory files and writes it to a lab location.
@@ -40,15 +53,31 @@ func (c *CLab) GenerateInventories() error {
 func (c *CLab) generateAnsibleInventory(w io.Writer) error {
 
 	i := AnsibleInventory{
-		Nodes:  make(map[string][]*types.NodeConfig),
-		Groups: make(map[string][]*types.NodeConfig),
+		Nodes:  make(map[string][]*AnsibleInventoryNode),
+		Groups: make(map[string][]*AnsibleInventoryNode),
 	}
 
 	for _, n := range c.Nodes {
-		i.Nodes[n.Config().Kind] = append(i.Nodes[n.Config().Kind], n.Config())
+		ansibleNode := &AnsibleInventoryNode{
+			NodeConfig: n.Config(),
+		}
+
+		// add username and password to the node
+		nodeRegEntry := c.Reg.Kind(n.Config().Kind)
+		if nodeRegEntry != nil {
+			ansibleNode.Username = nodeRegEntry.Credentials().GetUsername()
+			ansibleNode.Password = nodeRegEntry.Credentials().GetPassword()
+		}
+
+		// add network_os to the node
+		ansibleNode.setNetworkOS()
+		// add ansible_connection to the node
+		ansibleNode.setAnsibleConnection()
+
+		i.Nodes[n.Config().Kind] = append(i.Nodes[n.Config().Kind], ansibleNode)
 		if n.Config().Labels["ansible-group"] != "" {
 			i.Groups[n.Config().Labels["ansible-group"]] =
-				append(i.Groups[n.Config().Labels["ansible-group"]], n.Config())
+				append(i.Groups[n.Config().Labels["ansible-group"]], ansibleNode)
 		}
 	}
 
@@ -74,5 +103,26 @@ func (c *CLab) generateAnsibleInventory(w io.Writer) error {
 	if err != nil {
 		return err
 	}
+
 	return err
+}
+
+// setNetworkOS sets the network_os variable for the kind.
+func (n *AnsibleInventoryNode) setNetworkOS() {
+	switch n.Kind {
+	case "nokia_srlinux", "srl":
+		n.NetworkOS = "nokia.srlinux.srlinux"
+	case "nokia_sros", "vr-sros":
+		n.NetworkOS = "nokia.sros.md"
+	}
+}
+
+// setAnsibleConnection sets the ansible_connection variable for the kind.
+func (n *AnsibleInventoryNode) setAnsibleConnection() {
+	switch n.Kind {
+	case "nokia_srlinux", "srl":
+		n.AnsibleConn = "ansible.netcommon.httpapi"
+	case "nokia_sros", "vr-sros":
+		n.AnsibleConn = "ansible.netcommon.network_cli"
+	}
 }

--- a/clab/inventory_ansible.go.tpl
+++ b/clab/inventory_ansible.go.tpl
@@ -8,20 +8,20 @@ all:
 {{- range $kind, $nodes := .Nodes}}
     {{$kind}}:
       hosts:
-{{- range $nodes}}
+      {{- range $nodes}}
         {{.LongName}}:
-    {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
+        {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
           ansible_host: {{.MgmtIPv4Address}}
-    {{- end -}}
-{{- end}}
+        {{- end -}}
+      {{- end}}
 {{- end}}
 {{- range $name, $nodes := .Groups}}
     {{$name}}:
       hosts:
-{{- range $nodes}}
+      {{- range $nodes}}
         {{.LongName}}:
-    {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
+        {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
           ansible_host: {{.MgmtIPv4Address}}
-    {{- end -}}
-{{- end}}
+        {{- end -}}
+      {{- end}}
 {{- end}}

--- a/clab/inventory_ansible.go.tpl
+++ b/clab/inventory_ansible.go.tpl
@@ -5,10 +5,11 @@ all:
     # module does not attempt using any global http proxy.
     ansible_httpapi_use_proxy: false
   children:
+{{- $root := . }}
 {{- range $kind, $nodes := .Nodes}}
     {{$kind}}:
       vars:
-        {{- with index $nodes 0 }}
+        {{- with index $root.Kinds $kind }}
         {{- if .NetworkOS }}
         ansible_network_os: {{ .NetworkOS }}
         {{- end }}
@@ -19,18 +20,18 @@ all:
         {{- else}}
         # ansible_connection: set ansible_connection variable if required
         {{- end }}
+        {{- if .Username }}
+        ansible_user: {{.Username}}
+        {{- end}}
+        {{- if .Password }}
+        ansible_password: {{.Password}}
+        {{- end }}
         {{- end }}
       hosts:
       {{- range $nodes}}
         {{.LongName}}:
         {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
           ansible_host: {{.MgmtIPv4Address}}
-          {{- if .Username }}
-          ansible_user: {{.Username}}
-          {{- end}}
-          {{- if .Username }}
-          ansible_password: {{.Password}}
-          {{- end}}
         {{- end -}}
       {{- end}}
 {{- end}}

--- a/clab/inventory_ansible.go.tpl
+++ b/clab/inventory_ansible.go.tpl
@@ -7,11 +7,30 @@ all:
   children:
 {{- range $kind, $nodes := .Nodes}}
     {{$kind}}:
+      vars:
+        {{- with index $nodes 0 }}
+        {{- if .NetworkOS }}
+        ansible_network_os: {{ .NetworkOS }}
+        {{- end }}
+        {{- if .AnsibleConn }}
+        # default connection type for nodes of this kind
+        # feel free to override this in your inventory
+        ansible_connection: {{ .AnsibleConn }}
+        {{- else}}
+        # ansible_connection: set ansible_connection variable if required
+        {{- end }}
+        {{- end }}
       hosts:
       {{- range $nodes}}
         {{.LongName}}:
         {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
           ansible_host: {{.MgmtIPv4Address}}
+          {{- if .Username }}
+          ansible_user: {{.Username}}
+          {{- end}}
+          {{- if .Username }}
+          ansible_password: {{.Password}}
+          {{- end}}
         {{- end -}}
       {{- end}}
 {{- end}}

--- a/clab/inventory_ansible.go.tpl
+++ b/clab/inventory_ansible.go.tpl
@@ -1,0 +1,27 @@
+all:
+  vars:
+    # The generated inventory is assumed to be used from the clab host.
+    # Hence no http proxy should be used. Therefore we make sure the http
+    # module does not attempt using any global http proxy.
+    ansible_httpapi_use_proxy: false
+  children:
+{{- range $kind, $nodes := .Nodes}}
+    {{$kind}}:
+      hosts:
+{{- range $nodes}}
+        {{.LongName}}:
+    {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
+          ansible_host: {{.MgmtIPv4Address}}
+    {{- end -}}
+{{- end}}
+{{- end}}
+{{- range $name, $nodes := .Groups}}
+    {{$name}}:
+      hosts:
+{{- range $nodes}}
+        {{.LongName}}:
+    {{- if not (eq (index .Labels "ansible-no-host-var") "true") }}
+          ansible_host: {{.MgmtIPv4Address}}
+    {{- end -}}
+{{- end}}
+{{- end}}

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -26,12 +26,18 @@ func TestGenerateAnsibleInventory(t *testing.T) {
     ansible_httpapi_use_proxy: false
   children:
     nokia_srlinux:
+      vars:
+        ansible_network_os: nokia.srlinux.srlinux
+        # default connection type for nodes of this kind
+        # feel free to override this in your inventory
+        ansible_connection: ansible.netcommon.httpapi
+        ansible_user: admin
+        ansible_password: NokiaSrl1!
       hosts:
         clab-topo1-node1:
           ansible_host: 172.100.100.11
         clab-topo1-node2:
-          ansible_host: 172.100.100.12
-`,
+          ansible_host: 172.100.100.12`,
 		},
 		"case2": {
 			got: "test_data/topo8_ansible_groups.yml",
@@ -43,9 +49,18 @@ func TestGenerateAnsibleInventory(t *testing.T) {
     ansible_httpapi_use_proxy: false
   children:
     linux:
+      vars:
+        # ansible_connection: set ansible_connection variable if required
       hosts:
         clab-topo8_ansible_groups-node4:
     nokia_srlinux:
+      vars:
+        ansible_network_os: nokia.srlinux.srlinux
+        # default connection type for nodes of this kind
+        # feel free to override this in your inventory
+        ansible_connection: ansible.netcommon.httpapi
+        ansible_user: admin
+        ansible_password: NokiaSrl1!
       hosts:
         clab-topo8_ansible_groups-node1:
           ansible_host: 172.100.100.11
@@ -62,8 +77,7 @@ func TestGenerateAnsibleInventory(t *testing.T) {
     spine:
       hosts:
         clab-topo8_ansible_groups-node1:
-          ansible_host: 172.100.100.11
-`,
+          ansible_host: 172.100.100.11`,
 		},
 	}
 
@@ -83,8 +97,8 @@ func TestGenerateAnsibleInventory(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !cmp.Equal(s.String(), tc.want) {
-				t.Errorf("failed at '%s', expected\n%v, got\n%+v", name, tc.want, s.String())
+			if diff := cmp.Diff(tc.want, s.String()); diff != "" {
+				t.Errorf("failed at '%s', diff: (-want +got)\n%s", name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
A shortcut approach with kind based variables added for nokia_srlinux and nokia_sros

the following vars are now part of the generated topology

* `ansible_network_os`
* `ansible_connection`
* `ansible_user`
* `ansible_password`