### PR TITLE
Support mounting anonymous volume

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -497,6 +497,11 @@ func (c *CLab) resolveBindPaths(binds []string, nodedir string) error {
 		// host path is a first element in a /hostpath:/remotepath(:options) string
 		elems := strings.Split(binds[i], ":")
 
+		if len(elems) == 1 {
+			// if there is only one element, it means that we have an anonymous
+			// volume, in this case we don't need to resolve the path
+			continue
+		}
 		// replace special variable
 		r := strings.NewReplacer(clabDirVar, c.TopoPaths.TopologyLabDir(), nodeDirVar, nodedir)
 		hp := r.Replace(elems[0])

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -178,12 +178,14 @@ topology:
         - /root/files:/root/files:ro # (2)!
         - somefile:/somefile # (3)!
         - ~/.ssh/id_rsa:/root/.ssh/id_rsa # (4)!
+        - /var/run/somedir # (5)!
 ```
 
 1. mount a host file found by the path `/usr/local/bin/gobgp` to a container under `/root/gobgp` (implicit RW mode)
 2. mount a `/root/files` directory from a host to a container in RO mode
 3. when a host path is given in a relative format, the path is considered relative to the topology file and not a current working directory.
 4. The `~` char will be expanded to a user's home directory.
+5. mount an anonymous volume to a container under `/var/run/somedir` (implicit RW mode)
 
 ???info "Bind variables"
     By default, binds are either provided as an absolute or a relative (to the current working dir) path. Although the majority of cases can be very well covered with this, there are situations in which it is desirable to use a path that is relative to the node-specific example.

--- a/types/bind.go
+++ b/types/bind.go
@@ -17,6 +17,12 @@ func NewBind(bind string) (*Bind, error) {
 	b := &Bind{}
 
 	split := strings.Split(bind, ":")
+	if len(split) == 1 {
+		// If there is only one part, the container runtime creates an anonymous
+		// volume and mounts it on the given destination.
+		b.dst = split[0]
+		return b, nil
+	}
 	if len(split) < 2 || len(split) > 3 {
 		return nil, fmt.Errorf("unable to parse bind %q", bind)
 	}
@@ -48,7 +54,10 @@ func (b *Bind) Mode() string {
 
 // String returns the bind mount as a string.
 func (b *Bind) String() string {
-	s := fmt.Sprintf("%s:%s", b.src, b.dst)
+	s := b.dst
+	if b.src != "" {
+		s = fmt.Sprintf("%s:%s", b.src, s)
+	}
 	if b.mode != "" {
 		s += fmt.Sprintf(":%s", b.mode)
 	}


### PR DESCRIPTION
The `docker run ... -v /path/to/dir` syntax creates an anonymous volume and mounts it to the given destination path in the container.