### PR TITLE
do not render empty vars section in the ansible inventory

### DIFF
--- a/clab/inventory_ansible.go.tpl
+++ b/clab/inventory_ansible.go.tpl
@@ -8,8 +8,9 @@ all:
 {{- $root := . }}
 {{- range $kind, $nodes := .Nodes}}
     {{$kind}}:
+      {{- with index $root.Kinds $kind }}
+      {{- if or .NetworkOS .AnsibleConn .Username .Password }}
       vars:
-        {{- with index $root.Kinds $kind }}
         {{- if .NetworkOS }}
         ansible_network_os: {{ .NetworkOS }}
         {{- end }}
@@ -27,6 +28,7 @@ all:
         ansible_password: {{.Password}}
         {{- end }}
         {{- end }}
+      {{- end }}
       hosts:
       {{- range $nodes}}
         {{.LongName}}:

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -49,8 +49,6 @@ func TestGenerateAnsibleInventory(t *testing.T) {
     ansible_httpapi_use_proxy: false
   children:
     linux:
-      vars:
-        # ansible_connection: set ansible_connection variable if required
       hosts:
         clab-topo8_ansible_groups-node4:
     nokia_srlinux:


### PR DESCRIPTION
fix #1855