### PR TITLE
Fixing unnessecary and even wrong error log

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -570,12 +570,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				// deployed properly. Hence we need to wait for all the links to be created.
 				// we just wait if there is actually a dependency on this state, otherwise
 				// we head on.
-				mustWait, err := dn.MustWait(types.WaitForCreateLinks)
-				if err != nil {
-					log.Error(err)
-				}
-
-				if mustWait {
+				if dn.MustWait(types.WaitForCreateLinks) {
 					node.WaitForAllLinksCreated()
 				}
 
@@ -601,11 +596,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				}
 
 				// health state processing
-				mustWait, err = dn.MustWait(types.WaitForHealthy)
-				if err != nil {
-					log.Error(err)
-				}
-				if mustWait {
+				if dn.MustWait(types.WaitForHealthy) {
 					// if there is a dependecy on the healthy state of this node, enter the checking procedure
 					for {
 						healthy, err := node.IsHealthy(ctx)
@@ -623,11 +614,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				}
 
 				// exit state processing
-				mustWait, err = dn.MustWait(types.WaitForExit)
-				if err != nil {
-					log.Error(err)
-				}
-				if mustWait {
+				if dn.MustWait(types.WaitForExit) {
 					// if there is a dependency on the healthy state of this node, enter the checking procedure
 					for {
 						status := node.GetContainerStatus(ctx)

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -88,11 +88,11 @@ func (d *DependencyNode) addDepender(dependerStage types.WaitForStage, depender 
 }
 
 // MustWait returns true if the node needs to wait for the given stage, because dependers do exist.
-func (d *DependencyNode) MustWait(state types.WaitForStage) (bool, error) {
+func (d *DependencyNode) MustWait(state types.WaitForStage) bool {
 	if b, exists := d.mustWait[state]; exists {
-		return b, nil
+		return b
 	}
-	return false, fmt.Errorf("stage %q not found", d.name)
+	return false
 }
 
 // dependerNodeStage is used to keep track of waitgroups that should be decreased (unblocked)

--- a/docs/rn/0.51.md
+++ b/docs/rn/0.51.md
@@ -51,3 +51,9 @@ So we brought back the support for `iptables` as a firewall backend while keepin
 * SR Linux config has been updated to support the coming 24.3 release #1845
 * Ansible inventory file will not have an empty vars section if no vars are defined #1863
 * Added a basic SR OS CI pipeline #1852
+
+## Patches
+
+### 0.51.1
+
+* fixed erroneous error log message about the stages not found #1892


### PR DESCRIPTION
On the call to MustWait on the dependency manager node, with a given stage, a non existing stage entry triggered an error log. However the non existence must simply be reflected by a false value. No Wait needs to happen.