### PR TITLE
k8s_kind: Display kind provisioning log

### DIFF
--- a/nodes/k8s_kind/k8s_kind.go
+++ b/nodes/k8s_kind/k8s_kind.go
@@ -139,7 +139,10 @@ func (n *k8s_kind) getProvider() (*cluster.Provider, error) {
 	}
 
 	// create the Provider with the above runtime based options
-	return cluster.NewProvider(kindProviderOptions), nil
+	return cluster.NewProvider(
+		kindProviderOptions,
+		cluster.ProviderWithLogger(newKindLogger(n.Cfg.ShortName, 0)),
+	), nil
 }
 
 // readClusterConfig reads the kind clusterconfig from a file.

--- a/nodes/k8s_kind/logger.go
+++ b/nodes/k8s_kind/logger.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Yutaro Hayakawa
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package k8s_kind
+
+import (
+	log "github.com/sirupsen/logrus"
+	kindLog "sigs.k8s.io/kind/pkg/log"
+)
+
+// kindLogger inplements the log.Logger interface for kind
+type kindLogger struct {
+	l log.FieldLogger
+	v kindLog.Level
+}
+
+func newKindLogger(clusterName string, v kindLog.Level) *kindLogger {
+	return &kindLogger{
+		l: log.WithField("kind-cluster", clusterName),
+		v: v,
+	}
+}
+
+func (l *kindLogger) Warn(message string) {
+	l.l.Warn(message)
+}
+
+func (l *kindLogger) Warnf(format string, args ...interface{}) {
+	l.l.Warnf(format, args...)
+}
+
+func (l *kindLogger) Error(message string) {
+	l.l.Error(message)
+}
+
+func (l *kindLogger) Errorf(format string, args ...interface{}) {
+	l.l.Errorf(format, args...)
+}
+
+func (l *kindLogger) V(v kindLog.Level) kindLog.InfoLogger {
+	return &kindInfoLogger{
+		l:       l.l,
+		v:       v,
+		enabled: v <= l.v,
+	}
+}
+
+type kindInfoLogger struct {
+	l       log.FieldLogger
+	v       kindLog.Level
+	enabled bool
+}
+
+func (l *kindInfoLogger) Info(message string) {
+	if !l.enabled {
+		return
+	}
+	l.l.Info(message)
+}
+
+func (l *kindInfoLogger) Infof(format string, args ...interface{}) {
+	if !l.enabled {
+		return
+	}
+	l.l.Infof(format, args...)
+}
+
+func (l *kindInfoLogger) Enabled() bool {
+	return l.enabled
+}


### PR DESCRIPTION
Currently, kind provisioning is not logged, so we cannot know how provisioning is going on. Implement a logger.

An example output:

```
INFO[0000] Containerlab v0.0.0 started
INFO[0000] Parsing & checking topology file: topo.yaml
INFO[0000] Creating docker network: Name="clab", IPv4Subnet="172.20.20.0/24", IPv6Subnet="2001:172:20:20::/64", MTU='ל'
INFO[0000] Creating lab directory: /home/yutaro/WorkSpace/containerlab/clab-kind01
INFO[0000] Creating container: "server"
INFO[0000] Creating cluster "k01" ...                    kind-cluster=k01
INFO[0000]  • Ensuring node image (kindest/node:v1.29.1) 🖼  ...  kind-cluster=k01
INFO[0000]  ✓ Ensuring node image (kindest/node:v1.29.1) 🖼  kind-cluster=k01
INFO[0000]  • Preparing nodes 📦   ...                    kind-cluster=k01
INFO[0001]  ✓ Preparing nodes 📦                          kind-cluster=k01
INFO[0001]  • Writing configuration 📜  ...               kind-cluster=k01
INFO[0001]  ✓ Writing configuration 📜                    kind-cluster=k01
INFO[0001]  • Starting control-plane 🕹️  ...             kind-cluster=k01
INFO[0010]  ✓ Starting control-plane 🕹️                  kind-cluster=k01
INFO[0010]  • Installing CNI 🔌  ...                      kind-cluster=k01
INFO[0010]  ✓ Installing CNI 🔌                           kind-cluster=k01
INFO[0010]  • Installing StorageClass 💾  ...             kind-cluster=k01
INFO[0010]  ✓ Installing StorageClass 💾                  kind-cluster=k01
INFO[0010]  • Waiting ≤ 15m0s for control-plane = Ready ⏳  ...  kind-cluster=k01
INFO[0026]  ✓ Waiting ≤ 15m0s for control-plane = Ready ⏳  kind-cluster=k01
INFO[0026]  • Ready after 15s 💚                          kind-cluster=k01
INFO[0026] Adding containerlab host entries to /etc/hosts file
INFO[0026] Adding ssh config for containerlab nodes
INFO[0026] 🎉 New containerlab version 0.51.1 is available! Release notes: https://containerlab.dev/rn/0.51/#0511
Run 'containerlab version upgrade' to upgrade or go check other installation options at https://containerlab.dev/install/
+---+--------------------+--------------+----------------------------------------------------------------------------------------------+---------------+---------+----------------+--------------------------+
| # |        Name        | Container ID |                                            Image                                             |     Kind      |  State  |  IPv4 Address  |       IPv6 Address       |
+---+--------------------+--------------+----------------------------------------------------------------------------------------------+---------------+---------+----------------+--------------------------+
| 1 | k01-control-plane  | 2312bccc821e | kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144 | ext-container | running | 172.22.0.5/16  | fc00:f853:ccd:e793::5/64 |
| 2 | clab-kind01-server | 06310d1d2a1d | nicolaka/netshoot:latest                                                                     | linux         | running | 172.20.20.2/24 | 2001:172:20:20::2/64     |
| 3 | k01-control-plane  | 2312bccc821e | kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144 | k8s-kind      | running | 172.22.0.5/16  | fc00:f853:ccd:e793::5/64 |
+---+--------------------+--------------+----------------------------------------------------------------------------------------------+---------------+---------+----------------+--------------------------+
```