### PR TITLE
Check DOCKER-USER chain exists in nf_tables

### DIFF
--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -50,7 +50,7 @@ func NewNftablesClient(bridgeName string) (*NftablesClient, error) {
 		return nil, err
 	}
 	if len(chains) == 0 {
-		log.Debug("nftables does not seem to be in use, no DOCKER-USER chain found.")
+		log.Debugf("nftables does not seem to be in use, no %s chain found.", definitions.DockerFWUserChain)
 		return nil, definitions.ErrNotAvailabel
 	}
 

--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -45,7 +45,7 @@ func NewNftablesClient(bridgeName string) (*NftablesClient, error) {
 		bridgeName: bridgeName,
 	}
 
-	chains, err := nftC.getChains("DOCKER-USER")
+	chains, err := nftC.getChains(definitions.DockerFWUserChain)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -45,6 +45,15 @@ func NewNftablesClient(bridgeName string) (*NftablesClient, error) {
 		bridgeName: bridgeName,
 	}
 
+	chains, err := nftC.getChains("DOCKER-USER")
+	if err != nil {
+		return nil, err
+	}
+	if len(chains) == 0 {
+		log.Debug("nftables does not seem to be in use, no DOCKER-USER chain found.")
+		return nil, definitions.ErrNotAvailabel
+	}
+
 	return nftC, nil
 }
 


### PR DESCRIPTION
The simple check for the loaded nf_tables kernel module is not enough. It can be loaded whilst nf_tables is still not in use. iptables-legacy then most probably is.
So via this PR, we check if the DOCKER-USER chain exists. If not, we return and iptables will be used.