### PR TITLE
Per-stage command execution

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -467,7 +467,6 @@ func (c *CLab) createStaticDynamicDependency() error {
 		for _, staticNode := range staticIPNodes {
 
 			err := staticNode.AddDepender(types.WaitForCreate, dynNode, types.WaitForCreate)
-
 			if err != nil {
 				return err
 			}

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -552,7 +552,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					log.Errorf("failed to update node runtime information for node %s: %v", node.Config().ShortName, err)
 				}
 
-				node.Done(types.WaitForCreate)
+				node.Done(ctx, types.WaitForCreate)
 
 				node.EnterStage(ctx, types.WaitForCreateLinks)
 
@@ -563,7 +563,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					continue
 				}
 
-				node.Done(types.WaitForCreateLinks)
+				node.Done(ctx, types.WaitForCreateLinks)
 
 				// start config stage
 				node.EnterStage(ctx, types.WaitForConfigure)
@@ -576,7 +576,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					}
 				}
 
-				node.Done(types.WaitForConfigure)
+				node.Done(ctx, types.WaitForConfigure)
 
 				// run execs
 				err = node.RunExecFromConfig(ctx, execCollection)
@@ -596,7 +596,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 						}
 						if healthy {
 							log.Infof("node %q turned healthy, continuing", node.GetShortName())
-							node.Done(types.WaitForHealthy)
+							node.Done(ctx, types.WaitForHealthy)
 							break
 						}
 						time.Sleep(time.Second)
@@ -611,7 +611,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 						status := node.GetContainerStatus(ctx)
 						if status == runtime.Stopped {
 							log.Infof("node %q stopped", node.GetShortName())
-							node.Done(types.WaitForExit)
+							node.Done(ctx, types.WaitForExit)
 							break
 						}
 						time.Sleep(time.Second)

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -505,9 +505,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 	execCollection := exec.NewExecCollection()
 
-	workerFunc := func(i int, input chan *depMgr.DependencyNode, wg *sync.WaitGroup,
-		dm depMgr.DependencyManager,
-	) {
+	workerFunc := func(i int, input chan *depMgr.DependencyNode, wg *sync.WaitGroup) {
 		defer wg.Done()
 		for {
 			select {
@@ -638,7 +636,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 	// it's safe to not check if all nodes are serial because in that case
 	// maxWorkers will be 0
 	for i := 0; i < maxWorkers; i++ {
-		go workerFunc(i, concurrentChan, wg, c.dependencyManager)
+		go workerFunc(i, concurrentChan, wg)
 	}
 
 	// Waitgroup protects the channel towards the workers of being closed too early

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -589,6 +589,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 				// health state processing
 				if node.MustWait(types.WaitForHealthy) {
+					node.EnterStage(ctx, types.WaitForHealthy)
 					// if there is a dependecy on the healthy state of this node, enter the checking procedure
 					for {
 						healthy, err := node.IsHealthy(ctx)
@@ -607,6 +608,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 				// exit state processing
 				if node.MustWait(types.WaitForExit) {
+					node.EnterStage(ctx, types.WaitForExit)
 					// if there is a dependency on the healthy state of this node, enter the checking procedure
 					for {
 						status := node.GetContainerStatus(ctx)

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -361,8 +361,8 @@ func (c *CLab) GlobalRuntime() runtime.ContainerRuntime {
 // is printed after the nodes are created.
 // Nodes interdependencies are created in this function.
 func (c *CLab) CreateNodes(ctx context.Context, maxWorkers uint, skipPostDeploy bool) (*sync.WaitGroup, *exec.ExecCollection, error) {
-	for nodeName := range c.Nodes {
-		c.dependencyManager.AddNode(nodeName)
+	for _, node := range c.Nodes {
+		c.dependencyManager.AddNode(node)
 	}
 
 	// nodes with static mgmt IP should be scheduled before the dynamic ones
@@ -402,15 +402,16 @@ func (c *CLab) CreateNodes(ctx context.Context, maxWorkers uint, skipPostDeploy 
 
 // create a set of dependencies, that makes the ignite nodes start one after the other.
 func (c *CLab) createIgniteSerialDependency() error {
-	var prevIgniteNode nodes.Node
+	var prevIgniteNode *depMgr.DependencyNode
 	// iterate through the nodes
-	for _, n := range c.Nodes {
+	for _, n := range c.dependencyManager.GetNodes() {
 		// find nodes that should run with IgniteRuntime
 		if n.GetRuntime().GetName() == ignite.RuntimeName {
 			if prevIgniteNode != nil {
-				// add a dependency to the previously found ignite node
-				c.dependencyManager.AddDependency(prevIgniteNode.Config().ShortName,
-					types.WaitForCreate, n.Config().ShortName, types.WaitForCreate)
+				err := n.AddDepender(types.WaitForCreate, prevIgniteNode, types.WaitForCreate)
+				if err != nil {
+					return err
+				}
 			}
 			prevIgniteNode = n
 		}
@@ -427,35 +428,32 @@ func (c *CLab) createIgniteSerialDependency() error {
 //
 // then node_a depends on node_b, and waits for node_b to be scheduled first.
 func (c *CLab) createNamespaceSharingDependency() {
-	for nodeName, n := range c.Nodes {
+	for _, n := range c.dependencyManager.GetNodes() {
 		nodeConfig := n.Config()
 		netModeArr := strings.SplitN(nodeConfig.NetworkMode, ":", 2)
 		if netModeArr[0] != "container" {
 			// we only care about nodes with shared netns network-mode ("container:<CONTAINERNAME>")
 			continue
 		}
-		// the referenced container might be an external pre-existing or a container defined in the given clab topology.
-		referencedNode := netModeArr[1]
 
-		// if the container does not exist in the list of containers, it must be an external dependency
-		// it can be ignored for internal processing so -> continue
-		if _, exists := c.Nodes[netModeArr[1]]; !exists {
-			continue
+		referenceNodeName := netModeArr[1]
+		referenceNode, err := c.dependencyManager.GetNode(referenceNodeName)
+		if err != nil {
+			log.Warnf("node %s refrenced in namespace sharing not found, considering it an external dependency.", referenceNodeName)
 		}
 
-		// since the referenced container is clab-managed node, we create a dependency between the nodes
-		c.dependencyManager.AddDependency(nodeName, types.WaitForCreate, referencedNode, types.WaitForCreate)
+		referenceNode.AddDepender(types.WaitForCreate, n, types.WaitForCreate)
 	}
 }
 
 // createStaticDynamicDependency creates the dependencies between the nodes such that all nodes with dynamic mgmt IP
 // are dependent on the nodes with static mgmt IP. This results in nodes with static mgmt IP to be scheduled before dynamic ones.
 func (c *CLab) createStaticDynamicDependency() error {
-	staticIPNodes := make(map[string]nodes.Node)
-	dynIPNodes := make(map[string]nodes.Node)
+	staticIPNodes := make(map[string]*depMgr.DependencyNode)
+	dynIPNodes := make(map[string]*depMgr.DependencyNode)
 
 	// divide the nodes into static and dynamic mgmt IP nodes.
-	for name, n := range c.Nodes {
+	for name, n := range c.dependencyManager.GetNodes() {
 		if n.Config().MgmtIPv4Address != "" || n.Config().MgmtIPv6Address != "" {
 			staticIPNodes[name] = n
 			continue
@@ -464,10 +462,12 @@ func (c *CLab) createStaticDynamicDependency() error {
 	}
 
 	// go through all the dynamic ip nodes
-	for dynNodeName := range dynIPNodes {
+	for _, dynNode := range dynIPNodes {
 		// and add their wait group to the the static nodes, while increasing the waitgroup
-		for staticNodeName := range staticIPNodes {
-			err := c.dependencyManager.AddDependency(dynNodeName, types.WaitForCreate, staticNodeName, types.WaitForCreate)
+		for _, staticNode := range staticIPNodes {
+
+			err := staticNode.AddDepender(types.WaitForCreate, dynNode, types.WaitForCreate)
+
 			if err != nil {
 				return err
 			}
@@ -479,12 +479,17 @@ func (c *CLab) createStaticDynamicDependency() error {
 // createWaitForDependency adds dependencies defined in the configuration via the wait-for field
 // of the deployment stages.
 func (c *CLab) createWaitForDependency() error {
-	for dependerNode, node := range c.Nodes {
+	for _, dependerNode := range c.dependencyManager.GetNodes() {
 		// add node's waitFor nodes to the dependency manager
-		for dependerStage, waitForNodes := range node.Config().Stages.GetWaitFor() {
+		for dependerStage, waitForNodes := range dependerNode.Config().Stages.GetWaitFor() {
 			for _, dependee := range waitForNodes {
-				err := c.dependencyManager.AddDependency(dependerNode,
-					dependerStage, dependee.Node, dependee.Stage)
+
+				dependeeNode, err := c.dependencyManager.GetNode(dependee.Node)
+				if err != nil {
+					return fmt.Errorf("dependee node %s not found", dependee.Node)
+				}
+
+				err = dependeeNode.AddDepender(dependerStage, dependerNode, dependee.Stage)
 				if err != nil {
 					return err
 				}
@@ -496,11 +501,11 @@ func (c *CLab) createWaitForDependency() error {
 }
 
 func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy bool) (*sync.WaitGroup, *exec.ExecCollection) {
-	concurrentChan := make(chan nodes.Node)
+	concurrentChan := make(chan *depMgr.DependencyNode)
 
 	execCollection := exec.NewExecCollection()
 
-	workerFunc := func(i int, input chan nodes.Node, wg *sync.WaitGroup,
+	workerFunc := func(i int, input chan *depMgr.DependencyNode, wg *sync.WaitGroup,
 		dm depMgr.DependencyManager,
 	) {
 		defer wg.Done()
@@ -510,11 +515,6 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				if node == nil || !ok {
 					log.Debugf("Worker %d terminating...", i)
 					return
-				}
-
-				dn, err := c.dependencyManager.GetNode(node.GetShortName())
-				if err != nil {
-					log.Error(err)
 				}
 
 				log.Debugf("Worker %d received node: %+v", i, node.Config())
@@ -527,7 +527,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				}
 
 				// Pre-deploy stage
-				err = node.PreDeploy(
+				err := node.PreDeploy(
 					ctx,
 					&nodes.PreDeployParams{
 						Cert:         c.Cert,
@@ -555,9 +555,9 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					log.Errorf("failed to update node runtime information for node %s: %v", node.Config().ShortName, err)
 				}
 
-				dn.Done(types.WaitForCreate)
+				node.Done(types.WaitForCreate)
 
-				dn.EnterStage(types.WaitForCreateLinks)
+				node.EnterStage(ctx, types.WaitForCreateLinks)
 
 				// Deploy the Nodes link endpoints
 				err = node.DeployEndpoints(ctx)
@@ -566,10 +566,10 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					continue
 				}
 
-				dn.Done(types.WaitForCreateLinks)
+				node.Done(types.WaitForCreateLinks)
 
 				// start config stage
-				dn.EnterStage(types.WaitForConfigure)
+				node.EnterStage(ctx, types.WaitForConfigure)
 
 				// if postdeploy should be skipped we do not call it
 				if !skipPostDeploy {
@@ -579,7 +579,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					}
 				}
 
-				dn.Done(types.WaitForConfigure)
+				node.Done(types.WaitForConfigure)
 
 				// run execs
 				err = node.RunExecFromConfig(ctx, execCollection)
@@ -588,7 +588,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				}
 
 				// health state processing
-				if dn.MustWait(types.WaitForHealthy) {
+				if node.MustWait(types.WaitForHealthy) {
 					// if there is a dependecy on the healthy state of this node, enter the checking procedure
 					for {
 						healthy, err := node.IsHealthy(ctx)
@@ -598,7 +598,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 						}
 						if healthy {
 							log.Infof("node %q turned healthy, continuing", node.GetShortName())
-							dn.Done(types.WaitForHealthy)
+							node.Done(types.WaitForHealthy)
 							break
 						}
 						time.Sleep(time.Second)
@@ -606,13 +606,13 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				}
 
 				// exit state processing
-				if dn.MustWait(types.WaitForExit) {
+				if node.MustWait(types.WaitForExit) {
 					// if there is a dependency on the healthy state of this node, enter the checking procedure
 					for {
 						status := node.GetContainerStatus(ctx)
 						if status == runtime.Stopped {
 							log.Infof("node %q stopped", node.GetShortName())
-							dn.Done(types.WaitForExit)
+							node.Done(types.WaitForExit)
 							break
 						}
 						time.Sleep(time.Second)
@@ -644,12 +644,12 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 	// schedule nodes via a go func to create links in parallel
 	go func() {
-		for _, n := range c.Nodes {
+		for _, dn := range c.dependencyManager.GetNodes() {
 			workerFuncChWG.Add(1)
 			// start a func for all the containers, then will wait for their own waitgroups
 			// to be set to zero by their depending containers, then enqueue to the creation channel
-			go func(node nodes.Node, dm depMgr.DependencyManager,
-				workerChan chan<- nodes.Node, wfcwg *sync.WaitGroup,
+			go func(node *depMgr.DependencyNode, dm depMgr.DependencyManager,
+				workerChan chan<- *depMgr.DependencyNode, wfcwg *sync.WaitGroup,
 			) {
 				// we are entering the create stage here and not in the workerFunc
 				// to avoid blocking the worker.
@@ -659,12 +659,8 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				// the nodes stuck in waiting.
 				// Entering the Create stage here would not consume a worker and let other nodes
 				// to be scheduled.
-				dn, err := c.dependencyManager.GetNode(node.GetShortName())
-				if err != nil {
-					log.Error(err)
-				}
 
-				dn.EnterStage(types.WaitForCreate)
+				node.EnterStage(ctx, types.WaitForCreate)
 
 				// wait for possible external dependencies
 				c.WaitForExternalNodeDependencies(ctx, node.Config().ShortName)
@@ -672,7 +668,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				workerChan <- node
 				// indicate we are done, such that only when all of these functions are done, the workerChan is being closed
 				wfcwg.Done()
-			}(n, c.dependencyManager, concurrentChan, workerFuncChWG) // execute this function straight away
+			}(dn, c.dependencyManager, concurrentChan, workerFuncChWG) // execute this function straight away
 		}
 
 		// Gate to make sure the channel is not closed before all the nodes made it though the channel

--- a/clab/clab_test.go
+++ b/clab/clab_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	errs "github.com/srl-labs/containerlab/errors"
-	"github.com/srl-labs/containerlab/mocks"
 	"github.com/srl-labs/containerlab/mocks/mocknodes"
 	"github.com/srl-labs/containerlab/mocks/mockruntime"
 	"github.com/srl-labs/containerlab/nodes"
@@ -21,58 +20,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/slices"
 )
-
-func Test_createNamespaceSharingDependencyOne(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	// instantiate a dependencyManager mock
-	dm := mocks.NewMockDependencyManager(mockCtrl)
-
-	// retrieve a map of nodes
-	nodeMap := getNodeMap(mockCtrl)
-
-	clab := &CLab{
-		Nodes: nodeMap,
-	}
-
-	err := WithDependencyManager(dm)(clab)
-	if err != nil {
-		t.Error(err)
-	}
-
-	dm.EXPECT().AddDependency("node3", types.WaitForCreate, "node2", types.WaitForCreate)
-	clab.createNamespaceSharingDependency()
-}
-
-func Test_createStaticDynamicDependency(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	// instantiate a dependencyManager mock
-	dm := mocks.NewMockDependencyManager(mockCtrl)
-
-	// retrieve a map of nodes
-	nodeMap := getNodeMap(mockCtrl)
-
-	clab := &CLab{
-		Nodes: nodeMap,
-	}
-
-	err := WithDependencyManager(dm)(clab)
-	if err != nil {
-		t.Error(err)
-	}
-
-	dm.EXPECT().AddDependency("node1", types.WaitForCreate, "node4", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node2", types.WaitForCreate, "node4", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node3", types.WaitForCreate, "node4", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node1", types.WaitForCreate, "node5", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node2", types.WaitForCreate, "node5", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node3", types.WaitForCreate, "node5", types.WaitForCreate)
-
-	clab.createStaticDynamicDependency()
-}
 
 // getNodeMap return a map of nodes for testing purpose.
 func getNodeMap(mockCtrl *gomock.Controller) map[string]nodes.Node {
@@ -218,37 +165,6 @@ func getNodeMap(mockCtrl *gomock.Controller) map[string]nodes.Node {
 	}
 
 	return nodeMap
-}
-
-func Test_createWaitForDependency(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	// instantiate a dependencyManager mock
-	dm := mocks.NewMockDependencyManager(mockCtrl)
-
-	// retrieve a map of nodes
-	nodeMap := getNodeMap(mockCtrl)
-
-	clab := &CLab{
-		Nodes: nodeMap,
-	}
-
-	err := WithDependencyManager(dm)(clab)
-	if err != nil {
-		t.Error(err)
-	}
-
-	dm.EXPECT().AddDependency("node2", types.WaitForCreate, "node1", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node3", types.WaitForCreate, "node1", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node3", types.WaitForCreate, "node2", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node5", types.WaitForCreate, "node3", types.WaitForCreate)
-	dm.EXPECT().AddDependency("node5", types.WaitForCreate, "node4", types.WaitForCreate)
-
-	err = clab.createWaitForDependency()
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func Test_WaitForExternalNodeDependencies_OK(t *testing.T) {

--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -373,7 +373,7 @@ func TestVerifyLinks(t *testing.T) {
 				t.Fatalf("wanted %q got %q", tc.want, err.Error())
 			}
 			if err == nil && tc.want != "" {
-				t.Fatalf("wanted %q got %q", tc.want, err.Error())
+				t.Fatalf("wanted %q got nil", tc.want)
 			}
 		})
 	}

--- a/clab/dependency_manager/dependency_manager.go
+++ b/clab/dependency_manager/dependency_manager.go
@@ -6,22 +6,20 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/nodes"
 )
 
 type DependencyManager interface {
 	// AddNode adds a node to the dependency manager.
-	AddNode(name string)
+	AddNode(node nodes.Node)
 	// GetNode gets a dependency node registered with the dependency manager.
 	GetNode(name string) (*DependencyNode, error)
-	// AddDependency adds a dependency between a depender and and a dependee.
-	// The depender will hold off the dependerStage until the dependee completes dependeeStage.
-	// This effectively makes the dependerStage to be start only after the dependeeStage finishes.
-	AddDependency(depender string, dependerStage types.WaitForStage, dependee string, dependeeStage types.WaitForStage) error
 	// CheckAcyclicity checks if dependencies contain cycles.
 	CheckAcyclicity() error
 	// String returns a string representation of dependencies recorded with dependency manager.
 	String() string
+	// GetNodes returns the DependencyNodes registered with the DependencyManager
+	GetNodes() map[string]*DependencyNode
 }
 
 // defaultDependencyManager is the default implementation of the DependencyManager.
@@ -37,26 +35,13 @@ func NewDependencyManager() DependencyManager {
 }
 
 // AddNode adds a node to the dependency manager.
-func (dm *defaultDependencyManager) AddNode(name string) {
-	dm.nodes[name] = newDependencyNode(name)
+func (dm *defaultDependencyManager) AddNode(node nodes.Node) {
+	dm.nodes[node.GetShortName()] = NewDependencyNode(node)
 }
 
-// AddDependency adds a dependency between a depender and and a dependee.
-// The depender will hold off its dependerStage until the dependee completes dependeeStage.
-// This effectively makes the dependerStage to be start only after the dependeeStage finishes.
-func (dm *defaultDependencyManager) AddDependency(depender string, dependerStage types.WaitForStage, dependee string, dependeeStage types.WaitForStage) error {
-	// first check if the referenced nodes are known to the dm
-	err := dm.checkNodesExist([]string{dependee})
-	if err != nil {
-		return err
-	}
-	err = dm.checkNodesExist([]string{depender})
-	if err != nil {
-		return err
-	}
-
-	dm.nodes[dependee].addDepender(dependerStage, dm.nodes[depender], dependeeStage)
-	return nil
+// GetNodes returns the DependencyNodes registered with the DependencyManager
+func (dm *defaultDependencyManager) GetNodes() map[string]*DependencyNode {
+	return dm.nodes
 }
 
 func (dm *defaultDependencyManager) GetNode(nodeName string) (*DependencyNode, error) {
@@ -112,7 +97,7 @@ func (dm *defaultDependencyManager) generateDependencyMap() map[string][]string 
 		dependencies[nodeName] = []string{}
 		for _, perStateDependerNSSlice := range node.depender {
 			for _, dependerNS := range perStateDependerNSSlice {
-				dependencies[nodeName] = append(dependencies[nodeName], dependerNS.depender.name)
+				dependencies[nodeName] = append(dependencies[nodeName], dependerNS.depender.GetShortName())
 			}
 		}
 	}

--- a/clab/dependency_manager/dependency_manager.go
+++ b/clab/dependency_manager/dependency_manager.go
@@ -39,7 +39,7 @@ func (dm *defaultDependencyManager) AddNode(node nodes.Node) {
 	dm.nodes[node.GetShortName()] = NewDependencyNode(node)
 }
 
-// GetNodes returns the DependencyNodes registered with the DependencyManager
+// GetNodes returns the DependencyNodes registered with the DependencyManager.
 func (dm *defaultDependencyManager) GetNodes() map[string]*DependencyNode {
 	return dm.nodes
 }

--- a/clab/dependency_manager/dependency_manager_test.go
+++ b/clab/dependency_manager/dependency_manager_test.go
@@ -2,8 +2,6 @@ package dependency_manager
 
 import (
 	"testing"
-
-	"github.com/srl-labs/containerlab/types"
 )
 
 func Test_recursiveAcyclicityCheck(t *testing.T) {
@@ -95,95 +93,6 @@ func Test_recursiveAcyclicityCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isAcyclic(tt.args.dependencies, tt.args.i); got != tt.want {
 				t.Errorf("recursiveAcyclicityCheck() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_defaultDependencyManager_String(t *testing.T) {
-	type fields struct {
-		nodes        map[string]*DependencyNode
-		dependencies []struct {
-			depender string
-			dependee string
-			waitFor  types.WaitForStage
-		}
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name: "test one",
-			fields: fields{
-				nodes: map[string]*DependencyNode{
-					"node1": newDependencyNode("node1"),
-					"node2": newDependencyNode("node2"),
-				},
-				dependencies: []struct {
-					depender string
-					dependee string
-					waitFor  types.WaitForStage
-				}{
-					{
-						depender: "node1",
-						dependee: "node2",
-						waitFor:  types.WaitForCreate,
-					},
-				},
-			},
-			want: `node1 -> [  ]
-node2 -> [ node1 ]`,
-		},
-		{
-			name: "test two",
-			fields: fields{
-				nodes: map[string]*DependencyNode{
-					"node1": newDependencyNode("node1"),
-					"node2": newDependencyNode("node2"),
-					"node3": newDependencyNode("node3"),
-					"node4": newDependencyNode("node4"),
-				},
-				dependencies: []struct {
-					depender string
-					dependee string
-					waitFor  types.WaitForStage
-				}{
-					{
-						depender: "node1",
-						dependee: "node2",
-						waitFor:  types.WaitForCreate,
-					},
-					{
-						depender: "node1",
-						dependee: "node3",
-						waitFor:  types.WaitForCreate,
-					},
-					{
-						depender: "node3",
-						dependee: "node4",
-						waitFor:  types.WaitForCreate,
-					},
-				},
-			},
-			want: `node1 -> [  ]
-node2 -> [ node1 ]
-node3 -> [ node1 ]
-node4 -> [ node3 ]`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dm := &defaultDependencyManager{
-				nodes: tt.fields.nodes,
-			}
-			for _, deps := range tt.fields.dependencies {
-				dm.AddDependency(deps.depender, types.WaitForCreate, deps.dependee, types.WaitForCreate)
-			}
-
-			if got := dm.String(); got != tt.want {
-				t.Errorf("defaultDependencyManager.String() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -37,6 +37,23 @@ func NewDependencyNode(node nodes.Node) *DependencyNode {
 		d.depender[p] = nil
 	}
 
+	// check if Stage based execs exist, if so make sure it will be
+	// waited for the respective phases
+	hasExecs := len(d.Config().Stages.CreateLinks.ExecContainerCommands) > 0
+	if hasExecs {
+		d.mustWait[types.WaitForCreateLinks] = true
+	}
+
+	hasExecs = len(d.Config().Stages.Configure.ExecContainerCommands) > 0
+	if hasExecs {
+		d.mustWait[types.WaitForConfigure] = true
+	}
+
+	hasExecs = len(d.Config().Stages.Healthy.ExecContainerCommands) > 0
+	if hasExecs {
+		d.mustWait[types.WaitForHealthy] = true
+	}
+
 	return d
 }
 

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -114,8 +114,8 @@ func (d *DependencyNode) runExecs(ctx context.Context, ct types.CommandType, p t
 func (d *DependencyNode) Done(ctx context.Context, p types.WaitForStage) {
 	// iterate through all the dependers, that wait for the specific stage
 	// and reduce the waitgroup
-	log.Debugf("StateChange: Done -> %s - %s", d.GetShortName(), p)
 	d.runExecs(ctx, types.CommandTypeExit, p)
+	log.Debugf("StateChange: Done -> %s - %s", d.GetShortName(), p)
 	for _, depender := range d.depender[p] {
 		log.Debugf("StateChange: Node %s unblocking %s", d.GetShortName(), depender.String())
 		depender.SignalDone()

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -77,7 +77,7 @@ func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {
 	log.Debugf("Stage Change: Enter Go -> %s - %s", d.GetShortName(), p)
 
 	var err error
-	var execs = []*exec.ExecCmd{}
+	execs := []*exec.ExecCmd{}
 	switch p {
 	case types.WaitForCreate:
 		execs, err = d.Config().Stages.Create.GetExecs()

--- a/clab/dependency_manager/depender_node_stage.go
+++ b/clab/dependency_manager/depender_node_stage.go
@@ -1,0 +1,33 @@
+package dependency_manager
+
+import (
+	"fmt"
+
+	"github.com/srl-labs/containerlab/types"
+)
+
+// dependerNodeStage is used to keep track of waitgroups that should be decreased (unblocked)
+// as soon as a certain delpoy stage is reached.
+type dependerNodeStage struct {
+	depender *DependencyNode    // reference to the node
+	stage    types.WaitForStage // reference to the nodes wg that is to be decremented
+}
+
+func newDependerNodeStage(node *DependencyNode, stage types.WaitForStage) *dependerNodeStage {
+	return &dependerNodeStage{
+		depender: node,
+		stage:    stage,
+	}
+}
+
+func (d *dependerNodeStage) SignalDone() {
+	d.depender.getStageWG(d.stage).Done()
+}
+
+func (d *dependerNodeStage) IncreaseDependencyWG() {
+	d.depender.stageWG[d.stage].Add(1)
+}
+
+func (d *dependerNodeStage) String() string {
+	return fmt.Sprintf("Node %s, State %s", d.depender.GetShortName(), d.stage)
+}

--- a/clab/export.go
+++ b/clab/export.go
@@ -42,7 +42,7 @@ type TopologyExport struct {
 }
 
 // exportTopologyDataWithTemplate generates and writes topology data file to w using a template.
-func (c *CLab) exportTopologyDataWithTemplate(ctx context.Context, w io.Writer, p string) error {
+func (c *CLab) exportTopologyDataWithTemplate(_ context.Context, w io.Writer, p string) error {
 	n := filepath.Base(p)
 	t, err := template.New(n).
 		Funcs(gomplate.CreateFuncs(context.Background(), new(data.Data))).

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -714,8 +714,30 @@ Note, that `wait-for` is a list, a node's stage may depend on several other node
 
 /// admonition | Usage scenarios
     type: tip
-One of the use cases where `wait-for` might be crucial is when a number of VM-based nodes are deployed. Typically simultaneous deployment of VMs might lead to shortage of CPU resources and VMs might fail to boot. In such cases, `wait-for` can be used to define the order of VM deployment, thus ensuring that certain VMs enter their `create` stage after certain nodes have reached `healthy` status.
+One of the use cases where `wait-for` might be crucial is when a number of VM-based nodes are deployed. Typically, simultaneous deployment of VMs might lead to shortage of CPU resources and VMs might fail to boot. In such cases, `wait-for` can be used to define the order of VM deployment, thus ensuring that certain VMs enter their `create` stage after certain nodes have reached `healthy` status.
 ///
+
+#### Per-stage command execution
+
+The existing [`exec`](#exec) node configuration parameter is used to run commands when then node has finished all its deployment stages. Whilst this is the most common use case, it has its limitations, namely you can't run commands when the node is about to deploy its links, or when it is about to enter the `healthy` stage.
+
+These more advanced command execution scenarios are enabled in the per-stage command execution feature.
+
+With per-stage command execution the user can define `exec` block under each stage; moreover, it is possible to specify when the commands should be run `on-enter` or `on-exit` of the stage.
+
+```yaml
+nodes:
+  node1:
+    stages:
+      create-links:
+        exec:
+          on-enter:
+            - ls /sys/class/net/
+```
+
+In the example above, the `ls /sys/class/net/` command will be executed when `node1` is about to enter the `create-links` stage. As expected, the command will list only interfaces provisioned by docker (eth0 and lo), but none of the containerlab-provisioned interfaces, since the create-links stage has not been finished yet.
+
+Per-stage command execution gives you additional flexibility in terms of when the commands are executed, and what commands are executed at each stage.
 
 ### certificate
 

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -115,7 +115,7 @@ func (l *LinkVEth) deployAEnd(ctx context.Context, idx int) error {
 	peerIdx := (idx + 1) % 2
 	peerEp := l.Endpoints[peerIdx]
 
-	log.Infof("Creating Endpoint: %s ( --> %s )", ep, peerEp)
+	log.Debugf("Creating Endpoint: %s ( --> %s )", ep, peerEp)
 
 	// build the netlink.Veth struct for the link provisioning
 	linkA := &netlink.Veth{

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -166,7 +166,7 @@ func (l *LinkVEth) deployBEnd(ctx context.Context, idx int) error {
 	ep := l.Endpoints[idx]
 	peerEp := l.Endpoints[(idx+1)%2]
 
-	log.Infof("Assigning Endpoint: %s ( --> %s )", ep, peerEp)
+	log.Debugf("Assigning Endpoint: %s ( --> %s )", ep, peerEp)
 
 	// retrieve the netlink.Link for the provided Endpoint
 	link, err := netlink.LinkByName(ep.GetRandIfaceName())

--- a/mocks/dependency_manager.go
+++ b/mocks/dependency_manager.go
@@ -13,7 +13,7 @@ import (
 	reflect "reflect"
 
 	dependency_manager "github.com/srl-labs/containerlab/clab/dependency_manager"
-	types "github.com/srl-labs/containerlab/types"
+	nodes "github.com/srl-labs/containerlab/nodes"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,30 +40,16 @@ func (m *MockDependencyManager) EXPECT() *MockDependencyManagerMockRecorder {
 	return m.recorder
 }
 
-// AddDependency mocks base method.
-func (m *MockDependencyManager) AddDependency(depender string, dependerStage types.WaitForStage, dependee string, dependeeStage types.WaitForStage) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddDependency", depender, dependerStage, dependee, dependeeStage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddDependency indicates an expected call of AddDependency.
-func (mr *MockDependencyManagerMockRecorder) AddDependency(depender, dependerStage, dependee, dependeeStage any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDependency", reflect.TypeOf((*MockDependencyManager)(nil).AddDependency), depender, dependerStage, dependee, dependeeStage)
-}
-
 // AddNode mocks base method.
-func (m *MockDependencyManager) AddNode(name string) {
+func (m *MockDependencyManager) AddNode(node nodes.Node) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddNode", name)
+	m.ctrl.Call(m, "AddNode", node)
 }
 
 // AddNode indicates an expected call of AddNode.
-func (mr *MockDependencyManagerMockRecorder) AddNode(name any) *gomock.Call {
+func (mr *MockDependencyManagerMockRecorder) AddNode(node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNode", reflect.TypeOf((*MockDependencyManager)(nil).AddNode), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNode", reflect.TypeOf((*MockDependencyManager)(nil).AddNode), node)
 }
 
 // CheckAcyclicity mocks base method.
@@ -93,6 +79,20 @@ func (m *MockDependencyManager) GetNode(name string) (*dependency_manager.Depend
 func (mr *MockDependencyManagerMockRecorder) GetNode(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockDependencyManager)(nil).GetNode), name)
+}
+
+// GetNodes mocks base method.
+func (m *MockDependencyManager) GetNodes() map[string]*dependency_manager.DependencyNode {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodes")
+	ret0, _ := ret[0].(map[string]*dependency_manager.DependencyNode)
+	return ret0
+}
+
+// GetNodes indicates an expected call of GetNodes.
+func (mr *MockDependencyManagerMockRecorder) GetNodes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodes", reflect.TypeOf((*MockDependencyManager)(nil).GetNodes))
 }
 
 // String mocks base method.

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -640,6 +640,9 @@
                     "properties": {
                         "wait-for": {
                             "$ref": "#/definitions/wait-for-config"
+                        },
+                        "exec": {
+                            "$ref": "#/definitions/stage-exec"
                         }
                     },
                     "additionalProperties": false
@@ -650,6 +653,9 @@
                     "properties": {
                         "wait-for": {
                             "$ref": "#/definitions/wait-for-config"
+                        },
+                        "exec": {
+                            "$ref": "#/definitions/stage-exec"
                         }
                     },
                     "additionalProperties": false
@@ -660,6 +666,9 @@
                     "properties": {
                         "wait-for": {
                             "$ref": "#/definitions/wait-for-config"
+                        },
+                        "exec": {
+                            "$ref": "#/definitions/stage-exec"
                         }
                     },
                     "additionalProperties": false
@@ -670,6 +679,9 @@
                     "properties": {
                         "wait-for": {
                             "$ref": "#/definitions/wait-for-config"
+                        },
+                        "exec": {
+                            "$ref": "#/definitions/stage-exec"
                         }
                     },
                     "additionalProperties": false
@@ -680,6 +692,9 @@
                     "properties": {
                         "wait-for": {
                             "$ref": "#/definitions/wait-for-config"
+                        },
+                        "exec": {
+                            "$ref": "#/definitions/stage-exec"
                         }
                     },
                     "additionalProperties": false
@@ -717,6 +732,27 @@
                 "healthy",
                 "exit"
             ]
+        },
+        "stage-exec": {
+            "type": "object",
+            "description": "per-stage exec configuration",
+            "properties": {
+                "on-enter": {
+                    "$ref": "#/definitions/stage-exec-list"
+                },
+                "on-exit": {
+                    "$ref": "#/definitions/stage-exec-list"
+                }
+            }
+        },
+        "stage-exec-list": {
+            "type": "array",
+            "description": "list of commands to execute",
+            "markdownDescription": "list of [commands to execute](https://containerlab.dev/manual/nodes/#exec)",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
         }
     },
     "type": "object",

--- a/tests/01-smoke/18-stages.robot
+++ b/tests/01-smoke/18-stages.robot
@@ -1,8 +1,10 @@
 *** Settings ***
 Library             OperatingSystem
 Library             String
+Library             Collections
 Library             Process
 Resource            ../common.robot
+Library             Collections
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Teardown
@@ -26,13 +28,15 @@ Pre-Pull Image
 
 Deploy ${lab-name} lab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file}
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}
     Log    ${output.stderr}
 
     Should Be Equal As Integers    ${output.rc}    0
+
+    Set Suite Variable    ${deploylog}    ${output}
 
 Ensure node3 started after node4
     [Documentation]    Ensure node3 is started after node4 since node3 waits for node4 to be healthy.
@@ -55,6 +59,38 @@ Ensure node3 started after node4
     ${n4} =    Convert To Integer    ${node4.stdout}
 
     Should Be True    ${n3} > ${n4}
+
+Ensure node4 executed on-exit commands for its create-links stage and this output contains all interfaces
+    ${match} =    Find Substring in Text
+    ...    ${deploylog.stderr}
+    ...    Executed command \\"ls /sys/class/net/\\" on the node \\"node4\\". stdout:\\neth0\\neth2\\neth3\\nlo\\n
+
+    Log    ${match}
+
+Ensure node4 executed on-exit commands for its heathy stage
+    ${match} =    Find Substring in Text
+    ...    ${deploylog.stderr}
+    ...    Executed command \\"echo hey I am existing healthy stage\\" on the node \\"node4\\". stdout:\\nhey I am existing healthy stage\\n
+
+    Log    ${match}
+
+Ensure node3 executed on-exit commands for its create stage and this output doesn't contain any non eth0/lo interfaces
+    ${match} =    Find Substring in Text
+    ...    ${deploylog.stderr}
+    ...    Executed command \\"ls /sys/class/net/\\" on the node \\"node3\\". stdout:\\neth0\\nlo\\n
+
+    Should Not Contain    ${match}    eth1
+
+    Log    ${match}
+
+Ensure node1 executed on-enter commands for its create-links stage and this output doesn't contain any non eth0/lo interfaces
+    ${match} =    Find Substring in Text
+    ...    ${deploylog.stderr}
+    ...    Executed command \\"ls /sys/class/net/\\" on the node \\"node1\\". stdout:\\neth0\\nlo\\n
+
+    Should Not Contain    ${match}    eth1
+
+    Log    ${match}
 
 Deploy ${lab-name} lab with a single worker
     Run Keyword    Teardown
@@ -104,3 +140,19 @@ Setup
     Log    ${output.stderr}
     # skipping this test suite for podman for now
     Skip If    '${runtime}' == 'podman'
+
+Find Substring in Text
+    [Documentation]    Find a substring in a text and return the match object. Errors if the match is empty (not found)
+    [Arguments]    ${text}    ${substring}
+
+    @{lines} =    String.Split To Lines    ${text}
+    Log    ${lines}
+
+    ${match} =    Collections.Get Matches
+    ...    ${lines}
+    ...    *${substring}*
+    Log    ${match}
+
+    Should Not Be Empty    ${match}
+
+    RETURN    ${match}

--- a/tests/01-smoke/stages.clab.yml
+++ b/tests/01-smoke/stages.clab.yml
@@ -32,6 +32,8 @@ topology:
           wait-for:
             - node: node4
               stage: healthy
+          exec:
+            - hostname
 
     node4:
       cmd: sh -c "date +%s%N > /tmp/time & sh"

--- a/tests/01-smoke/stages.clab.yml
+++ b/tests/01-smoke/stages.clab.yml
@@ -16,6 +16,10 @@ topology:
           wait-for:
             - node: node2
               stage: create
+        create-links:
+          exec:
+            on-enter:
+              - ls /sys/class/net/
 
     node2:
       cmd: sh -c "date +%s%N > /tmp/time & sh"
@@ -34,7 +38,7 @@ topology:
               stage: healthy
           exec:
             on-exit:
-              - hostname
+              - ls /sys/class/net/
 
     node4:
       cmd: sh -c "date +%s%N > /tmp/time & sh"
@@ -44,6 +48,15 @@ topology:
         test:
           - CMD-SHELL
           - cat /etc/os-release
+      stages:
+        create-links:
+          exec:
+            on-exit:
+              - ls /sys/class/net/
+        healthy:
+          exec:
+            on-exit:
+              - echo 'hey I am existing healthy stage'
 
   links:
     - endpoints: ["node1:eth1", "node2:eth1"]

--- a/tests/01-smoke/stages.clab.yml
+++ b/tests/01-smoke/stages.clab.yml
@@ -33,7 +33,8 @@ topology:
             - node: node4
               stage: healthy
           exec:
-            - hostname
+            on-exit:
+              - hostname
 
     node4:
       cmd: sh -c "date +%s%N > /tmp/time & sh"

--- a/types/stages.go
+++ b/types/stages.go
@@ -104,16 +104,16 @@ func (s *Stages) Merge(other *Stages) error {
 
 type ExecContainer struct {
 	// list of commands to run on the host
-	ExecCommandsHost []string `yaml:"exec,omitempty"`
+	ExecContainerCommands []string `yaml:"exec,omitempty"`
 }
 
 func (e *ExecContainer) Merge(other *ExecContainer) {
-	e.ExecCommandsHost = append(e.ExecCommandsHost, other.ExecCommandsHost...)
+	e.ExecContainerCommands = append(e.ExecContainerCommands, other.ExecContainerCommands...)
 }
 
 func (e *ExecContainer) GetExecs() ([]*exec.ExecCmd, error) {
 	ex := []*exec.ExecCmd{}
-	for _, c := range e.ExecCommandsHost {
+	for _, c := range e.ExecContainerCommands {
 		newCmd, err := exec.NewExecCmdFromString(c)
 		if err != nil {
 			return nil, err

--- a/types/stages.go
+++ b/types/stages.go
@@ -115,6 +115,9 @@ func (s *Stages) Merge(other *Stages) error {
 }
 
 // Execs represents configuration of commands to execute at a given stage.
+// Every stage has two commands lists: on-enter and on-exit.
+// On-enter commands are executed when the node enters the stage.
+// On-exit commands are executed when the node exits the stage.
 type Execs struct {
 	// Commands is a list of commands to to execute
 	CommandsOnEnter []string `yaml:"on-enter,omitempty"`
@@ -128,22 +131,26 @@ func (e *Execs) HasCommands() bool {
 type CommandType uint
 
 const (
+	// CommandTypeEnter represents a command to be executed when the node enters the stage.
 	CommandTypeEnter CommandType = iota
+	// CommandTypeExit represents a command to be executed when the node exits the stage.
 	CommandTypeExit
 )
 
 // GetExecCommands returns a list of exec commands to be executed.
 func (e *Execs) GetExecCommands(ct CommandType) ([]*exec.ExecCmd, error) {
-	var commandsStrSl []string
+	var commands []string
+
 	switch ct {
 	case CommandTypeEnter:
-		commandsStrSl = e.CommandsOnEnter
+		commands = e.CommandsOnEnter
 	case CommandTypeExit:
-		commandsStrSl = e.CommandsOnExit
+		commands = e.CommandsOnExit
 	}
 
 	ex := []*exec.ExecCmd{}
-	for _, c := range commandsStrSl {
+
+	for _, c := range commands {
 		newCmd, err := exec.NewExecCmdFromString(c)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR will allow to execute commands in the container when certain stages are reached.
Taking a look at the following topology.

- L2 will execute `ip l` on entry to the configure stage.
- L2 will execute `ip a` as the last step of its deployment (std. behaviour as it is implemented for ever)
- L3 will execute `ip a` as soon as it turns healthy
```
name: linux

topology:
  kinds:
    linux:
      image: alpine
      cmd: sleep infinity
  nodes:
    l1:
      kind: linux
    l2:
      kind: linux
      stages:
        configure:
          wait-for:
            - node: l1
              stage: create
          exec:
            - ip l
      exec:
        - ip a
    l3:
      kind: linux
      image: mavatest
      stages:
        create:
          wait-for:
            - node: l1
              stage: create-links
        healthy:
          exec:
            - ip a
    l4:
      kind: linux
      stages:
        create:
          wait-for:
            - node: l3
              stage: configure
  links:
    - endpoints: ["l1:eth1","host:l1eth"]
    - endpoints: ["l2:eth1","l1:l2"]
    - endpoints: ["l3:eth1","l4:l3"]
    - endpoints: ["l4:eth1","l2:l4"]
```