### PR TITLE
k8s-kind: Expose kind command line option via extras field

### DIFF
--- a/docs/manual/kinds/k8s-kind.md
+++ b/docs/manual/kinds/k8s-kind.md
@@ -100,6 +100,22 @@ With `k8s-kind`` nodes it is possible to use the following configuration paramet
 - [image](../nodes.md#image) - to define the kind container image to use for the kind cluster
 - [startup-config](../nodes.md#startup-config) - to provide a kind cluster configuration (optional, kind defaults apply otherwise)
 
+### Extra parameters
+
+In addition to the generic node parameters, `k8s-kind` can take following extra parameters from `extras` field.
+
+```
+topology:
+  nodes:
+    kind0:
+      kind: k8s_kind
+      extras:
+        k8s_kind:
+          deploy:
+            # Corresponds to --wait option. Wait given duration until the cluster becomes ready.
+            wait: 0s
+```
+
 ## Known issues
 
 ### Duplication of nodes in the output

--- a/types/types.go
+++ b/types/types.go
@@ -270,12 +270,26 @@ func (cd *ConfigDispatcher) GetVars() map[string]interface{} {
 
 // Extras contains extra node parameters which are not entitled to be part of a generic node config.
 type Extras struct {
-	SRLAgents []string `yaml:"srl-agents,omitempty"`
 	// Nokia SR Linux agents. As of now just the agents spec files can be provided here
-	MysocketProxy string `yaml:"mysocket-proxy,omitempty"`
+	SRLAgents []string `yaml:"srl-agents,omitempty"`
 	// Proxy address that mysocketctl will use
-	CeosCopyToFlash []string `yaml:"ceos-copy-to-flash,omitempty"`
+	MysocketProxy string `yaml:"mysocket-proxy,omitempty"`
 	// paths to files which are to be copied to ceos flash dir
+	CeosCopyToFlash []string `yaml:"ceos-copy-to-flash,omitempty"`
+	// k8s-kind node specific options
+	K8sKind *K8sKindExtras `yaml:"k8s_kind,omitempty"`
+}
+
+// K8sKindExtras represents the k8s-kind-specific extra options
+type K8sKindExtras struct {
+	Deploy *K8sKindDeployExtras `yaml:"deploy,omitempty"`
+}
+
+// KindDeployOptions represents the options used for the kind cluster creation.
+// It is aligned with the `kind create cluster` command options, but exposes
+// only the ones that are relevant for containerlab.
+type K8sKindDeployExtras struct {
+	Wait *string `yaml:"wait,omitempty"`
 }
 
 // ContainerDetails contains information that is commonly outputted to tables or graphs.


### PR DESCRIPTION
When the default CNI is disabled, the k8s nodes won't become ready forever until CNI is installed. However, the containerlab waits for the cluster readiness which will never succeeds. To solve this issue, don't wait for the cluster readiness and let deploy command finish, so that we can install the CNI after that.

We could conditionally wait for the cluster readiness by checking cluster configuration (e.g., wait only when disableDefaultCNI=false), but it can be a bit confusing from user's standpoint and if users wish to wait, they can always do it by themselves, for example with kubectl wait command.