### PR TITLE
veth creation: make first node create the veth endpoints

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -565,15 +565,6 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 					continue
 				}
 
-				// DeployLinks does not necessarily create all the links already.
-				// veth links might be created by the peer node, if it was not already
-				// deployed properly. Hence we need to wait for all the links to be created.
-				// we just wait if there is actually a dependency on this state, otherwise
-				// we head on.
-				if dn.MustWait(types.WaitForCreateLinks) {
-					node.WaitForAllEndpointsCreated()
-				}
-
 				dn.Done(types.WaitForCreateLinks)
 
 				// start config stage

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -559,7 +559,8 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 				dn.EnterStage(types.WaitForCreateLinks)
 
-				err = node.DeployLinks(ctx)
+				// Deploy the Nodes link endpoints
+				err = node.DeployEndpoints(ctx)
 				if err != nil {
 					log.Errorf("failed deploy links for node %q: %v", node.Config().ShortName, err)
 					continue

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -571,7 +571,7 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 				// we just wait if there is actually a dependency on this state, otherwise
 				// we head on.
 				if dn.MustWait(types.WaitForCreateLinks) {
-					node.WaitForAllLinksCreated()
+					node.WaitForAllEndpointsCreated()
 				}
 
 				dn.Done(types.WaitForCreateLinks)

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -589,12 +589,11 @@ func (c *CLab) scheduleNodes(ctx context.Context, maxWorkers int, skipPostDeploy
 
 				dn.Done(types.WaitForConfigure)
 
-				// HOTFIX: EXECS are for now being run after all nodes are deployed, see: deploy.go
-				// // run execs
-				// err = node.RunExecFromConfig(ctx, execCollection)
-				// if err != nil {
-				// 	log.Errorf("failed to run exec commands for %s: %v", node.GetShortName(), err)
-				// }
+				// run execs
+				err = node.RunExecFromConfig(ctx, execCollection)
+				if err != nil {
+					log.Errorf("failed to run exec commands for %s: %v", node.GetShortName(), err)
+				}
 
 				// health state processing
 				if dn.MustWait(types.WaitForHealthy) {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -221,10 +221,6 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if nodesWg != nil {
-		nodesWg.Wait()
-	}
-
 	// also call deploy on the special nodes endpoints
 	for _, n := range c.GetSpecialLinkNodes() {
 		for _, ep := range n.GetEndpoints() {
@@ -233,21 +229,11 @@ func deployFn(_ *cobra.Command, _ []string) error {
 				log.Warnf("failed deploying endpoint %s", ep)
 			}
 		}
-
 	}
 
-	// HOTFIX: originally execs were executed by the node, but because
-	// execs were run before all the links are connected between the nodes they could fail.
-	// we couldn't wait for all links to be created/connected since this would cause a deadlock
-	// either when a nodeA depends on nodeB and there is a link between them, or when
-	// there is more links than concurrent node worker.
-	// For the time being the execs would be executed only after the nodes are created
-	// with a more elegant fix in the works.
-	for _, n := range c.Nodes {
-		err = n.RunExecFromConfig(ctx, execCollection)
-		if err != nil {
-			return err
-		}
+	// wait for all the containers to get created
+	if nodesWg != nil {
+		nodesWg.Wait()
 	}
 
 	// write to log

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -221,13 +221,13 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// also call deploy on the special nodes endpoints
-	for _, n := range c.GetSpecialLinkNodes() {
-		for _, ep := range n.GetEndpoints() {
-			err = ep.Deploy(ctx)
-			if err != nil {
-				log.Warnf("failed deploying endpoint %s", ep)
-			}
+	// also call deploy on the special nodes endpoints (only host is required for the
+	// vxlan stitched endpoints)
+	eps := c.GetSpecialLinkNodes()["host"].GetEndpoints()
+	for _, ep := range eps {
+		err = ep.Deploy(ctx)
+		if err != nil {
+			log.Warnf("failed deploying endpoint %s", ep)
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -225,6 +225,17 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		nodesWg.Wait()
 	}
 
+	// also call deploy on the special nodes endpoints
+	for _, n := range c.GetSpecialLinkNodes() {
+		for _, ep := range n.GetEndpoints() {
+			err = ep.Deploy(ctx)
+			if err != nil {
+				log.Warnf("failed deploying endpoint %s", ep)
+			}
+		}
+
+	}
+
 	// HOTFIX: originally execs were executed by the node, but because
 	// execs were run before all the links are connected between the nodes they could fail.
 	// we couldn't wait for all links to be created/connected since this would cause a deadlock

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -111,9 +111,9 @@ var vethCreateCmd = &cobra.Command{
 			return err
 		}
 
-		err = link.Deploy(ctx)
-		if err != nil {
-			return err
+		// deploy the endpoints of the Link
+		for _, ep := range link.GetEndpoints() {
+			ep.Deploy(ctx)
 		}
 
 		log.Info("veth interface successfully created!")

--- a/cmd/vxlan.go
+++ b/cmd/vxlan.go
@@ -108,10 +108,10 @@ var vxlanCreateCmd = &cobra.Command{
 			return fmt.Errorf("not a VxlanStitched link")
 		}
 
-		err = vxl.DeployWithExistingVeth(ctx)
-		if err != nil {
-			return err
+		for _, ep := range vxl.GetEndpoints() {
+			ep.Deploy(ctx)
 		}
+
 		return nil
 	},
 }

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -152,12 +152,6 @@ topology:
               stage: healthy
 ```
 
-/// admonition | Warning!
-    type: warning
-When using VM-based nodes and creating the dependencies for the heatlhy stage, it is important to ensure that no links exist between the nodes that depend on each other. This is because the VM-based node do not support link hot plugging and wait till all the links are attached to the container before starting the boot process.  
-Pay attention, as it may lead to a deadlock situation where the nodes are waiting for each other to boot.
-///
-
 ### Boot delay
 
 A predecessor of the Boot Order is the boot delay that can be set with `BOOT_DELAY` environment variable that the supported VM-based nodes will respect.

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -36,10 +36,11 @@ type Endpoint interface {
 	// and passing the endpoint as an argument so that the link that consists of A and B endpoints
 	// can deploy them independently.
 	Deploy(context.Context) error
-	// AutoDeployWithAEnd indicates if this endpoint is to be deployed
-	// along with the peer Endpoint. This should be true for e.g. host endpoints
-	// because there is no host node that would bring the interface and rename it.
-	AutoDeployWithAEnd() bool
+	// IsNodeless returns true for the endpoints that has no explicit node defined in the topology.
+	// E.g. host endpoints, mgmt bridge endpoints.
+	// Because there is no node that would deploy this side of the link they should be deployed along
+	// with the A side of the veth link.
+	IsNodeless() bool
 }
 
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -31,6 +32,7 @@ type Endpoint interface {
 	// has the same node and interface name as the given endpoint.
 	HasSameNodeAndInterface(ept Endpoint) bool
 	Remove() error
+	Deploy(context.Context) error
 }
 
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -32,6 +32,9 @@ type Endpoint interface {
 	// has the same node and interface name as the given endpoint.
 	HasSameNodeAndInterface(ept Endpoint) bool
 	Remove() error
+	// Deploy deploys the endpoint by calling the Deploy method of the link it is assigned to
+	// and passing the endpoint as an argument so that the link that consists of A and B endpoints
+	// can deploy them independently.
 	Deploy(context.Context) error
 	// AutoDeployWithAEnd indicates if this endpoint is to be deployed
 	// along with the peer Endpoint. This should be true for e.g. host endpoints

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -33,6 +33,10 @@ type Endpoint interface {
 	HasSameNodeAndInterface(ept Endpoint) bool
 	Remove() error
 	Deploy(context.Context) error
+	// AutoDeployWithAEnd indicates if this endpoint is to be deployed
+	// along with the peer Endpoint. This should be true for e.g. host endpoints
+	// because there is no host node that would bring the interface and rename it.
+	AutoDeployWithAEnd() bool
 }
 
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -48,9 +48,9 @@ func (e *EndpointBridge) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
 
-func (e *EndpointBridge) AutoDeployWithAEnd() bool {
-	// the mgmt bridge needs AutoDeployment. Otherwise the regular bridge node
-	// should trigger BEnd deployment seperately
+func (e *EndpointBridge) IsNodeless() bool {
+	// the mgmt bridge is nodeless.
+	// If this is a regular bridge, then it should trigger BEnd deployment.
 	return e.isMgmtBridgeEndpoint
 }
 

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -12,11 +12,13 @@ import (
 
 type EndpointBridge struct {
 	EndpointGeneric
+	isMgmtBridgeEndpoint bool
 }
 
-func NewEndpointBridge(eg *EndpointGeneric) *EndpointBridge {
+func NewEndpointBridge(eg *EndpointGeneric, isMgmtBridgeEndpoint bool) *EndpointBridge {
 	return &EndpointBridge{
-		EndpointGeneric: *eg,
+		isMgmtBridgeEndpoint: isMgmtBridgeEndpoint,
+		EndpointGeneric:      *eg,
 	}
 }
 
@@ -44,6 +46,12 @@ func (e *EndpointBridge) Verify(p *VerifyLinkParams) error {
 
 func (e *EndpointBridge) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
+}
+
+func (e *EndpointBridge) AutoDeployWithAEnd() bool {
+	// the mgmt bridge needs AutoDeployment. Otherwise the regular bridge node
+	// should trigger BEnd deployment seperately
+	return e.isMgmtBridgeEndpoint
 }
 
 // CheckBridgeExists verifies that the given bridge is present in the

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -39,6 +40,10 @@ func (e *EndpointBridge) Verify(p *VerifyLinkParams) error {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+func (e *EndpointBridge) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
 }
 
 // CheckBridgeExists verifies that the given bridge is present in the

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -1,6 +1,9 @@
 package links
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 type EndpointHost struct {
 	EndpointGeneric
@@ -10,6 +13,10 @@ func NewEndpointHost(eg *EndpointGeneric) *EndpointHost {
 	return &EndpointHost{
 		EndpointGeneric: *eg,
 	}
+}
+
+func (e *EndpointHost) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
 }
 
 func (e *EndpointHost) Verify(_ *VerifyLinkParams) error {

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -35,6 +35,6 @@ func (e *EndpointHost) Verify(_ *VerifyLinkParams) error {
 	return nil
 }
 
-func (e *EndpointHost) AutoDeployWithAEnd() bool {
+func (e *EndpointHost) IsNodeless() bool {
 	return true
 }

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -34,3 +34,7 @@ func (e *EndpointHost) Verify(_ *VerifyLinkParams) error {
 	}
 	return nil
 }
+
+func (e *EndpointHost) AutoDeployWithAEnd() bool {
+	return true
+}

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -20,3 +20,7 @@ func (e *EndpointMacVlan) Deploy(ctx context.Context) error {
 func (e *EndpointMacVlan) Verify(_ *VerifyLinkParams) error {
 	return CheckEndpointExists(e)
 }
+
+func (e *EndpointMacVlan) AutoDeployWithAEnd() bool {
+	return false
+}

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -1,5 +1,7 @@
 package links
 
+import "context"
+
 type EndpointMacVlan struct {
 	EndpointGeneric
 }
@@ -8,6 +10,10 @@ func NewEndpointMacVlan(eg *EndpointGeneric) *EndpointMacVlan {
 	return &EndpointMacVlan{
 		EndpointGeneric: *eg,
 	}
+}
+
+func (e *EndpointMacVlan) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
 }
 
 // Verify runs verification to check if the endpoint can be deployed.

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -21,6 +21,6 @@ func (e *EndpointMacVlan) Verify(_ *VerifyLinkParams) error {
 	return CheckEndpointExists(e)
 }
 
-func (e *EndpointMacVlan) AutoDeployWithAEnd() bool {
+func (e *EndpointMacVlan) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_raw.go
+++ b/links/endpoint_raw.go
@@ -58,7 +58,7 @@ func (er *EndpointRaw) Resolve(params *ResolveParams, l Link) (Endpoint, error) 
 
 	switch node.GetLinkEndpointType() {
 	case LinkEndpointTypeBridge:
-		e = NewEndpointBridge(genericEndpoint)
+		e = NewEndpointBridge(genericEndpoint, false)
 
 	case LinkEndpointTypeHost:
 		e = NewEndpointHost(genericEndpoint)

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -20,3 +20,7 @@ func (e *EndpointVeth) Verify(_ *VerifyLinkParams) error {
 func (e *EndpointVeth) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
+
+func (e *EndpointVeth) AutoDeployWithAEnd() bool {
+	return false
+}

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -1,5 +1,7 @@
 package links
 
+import "context"
+
 type EndpointVeth struct {
 	EndpointGeneric
 }
@@ -13,4 +15,8 @@ func NewEndpointVeth(eg *EndpointGeneric) *EndpointVeth {
 // Verify verifies the veth based deployment pre-conditions.
 func (e *EndpointVeth) Verify(_ *VerifyLinkParams) error {
 	return CheckEndpointUniqueness(e)
+}
+
+func (e *EndpointVeth) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
 }

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -21,6 +21,6 @@ func (e *EndpointVeth) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
 
-func (e *EndpointVeth) AutoDeployWithAEnd() bool {
+func (e *EndpointVeth) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -38,6 +38,6 @@ func (e *EndpointVxlan) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
 
-func (e *EndpointVxlan) AutoDeployWithAEnd() bool {
+func (e *EndpointVxlan) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -37,3 +37,7 @@ func (e *EndpointVxlan) Verify(*VerifyLinkParams) error {
 func (e *EndpointVxlan) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
+
+func (e *EndpointVxlan) AutoDeployWithAEnd() bool {
+	return false
+}

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"context"
 	"fmt"
 	"net"
 )
@@ -31,4 +32,8 @@ func (e *EndpointVxlan) String() string {
 // Verify verifies that the endpoint is valid and can be deployed.
 func (e *EndpointVxlan) Verify(*VerifyLinkParams) error {
 	return CheckEndpointUniqueness(e)
+}
+
+func (e *EndpointVxlan) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
 }

--- a/links/generic_link_node.go
+++ b/links/generic_link_node.go
@@ -10,7 +10,6 @@ import (
 
 type GenericLinkNode struct {
 	shortname string
-	links     []Link
 	endpoints []Endpoint
 	nspath    string
 }
@@ -39,10 +38,6 @@ func (g *GenericLinkNode) ExecFunction(f func(ns.NetNS) error) error {
 	return netns.Do(f)
 }
 
-func (g *GenericLinkNode) AddLink(l Link) {
-	g.links = append(g.links, l)
-}
-
 func (g *GenericLinkNode) AddEndpoint(e Endpoint) {
 	g.endpoints = append(g.endpoints, e)
 }
@@ -62,8 +57,8 @@ func (*GenericLinkNode) GetState() state.NodeState {
 }
 
 func (g *GenericLinkNode) Delete(ctx context.Context) error {
-	for _, l := range g.links {
-		err := l.Remove(ctx)
+	for _, e := range g.endpoints {
+		err := e.GetLink().Remove(ctx)
 		if err != nil {
 			return err
 		}

--- a/links/link.go
+++ b/links/link.go
@@ -20,7 +20,8 @@ const (
 	DefaultLinkMTU = 9500
 
 	LinkDeploymentStateNotDeployed = iota
-	LinkDeploymentStateDeployed
+	LinkDeploymentStateHalfDeployed
+	LinkDeploymentStateFullDeployed
 	LinkDeploymentStateRemoved
 )
 

--- a/links/link.go
+++ b/links/link.go
@@ -295,8 +295,8 @@ type RawLink interface {
 // Link is an interface that all concrete link types must implement.
 // Concrete link types are resolved from raw links and become part of CLab.Links.
 type Link interface {
-	// Deploy deploys the link.
-	Deploy(context.Context) error
+	// Deploy deploys the link. Endpoint is the endpoint that triggers the creation of the link.
+	Deploy(context.Context, Endpoint) error
 	// Remove removes the link.
 	Remove(context.Context) error
 	// GetType returns the type of the link.
@@ -353,7 +353,6 @@ type Node interface {
 	// In case of a bridge node (ovs or regular linux bridge) it will take the interface and make the bridge
 	// the master of the interface and bring the interface up.
 	AddLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error
-	AddLink(l Link)
 	// AddEndpoint adds the Endpoint to the node
 	AddEndpoint(e Endpoint)
 	GetLinkEndpointType() LinkEndpointType

--- a/links/link.go
+++ b/links/link.go
@@ -20,6 +20,8 @@ const (
 	DefaultLinkMTU = 9500
 
 	LinkDeploymentStateNotDeployed = iota
+	// LinkDeploymentStateHalfDeployed is a state in which one of the endpoints
+	// of the links finished deploying and the other one is not yet deployed.
 	LinkDeploymentStateHalfDeployed
 	LinkDeploymentStateFullDeployed
 	LinkDeploymentStateRemoved

--- a/links/link_host.go
+++ b/links/link_host.go
@@ -79,9 +79,7 @@ func (r *LinkHostRaw) Resolve(params *ResolveParams) (Link, error) {
 	link.Endpoints = []Endpoint{ep, hostEp}
 
 	// add the link to the endpoints node
-	hostEp.GetNode().AddLink(link)
 	hostEp.GetNode().AddEndpoint(hostEp)
-	ep.GetNode().AddLink(link)
 
 	// set default link mtu if MTU is unset
 	if link.MTU == 0 {

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -125,7 +125,7 @@ func (l *LinkMacVlan) GetParentInterfaceMTU() (int, error) {
 	return hostLink.Attrs().MTU, nil
 }
 
-func (l *LinkMacVlan) Deploy(ctx context.Context, ep Endpoint) error {
+func (l *LinkMacVlan) Deploy(ctx context.Context, _ Endpoint) error {
 	// lookup the parent host interface
 	parentInterface, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
 	if err != nil {

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -103,9 +103,6 @@ func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
 		return nil, err
 	}
 
-	// add endpoint links to nodes
-	link.NodeEndpoint.GetNode().AddLink(link)
-
 	return link, nil
 }
 
@@ -128,7 +125,7 @@ func (l *LinkMacVlan) GetParentInterfaceMTU() (int, error) {
 	return hostLink.Attrs().MTU, nil
 }
 
-func (l *LinkMacVlan) Deploy(ctx context.Context) error {
+func (l *LinkMacVlan) Deploy(ctx context.Context, ep Endpoint) error {
 	// lookup the parent host interface
 	parentInterface, err := utils.LinkByNameOrAlias(l.HostEndpoint.GetIfaceName())
 	if err != nil {

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -66,9 +66,7 @@ func (r *LinkMgmtNetRaw) Resolve(params *ResolveParams) (Link, error) {
 	link.Endpoints = []Endpoint{bridgeEp, contEp}
 
 	// add link to respective endpoint nodes
-	bridgeEp.GetNode().AddLink(link)
 	bridgeEp.GetNode().AddEndpoint(bridgeEp)
-	contEp.GetNode().AddLink(link)
 
 	// set default link mtu if MTU is unset
 	if link.MTU == 0 {

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -47,9 +47,7 @@ func (r *LinkMgmtNetRaw) Resolve(params *ResolveParams) (Link, error) {
 
 	mgmtBridgeNode := GetMgmtBrLinkNode()
 
-	bridgeEp := &EndpointBridge{
-		EndpointGeneric: *NewEndpointGeneric(mgmtBridgeNode, r.HostInterface, link),
-	}
+	bridgeEp := NewEndpointBridge(NewEndpointGeneric(mgmtBridgeNode, r.HostInterface, link), true)
 
 	var err error
 	bridgeEp.MAC, err = utils.GenMac(ClabOUI)

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -110,7 +110,7 @@ func (*mgmtBridgeLinkNode) GetLinkEndpointType() LinkEndpointType {
 	return LinkEndpointTypeBridge
 }
 
-func (b *mgmtBridgeLinkNode) AddLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error {
+func (b *mgmtBridgeLinkNode) AddLinkToContainer(_ context.Context, link netlink.Link, f func(ns.NetNS) error) error {
 	// retrieve the namespace handle
 	ns, err := ns.GetCurrentNS()
 	if err != nil {

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -232,7 +232,7 @@ func (l *LinkVEth) Deploy(ctx context.Context, ep Endpoint) error {
 	// The first node to trigger the link creation will call deployAEnd,
 	// subsequent (the second) call will end up in deployBEnd.
 	switch l.DeploymentState {
-	case LinkDeploymentStateFullDeployed:
+	case LinkDeploymentStateHalfDeployed:
 		return l.deployBEnd(ctx, idx)
 	default:
 		return l.deployAEnd(ctx, idx)

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -153,9 +153,9 @@ func (l *LinkVEth) deployAEnd(ctx context.Context, idx int) error {
 
 	l.DeploymentState = LinkDeploymentStateHalfDeployed
 
-	// e.g. host endpoints have no trigger for the BEnd Endpoint. Hence they will indicate via
-	// the AutoDeployWithAEnd func, if the BEnd ist to automatically be provisioned on AEnd Provisioning
-	if peerEp.AutoDeployWithAEnd() {
+	// e.g. host endpoints are nodeless, and therefore the B end of the veth link should
+	// be deployed right after the A end is deployed.
+	if peerEp.IsNodeless() {
 		return l.deployBEnd(ctx, peerIdx)
 	}
 

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -156,6 +156,12 @@ func (l *LinkVEth) deployAEnd(ctx context.Context, ep Endpoint) error {
 		return err
 	}
 
+	// e.g. host endpoints have no trigger for the BEnd Endpoint. Hence they will indicate via
+	// the AutoDeployWithAEnd func, if the BEnd ist to automatically be provisioned on AEnd Provisioning
+	if peerEp.AutoDeployWithAEnd() {
+		return l.deployBEnd(ctx, peerEp)
+	}
+
 	return nil
 }
 

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -109,11 +109,27 @@ func (*LinkVEth) GetType() LinkType {
 	return LinkTypeVEth
 }
 
+func (l *LinkVEth) deployAEnd(ctx context.Context) error {
+	return nil
+}
+
+func (l *LinkVEth) deployBEnd(ctx context.Context) error {
+	return nil
+}
+
 func (l *LinkVEth) Deploy(ctx context.Context) error {
 	// since each node calls deploy on its links, we need to make sure that we only deploy
 	// the link once, even if multiple nodes call deploy on the same link.
 	l.deployMutex.Lock()
 	defer l.deployMutex.Unlock()
+
+	switch l.DeploymentState {
+	case LinkDeploymentStateNotDeployed:
+		return l.deployAEnd(ctx)
+	case LinkDeploymentStateDeployed:
+		return l.deployBEnd(ctx)
+	}
+
 	if l.DeploymentState == LinkDeploymentStateDeployed {
 		return nil
 	}

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -205,7 +205,7 @@ type LinkVxlan struct {
 	remoteEndpoint *EndpointVxlan
 }
 
-func (l *LinkVxlan) Deploy(ctx context.Context, ep Endpoint) error {
+func (l *LinkVxlan) Deploy(ctx context.Context, _ Endpoint) error {
 	err := l.deployVxlanInterface()
 	if err != nil {
 		return err

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -73,7 +73,7 @@ func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(params *ResolveParams) (*Li
 
 	vethLink := hl.(*LinkVEth)
 
-	// host endpoint is always a 2nd element in the Endpoints slice
+	// host endpoint is always the 2nd element in the Endpoints slice
 	return vethLink, vethLink.Endpoints[1], nil
 }
 

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -94,9 +94,6 @@ func (lr *LinkVxlanRaw) resolveStitchedVxlan(params *ResolveParams) (Link, error
 	// return the stitched vxlan link
 	stitchedLink := NewVxlanStitched(vxlanLink, vethLink, stitchEp)
 
-	// add stitched link to node
-	params.Nodes[lr.Endpoint.Node].AddLink(stitchedLink)
-
 	return stitchedLink, nil
 }
 
@@ -172,9 +169,6 @@ func (lr *LinkVxlanRaw) resolveVxlan(params *ResolveParams, stitched bool) (*Lin
 		link.remoteEndpoint.MAC = hwaddr
 	}
 
-	// add link to local endpoints node
-	link.localEndpoint.GetNode().AddLink(link)
-
 	return link, nil
 }
 
@@ -211,7 +205,7 @@ type LinkVxlan struct {
 	remoteEndpoint *EndpointVxlan
 }
 
-func (l *LinkVxlan) Deploy(ctx context.Context) error {
+func (l *LinkVxlan) Deploy(ctx context.Context, ep Endpoint) error {
 	err := l.deployVxlanInterface()
 	if err != nil {
 		return err

--- a/links/link_vxlan_stitched.go
+++ b/links/link_vxlan_stitched.go
@@ -37,25 +37,25 @@ func NewVxlanStitched(vxlan *LinkVxlan, veth *LinkVEth, vethStitchEp Endpoint) *
 // DeployWithExistingVeth provisons the stitched vxlan link whilst the
 // veth interface does already exist, hence it is not created as part of this
 // deployment.
-func (l *VxlanStitched) DeployWithExistingVeth(ctx context.Context) error {
-	return l.internalDeploy(ctx, true)
+func (l *VxlanStitched) DeployWithExistingVeth(ctx context.Context, ep Endpoint) error {
+	return l.internalDeploy(ctx, ep, true)
 }
 
 // Deploy provisions the stitched vxlan link with all its underlaying sub-links.
-func (l *VxlanStitched) Deploy(ctx context.Context) error {
-	return l.internalDeploy(ctx, false)
+func (l *VxlanStitched) Deploy(ctx context.Context, ep Endpoint) error {
+	return l.internalDeploy(ctx, ep, false)
 }
 
-func (l *VxlanStitched) internalDeploy(ctx context.Context, skipVethCreation bool) error {
+func (l *VxlanStitched) internalDeploy(ctx context.Context, ep Endpoint, skipVethCreation bool) error {
 	// deploy the vxlan link
-	err := l.vxlanLink.Deploy(ctx)
+	err := l.vxlanLink.Deploy(ctx, ep)
 	if err != nil {
 		return err
 	}
 
 	// the veth creation might be skipped if it already exists
 	if !skipVethCreation {
-		err = l.vethLink.Deploy(ctx)
+		err = l.vethLink.Deploy(ctx, ep)
 		if err != nil {
 			return err
 		}

--- a/mocks/dependency_manager.go
+++ b/mocks/dependency_manager.go
@@ -95,21 +95,6 @@ func (mr *MockDependencyManagerMockRecorder) GetNode(name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockDependencyManager)(nil).GetNode), name)
 }
 
-// MustWait mocks base method.
-func (m *MockDependencyManager) MustWait(nodeName string, stage types.WaitForStage) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MustWait", nodeName, stage)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MustWait indicates an expected call of MustWait.
-func (mr *MockDependencyManagerMockRecorder) MustWait(nodeName, stage any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustWait", reflect.TypeOf((*MockDependencyManager)(nil).MustWait), nodeName, stage)
-}
-
 // String mocks base method.
 func (m *MockDependencyManager) String() string {
 	m.ctrl.T.Helper()

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -471,18 +471,6 @@ func (mr *MockNodeMockRecorder) VerifyStartupConfig(topoDir any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyStartupConfig", reflect.TypeOf((*MockNode)(nil).VerifyStartupConfig), topoDir)
 }
 
-// WaitForAllEndpointsCreated mocks base method.
-func (m *MockNode) WaitForAllEndpointsCreated() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WaitForAllEndpointsCreated")
-}
-
-// WaitForAllEndpointsCreated indicates an expected call of WaitForAllEndpointsCreated.
-func (mr *MockNodeMockRecorder) WaitForAllEndpointsCreated() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAllEndpointsCreated", reflect.TypeOf((*MockNode)(nil).WaitForAllEndpointsCreated))
-}
-
 // WithMgmtNet mocks base method.
 func (m *MockNode) WithMgmtNet(arg0 *types.MgmtNet) {
 	m.ctrl.T.Helper()

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -59,18 +59,6 @@ func (mr *MockNodeMockRecorder) AddEndpoint(e any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockNode)(nil).AddEndpoint), e)
 }
 
-// AddLink mocks base method.
-func (m *MockNode) AddLink(l links.Link) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddLink", l)
-}
-
-// AddLink indicates an expected call of AddLink.
-func (mr *MockNodeMockRecorder) AddLink(l any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLink", reflect.TypeOf((*MockNode)(nil).AddLink), l)
-}
-
 // AddLinkToContainer mocks base method.
 func (m *MockNode) AddLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error {
 	m.ctrl.T.Helper()
@@ -483,16 +471,16 @@ func (mr *MockNodeMockRecorder) VerifyStartupConfig(topoDir any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyStartupConfig", reflect.TypeOf((*MockNode)(nil).VerifyStartupConfig), topoDir)
 }
 
-// WaitForAllLinksCreated mocks base method.
-func (m *MockNode) WaitForAllLinksCreated() {
+// WaitForAllEndpointsCreated mocks base method.
+func (m *MockNode) WaitForAllEndpointsCreated() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WaitForAllLinksCreated")
+	m.ctrl.Call(m, "WaitForAllEndpointsCreated")
 }
 
-// WaitForAllLinksCreated indicates an expected call of WaitForAllLinksCreated.
-func (mr *MockNodeMockRecorder) WaitForAllLinksCreated() *gomock.Call {
+// WaitForAllEndpointsCreated indicates an expected call of WaitForAllEndpointsCreated.
+func (mr *MockNodeMockRecorder) WaitForAllEndpointsCreated() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAllLinksCreated", reflect.TypeOf((*MockNode)(nil).WaitForAllLinksCreated))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAllEndpointsCreated", reflect.TypeOf((*MockNode)(nil).WaitForAllEndpointsCreated))
 }
 
 // WithMgmtNet mocks base method.

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -157,18 +157,18 @@ func (mr *MockNodeMockRecorder) Deploy(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockNode)(nil).Deploy), arg0, arg1)
 }
 
-// DeployLinks mocks base method.
-func (m *MockNode) DeployLinks(ctx context.Context) error {
+// DeployEndpoints mocks base method.
+func (m *MockNode) DeployEndpoints(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployLinks", ctx)
+	ret := m.ctrl.Call(m, "DeployEndpoints", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeployLinks indicates an expected call of DeployLinks.
-func (mr *MockNodeMockRecorder) DeployLinks(ctx any) *gomock.Call {
+// DeployEndpoints indicates an expected call of DeployEndpoints.
+func (mr *MockNodeMockRecorder) DeployEndpoints(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLinks", reflect.TypeOf((*MockNode)(nil).DeployLinks), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployEndpoints", reflect.TypeOf((*MockNode)(nil).DeployEndpoints), ctx)
 }
 
 // ExecFunction mocks base method.

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -515,8 +515,8 @@ func (d *DefaultNode) GetShortName() string {
 	return d.Cfg.ShortName
 }
 
-// DeployLinks deploys links associated with the node.
-func (d *DefaultNode) DeployLinks(ctx context.Context) error {
+// DeployEndpoints deploys links associated with the node.
+func (d *DefaultNode) DeployEndpoints(ctx context.Context) error {
 	for _, ep := range d.Endpoints {
 		err := ep.Deploy(ctx)
 		if err != nil {

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -515,7 +515,8 @@ func (d *DefaultNode) GetShortName() string {
 	return d.Cfg.ShortName
 }
 
-// DeployEndpoints deploys links associated with the node.
+// DeployEndpoints deploys endpoints associated with the node.
+// The deployment of endpoints is done by deploying a link with the endpoint triggering it.
 func (d *DefaultNode) DeployEndpoints(ctx context.Context) error {
 	for _, ep := range d.Endpoints {
 		err := ep.Deploy(ctx)

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -42,15 +42,13 @@ type DefaultNode struct {
 	// OverwriteNode stores the interface used to overwrite methods defined
 	// for DefaultNode, so that particular nodes can provide custom implementations.
 	OverwriteNode NodeOverwrites
-	// List of links that reference the node.
-	Links []links.Link
 	// List of link endpoints that are connected to the node.
 	Endpoints []links.Endpoint
 	// State of the node
 	state      state.NodeState
 	statemutex sync.RWMutex
 	// links created wg
-	linksCreated *sync.WaitGroup
+	endpointsCreate *sync.WaitGroup
 }
 
 // NewDefaultNode initializes the DefaultNode structure and receives a NodeOverwrites interface
@@ -62,7 +60,7 @@ func NewDefaultNode(n NodeOverwrites) *DefaultNode {
 		OverwriteNode:    n,
 		LicensePolicy:    types.LicensePolicyNone,
 		SSHConfig:        types.NewSSHConfig(),
-		linksCreated:     &sync.WaitGroup{},
+		endpointsCreate:  &sync.WaitGroup{},
 	}
 
 	return dn
@@ -74,8 +72,8 @@ func (d *DefaultNode) GetRuntime() runtime.ContainerRuntime                  { r
 func (d *DefaultNode) Config() *types.NodeConfig                             { return d.Cfg }
 func (*DefaultNode) PostDeploy(_ context.Context, _ *PostDeployParams) error { return nil }
 
-func (d *DefaultNode) WaitForAllLinksCreated() {
-	d.linksCreated.Wait()
+func (d *DefaultNode) WaitForAllEndpointsCreated() {
+	d.endpointsCreate.Wait()
 }
 
 // PreDeploy is a common method for all nodes that is called before the node is deployed.
@@ -153,8 +151,8 @@ func (d *DefaultNode) Deploy(ctx context.Context, _ *DeployParams) error {
 }
 
 func (d *DefaultNode) Delete(ctx context.Context) error {
-	for _, l := range d.Links {
-		err := l.Remove(ctx)
+	for _, e := range d.Endpoints {
+		err := e.GetLink().Remove(ctx)
 		if err != nil {
 			return err
 		}
@@ -479,7 +477,7 @@ func (d *DefaultNode) AddLinkToContainer(_ context.Context, link netlink.Link, f
 		return err
 	}
 	// indicate this link is created
-	d.linksCreated.Done()
+	d.endpointsCreate.Done()
 	return nil
 }
 
@@ -508,13 +506,9 @@ func (d *DefaultNode) ExecFunction(f func(ns.NetNS) error) error {
 	return netns.Do(f)
 }
 
-func (d *DefaultNode) AddLink(l links.Link) {
-	d.Links = append(d.Links, l)
-	d.linksCreated.Add(1)
-}
-
 func (d *DefaultNode) AddEndpoint(e links.Endpoint) {
 	d.Endpoints = append(d.Endpoints, e)
+	d.endpointsCreate.Add(1)
 }
 
 func (d *DefaultNode) GetEndpoints() []links.Endpoint {
@@ -533,13 +527,12 @@ func (d *DefaultNode) GetShortName() string {
 
 // DeployLinks deploys links associated with the node.
 func (d *DefaultNode) DeployLinks(ctx context.Context) error {
-	for _, l := range d.Links {
-		err := l.Deploy(ctx)
+	for _, ep := range d.Endpoints {
+		err := ep.Deploy(ctx)
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -96,7 +96,6 @@ type Node interface {
 	// Adds the given link to the Node (container). After adding the Link to the node,
 	// the given function f is called within the Nodes namespace to setup the link.
 	AddLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error
-	AddLink(l links.Link)
 	AddEndpoint(e links.Endpoint)
 	GetEndpoints() []links.Endpoint
 	GetLinkEndpointType() links.LinkEndpointType
@@ -108,8 +107,8 @@ type Node interface {
 	GetState() state.NodeState
 	SetState(state.NodeState)
 	GetSSHConfig() *types.SSHConfig
-	// WaitForAllLinksCreated will block until all the nodes links are created
-	WaitForAllLinksCreated()
+	// WaitForAllEndpointsCreated will block until all the nodes links are created
+	WaitForAllEndpointsCreated()
 	// RunExecFromConfig executes the topologyfile defined exec commands
 	RunExecFromConfig(context.Context, *exec.ExecCollection) error
 	IsHealthy(ctx context.Context) (bool, error)

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -107,8 +107,6 @@ type Node interface {
 	GetState() state.NodeState
 	SetState(state.NodeState)
 	GetSSHConfig() *types.SSHConfig
-	// WaitForAllEndpointsCreated will block until all the nodes links are created
-	WaitForAllEndpointsCreated()
 	// RunExecFromConfig executes the topologyfile defined exec commands
 	RunExecFromConfig(context.Context, *exec.ExecCollection) error
 	IsHealthy(ctx context.Context) (bool, error)

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -100,8 +100,8 @@ type Node interface {
 	GetEndpoints() []links.Endpoint
 	GetLinkEndpointType() links.LinkEndpointType
 	GetShortName() string
-	// DeployLinks deploys the links for the node.
-	DeployLinks(ctx context.Context) error
+	// DeployEndpoints deploys the links for the node.
+	DeployEndpoints(ctx context.Context) error
 	// ExecFunction executes the given function within the nodes network namespace
 	ExecFunction(func(ns.NetNS) error) error
 	GetState() state.NodeState

--- a/tests/08-vxlan/02-vxlan-stitch.robot
+++ b/tests/08-vxlan/02-vxlan-stitch.robot
@@ -29,7 +29,7 @@ Check VxLAN interface parameters on the host for srl1 node
 
     Should Contain        ${output}    mtu 9050
 
-    Should Contain        ${output}    vxlan id 100 remote 172.20.25.22 dev clab-vxlan-br srcport 0 0 dstport 14788
+    Should Contain        ${output}    vxlan id 100 remote 172.20.25.22 dev ${vxlan-br} srcport 0 0 dstport 14788
     
     Should Not Contain    ${output}    nolearning
 


### PR DESCRIPTION
This is the PR to tackle the link creation issues described in #1907.

This PR now changes the link creation strategy. For the veth, where there are two endpoints located in two network namespaces. The link is created by the first node that reaches the create-links phases. It creates the link with its two endpoints in the host namespace with randomized interface names. One endpoint (netlink.link) is then transferred to the netns of the container, renamed to the designated name, and set admin up.
The other endpoint remains in the root/host netns (wiht its random clab-<randid> name) until the second node reaches the create-links phase. The second node, instead of creating the whole veth link, only pulls in the existing endpoint, renames it and sets it admin up.

This way, the defined interfaces will exist, as soon as the create-links phase is reached. However, it is not guarantied that the link is already operational. But anyways will this help to perform `ip link` and `ip address` commands and further also prevents deadlocks in case of vrnetlab nodes, where the nodes would only boot the VMs when all the interfaces are available to the network namespace.

Further did I remove the reference from nodes to links. Nodes do own endpoints that belong to links. Hence to access Link attributes, the endpoint should be consulted. This prevents us from drifting state, if an endpoint is added but the link is missed or the other way around.