### PR TITLE
Collect partial configs (partial config and ssh keys) before appying

### DIFF
--- a/nodes/vr_sros/sshKey.go
+++ b/nodes/vr_sros/sshKey.go
@@ -19,9 +19,9 @@ import (
 //go:embed ssh_keys.go.tpl
 var SROSSSHKeysTemplate string
 
-// generateSSHPublicKeysConfig configures public keys extracted from clab host
-// on SR OS node using SSH.
-func (s *vrSROS) generateSSHPublicKeysConfig(ctx context.Context) (io.Reader, error) {
+// generateSSHPublicKeysConfig generates public keys configuration blob
+// to add keys extracted from the clab host.
+func (s *vrSROS) generateSSHPublicKeysConfig() (io.Reader, error) {
 	tplData := SROSTemplateData{}
 
 	s.prepareSSHPubKeys(&tplData)

--- a/nodes/vr_sros/sshKey.go
+++ b/nodes/vr_sros/sshKey.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"io"
 	"strings"
 	"text/template"
 
@@ -18,9 +19,9 @@ import (
 //go:embed ssh_keys.go.tpl
 var SROSSSHKeysTemplate string
 
-// configureSSHPublicKeys configures public keys extracted from clab host
+// generateSSHPublicKeysConfig configures public keys extracted from clab host
 // on SR OS node using SSH.
-func (s *vrSROS) configureSSHPublicKeys(ctx context.Context) error {
+func (s *vrSROS) generateSSHPublicKeysConfig(ctx context.Context) (io.Reader, error) {
 	tplData := SROSTemplateData{}
 
 	s.prepareSSHPubKeys(&tplData)
@@ -28,21 +29,16 @@ func (s *vrSROS) configureSSHPublicKeys(ctx context.Context) error {
 	t, err := template.New("SSHKeys").Funcs(
 		gomplate.CreateFuncs(context.Background(), new(data.Data))).Parse(SROSSSHKeysTemplate)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	buf := new(bytes.Buffer)
 	err = t.Execute(buf, tplData)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = s.applyPartialConfig(ctx, s.Cfg.MgmtIPv4Address, scrapliPlatformName,
-		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(),
-		buf,
-	)
-
-	return err
+	return buf, nil
 }
 
 // prepareSSHPubKeys maps the ssh pub keys into the SSH key type based slice

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -129,7 +129,7 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) erro
 			return err
 		}
 
-		defer r.Close()
+		defer r.Close() // skipcq: GO-S2307
 
 		_, err = io.Copy(b, r)
 		if err != nil {


### PR DESCRIPTION
fixing #1916 by collecting the partial config and ssh keys in a buffer before deploying it altogether.