### PR TITLE
Network-Mode fix

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -439,7 +439,7 @@ func (c *CLab) createNamespaceSharingDependency() {
 		referenceNodeName := netModeArr[1]
 		referenceNode, err := c.dependencyManager.GetNode(referenceNodeName)
 		if err != nil {
-			log.Warnf("node %s refrenced in namespace sharing not found, considering it an external dependency.", referenceNodeName)
+			log.Warnf("node %s referenced in namespace sharing not found, considering it an external dependency.", referenceNodeName)
 		}
 
 		referenceNode.AddDepender(types.WaitForCreate, n, types.WaitForCreate)

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -439,7 +439,8 @@ func (c *CLab) createNamespaceSharingDependency() {
 		referenceNodeName := netModeArr[1]
 		referenceNode, err := c.dependencyManager.GetNode(referenceNodeName)
 		if err != nil {
-			log.Warnf("node %s referenced in namespace sharing not found, considering it an external dependency.", referenceNodeName)
+			log.Warnf("node %s referenced in namespace sharing not found in topology definition, considering it an external dependency.", referenceNodeName)
+			continue
 		}
 
 		referenceNode.AddDepender(types.WaitForCreate, n, types.WaitForCreate)

--- a/tests/06-ext-container/02-shared-namespace-ext.clab.yaml
+++ b/tests/06-ext-container/02-shared-namespace-ext.clab.yaml
@@ -1,0 +1,14 @@
+name: shared-namespace-ext
+prefix: ""
+
+topology:
+  kinds:
+    linux:
+      cmd: sh
+  nodes:
+    ext-node:
+      kind: linux
+      image: alpine
+      exec:
+        - ip l add dev d1 type dummy
+        - ip a add dev d1 128.66.0.1/32

--- a/tests/06-ext-container/02-shared-namespace.clab.yaml
+++ b/tests/06-ext-container/02-shared-namespace.clab.yaml
@@ -1,0 +1,20 @@
+name: shared-namespace
+
+topology:
+  kinds:
+    linux:
+      cmd: sh
+  nodes:
+    node0:
+      kind: linux
+      image: alpine
+      exec:
+        - ip a
+    node1:
+      kind: linux
+      image: alpine
+      network-mode: container:ext-node
+      exec:
+        - ip a
+  links:
+    - endpoints: ["node0:net0", "node1:net0"]

--- a/tests/06-ext-container/02-shared-namespace.robot
+++ b/tests/06-ext-container/02-shared-namespace.robot
@@ -1,0 +1,72 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Process
+Resource            ../common.robot
+
+Suite Setup         Setup
+Suite Teardown      Run Keyword    Cleanup
+
+
+*** Variables ***
+${lab-name}         06-shared-namespace
+${lab-file-name-1}    02-shared-namespace-ext.clab.yaml
+${lab-file-name-2}    02-shared-namespace.clab.yaml
+${runtime}          docker
+
+
+*** Test Cases ***
+Deploy ${lab-name}-ext lab
+    Log    ${CURDIR}
+    ${output} =    Run Process
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-1}
+    ...    shell=True
+    Log    ${output.stdout}
+    Log    ${output.stderr}
+    Should Be Equal As Integers    ${output.rc}    0
+
+Deploy ${lab-name} lab
+    Log    ${CURDIR}
+    ${output} =    Run Process
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-2}
+    ...    shell=True
+    ...    timeout=30s
+    Log    ${output.stdout}
+    Log    ${output.stderr}
+    Should Be Equal As Integers    ${output.rc}    0
+
+Verify ip on ext-node
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext-node --cmd "ip address show dev d1"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    128.66.0.1/32
+
+Verify links in node0
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node0 --cmd "ip link show dev net0"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    state UP
+
+Verify ext-node defined interface is present for node1
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip address show dev d1"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    128.66.0.1/32
+
+Verify topo defined link in node1
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip link show dev net0"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    state UP
+
+
+*** Keywords ***
+Setup
+    Cleanup
+
+Cleanup
+    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-1} --cleanup
+    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-2} --cleanup


### PR DESCRIPTION
Closes #1939

re-introducing the `continue` statement for network-namespace sharing, when the referenced namespace is considered an external container. This got messed up via https://github.com/srl-labs/containerlab/commit/fff2a5408aa1eee88162a0f2c4b43faef454463d#diff-831ecb8143ceda28e72434a64e3b7f88d15f9492071603608fd0180ae3105e67L440-L444