### PR TITLE
srl.Ready(): fixing a possible nil pointer

### DIFF
--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -333,7 +333,7 @@ func (s *srl) Ready(ctx context.Context) error {
 					logMsg += fmt.Sprintf(" error: %v", err)
 				}
 
-				if execResult.GetReturnCode() != 0 {
+				if execResult != nil && execResult.GetReturnCode() != 0 {
 					logMsg += fmt.Sprintf(", output: \n%s", execResult)
 				}
 


### PR DESCRIPTION
This nil pointer did cause the stack trace in #1951.