### PR TITLE
Post install script

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ env:
   GO_VER: "1.20.2"
   CGO_ENABLED: 0
   MKDOCS_INS_VER: 9.5.9-insiders-4.52.2-hellt
-  GORELEASER_VER: v1.11.4
+  GORELEASER_VER: v1.19.2
   PY_VER: "3.10"
 
 jobs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,7 @@ dockers:
       - 'ghcr.io/srl-labs/clab:{{ replace .Version "v" ""}}'
     dockerfile: goreleaser.dockerfile
 archives:
-  - replacements:
-      linux: Linux
+  - name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Os }}_{{ .Arch }}'
     files:
       - lab-examples/**/*
       - templates/**/*
@@ -52,9 +51,9 @@ changelog:
 
 nfpms:
   - id: containerlab-nfpms
-    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    file_name_template: '{{ .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Os }}_{{ .Arch }}'
     package_name: containerlab
-    maintainer: Roman Dodin <dodin.roman@gmail.com>, Karim Radhouani <medkarimrdi@gmail.com>
+    maintainer: Roman Dodin <dodin.roman@gmail.com>, Markus Vahlenkamp <markus.vahlenkamp@nokia.com>, Karim Radhouani <medkarimrdi@gmail.com>
     homepage: https://containerlab.dev
     description: |
       containerlab deploys containerized networking topologies
@@ -64,6 +63,8 @@ nfpms:
       - rpm
       - deb
       - apk
+    scripts:
+      postinstall: ./utils/postinstall.sh
     bindir: /usr/bin
     contents:
       - src: ./lab-examples

--- a/docs/manual/published-ports.md
+++ b/docs/manual/published-ports.md
@@ -117,7 +117,7 @@ topology:
 
 The `border0` node is a tiny linux container with border0 client installed. Containerlab uses this node to create the sockets and start the tunnels as per `publish` block instructions.
 
-Internally containerlab utilizes the [Static Sockets Plugin](https://docs.border0.com/docs/static-sockets-plugin) to provide the necessary configuration to the border0 process.
+Internally containerlab utilizes the Static Sockets Plugin to provide the necessary configuration to the border0 process.
 
 ## Border0.com policies
 

--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# this post install script is used to count the number of installations of containerlab
+# when the installation is done via apt or yum package manager
+
+# exit if bash shell is not found
+if [ ! -e /bin/bash ]; then
+    exit 0
+fi
+
+# exit if no /etc/apt/sources.list.d/netdevops.list or /etc/yum.repos.d/yum.fury.io_netdevops_.repo is found
+if [ ! -e /etc/apt/sources.list.d/netdevops.list ] && [ ! -e /etc/yum.repos.d/yum.fury.io_netdevops_.repo ]; then
+    exit 0
+fi
+
+# run `containerlab version` and parse the version from the output
+version=$(containerlab version | awk '/version:/{print $2}')
+
+if [ -z "$version" ]; then
+    exit 0
+fi
+
+# prefixed with v
+rel_version=v${version}
+
+REPO_URL="https://github.com/srl-labs/containerlab/releases/download/${rel_version}/checksums.txt"
+
+if type "curl" &>/dev/null; then
+    curl -sL -o /dev/null $REPO_URL || true
+    exit 0
+elif type "wget" &>/dev/null; then
+    wget -q -O /dev/null $REPO_URL || true
+    exit 0
+fi


### PR DESCRIPTION
When clab is installed via a package manager the download counts are not accounted for.
The post install script will make a tiny curl call to fetch the checksum, thus contributing to the only metric we track.