### PR TITLE
Support for podman local images 

### DIFF
--- a/utils/containers.go
+++ b/utils/containers.go
@@ -19,6 +19,7 @@ func GetCanonicalImageName(imageName string) string {
 	//    alpine == docker.io/library/alpine:latest
 	//    foo/bar == docker.io/foo/bar:latest
 	//    foo.bar/baz == foo.bar/bar:latest
+	//    localhost/foo:bar == localhost/foo:bar
 	//    docker.elastic.co/elasticsearch/elasticsearch == docker.elastic.co/elasticsearch/elasticsearch:latest
 	canonicalImageName := imageName
 	slashCount := strings.Count(imageName, "/")
@@ -31,6 +32,9 @@ func GetCanonicalImageName(imageName string) string {
 		nameSplit := strings.Split(imageName, "/")
 		// case of foo.bar/baz
 		if strings.Contains(nameSplit[0], ".") {
+			canonicalImageName = imageName
+		} else if strings.Contains(nameSplit[0], "localhost") {
+			//case of localhost/foo:bar - podman prefixes local images with "localhost"
 			canonicalImageName = imageName
 		} else {
 			canonicalImageName = "docker.io/" + imageName

--- a/utils/containers.go
+++ b/utils/containers.go
@@ -34,7 +34,7 @@ func GetCanonicalImageName(imageName string) string {
 		if strings.Contains(nameSplit[0], ".") {
 			canonicalImageName = imageName
 		} else if strings.Contains(nameSplit[0], "localhost") {
-			//case of localhost/foo:bar - podman prefixes local images with "localhost"
+			// case of localhost/foo:bar - podman prefixes local images with "localhost"
 			canonicalImageName = imageName
 		} else {
 			canonicalImageName = "docker.io/" + imageName


### PR DESCRIPTION
GetCanonicalImageName does not look to be compatible with local images created with podman.  "docker.io" is prefixed to images which fails the [libpod image exists API](https://docs.podman.io/en/latest/_static/api.html#tag/images/operation/ImageExistsLibpod)

```
gravy_paradise1>sudo curl -i --unix-socket /run/podman/podman.sock http://d/v4.9.3/libpod/images/localhost%2Fceos:4.31.2F/exists
HTTP/1.1 204 No Content
Api-Version: 1.41
Libpod-Api-Version: 4.6.2
Server: Libpod/4.6.2 (linux)
X-Reference-Id: 0xc0006525c0
Date: Tue, 02 Apr 2024 21:19:46 GMT

gravy_paradise1>sudo curl -i --unix-socket /run/podman/podman.sock http://d/v4.9.3/libpod/images/docker.io/localhost%2Fceos:4.31.2F/exists
HTTP/1.1 404 Not Found
Api-Version: 1.41
Content-Type: application/json
Libpod-Api-Version: 4.6.2
Server: Libpod/4.6.2 (linux)
X-Reference-Id: 0xc0006485c0
Date: Tue, 02 Apr 2024 21:19:56 GMT
Content-Length: 147

{"cause":"failed to find image docker.io/localhost/ceos:4.31.2F","message":"failed to find image docker.io/localhost/ceos:4.31.2F","response":404}
```


```
gravy_paradise1>sudo podman images --format json | jq .[].Names
[
  "localhost/ceos:4.31.2F"
]
```
```
gravy_paradise1>cat /var/tmp/topologies/test.yaml 
name: test

topology:
  nodes:
    ceos1:
      kind: arista_ceos
      image: localhost/ceos:4.31.2F
      image-pull-policy: Never
    ceos2:
      kind: arista_ceos
      image: localhost/ceos:4.31.2F
      image-pull-policy: Never

  links:
    - endpoints: ["ceos1:eth1", "ceos2:eth1"]
```

```
gravy_paradise1>sudo ./bin/containerlab deploy -r podman -t /var/tmp/topologies/test.yaml --log-level=debug
INFO[0000] Containerlab v0.0.0 started                  
DEBU[0000] template variables: <nil>                    
DEBU[0000] topology:
# topology documentation: http://containerlab.dev/lab-examples/srl-ceos/
name: test

topology:
  nodes:
    ceos1:
      kind: arista_ceos
      image: localhost/ceos:4.31.2F
      image-pull-policy: Never
    ceos2:
      kind: arista_ceos
      image: localhost/ceos:4.31.2F
      image-pull-policy: Never

  links:
    - endpoints: ["ceos1:eth1", "ceos2:eth1"]
 
DEBU[0000] method initMgmtNetwork was called mgmt params &{Network: Bridge: IPv4Subnet: IPv4Gw: IPv4Range: IPv6Subnet: IPv6Gw: IPv6Range: MTU:0 ExternalAccess:<nil>} 
DEBU[0000] New mgmt params are &{Network:clab Bridge: IPv4Subnet:172.20.20.0/24 IPv4Gw: IPv4Range: IPv6Subnet:2001:172:20:20::/64 IPv6Gw: IPv6Range: MTU:0 ExternalAccess:0xc000a8979a} 
DEBU[0000] env runtime var value is                     
DEBU[0000] Running runtime.Init with params &{Timeout:2m0s GracefulShutdown:false Debug:false KeepMgmtNet:false VerifyLinkParams:<nil>} and &{Network:clab Bridge: IPv4Subnet:172.20.20.0/24 IPv4Gw: IPv4Range: IPv6Subnet:2001:172:20:20::/64 IPv6Gw: IPv6Range: MTU:0 ExternalAccess:0xc000a8979a} 
DEBU[0000] Podman method WithConfig was called with cfg params: &{Timeout:2m0s GracefulShutdown:false Debug:false KeepMgmtNet:false VerifyLinkParams:<nil>} 
DEBU[0000] Podman method WithMgmtNet was called with net params: &{Network:clab Bridge: IPv4Subnet:172.20.20.0/24 IPv4Gw: IPv4Range: IPv6Subnet:2001:172:20:20::/64 IPv6Gw: IPv6Range: MTU:0 ExternalAccess:0xc000a8979a} 
DEBU[0000] initialized a runtime with params &{config:0xc000a9a378 mgmt:0xc0005a9290} 
INFO[0000] Parsing & checking topology file: test.yaml  
DEBU[0000] node config: &{ShortName:ceos1 LongName:clab-test-ceos1 Fqdn:ceos1.test.io LabDir:/home/ra1n/containerlab/clab-test/ceos1 Index:0 Group: Kind:arista_ceos StartupConfig: StartupDelay:0 EnforceStartupConfig:false SuppressStartupConfig:false AutoRemove:false ResStartupConfig: Config:<nil> ResConfig: NodeType: Position: License: Image:localhost/ceos:4.31.2F ImagePullPolicy:Never Sysctls:map[] User: Entrypoint: Cmd: Exec:[] Env:map[] Binds:[] PortBindings:map[] ResultingPortBindings:[] PortSet:map[] NetworkMode: MgmtNet: MgmtIntf: MgmtIPv4Address: MgmtIPv4PrefixLength:0 MgmtIPv6Address: MgmtIPv6PrefixLength:0 MgmtIPv4Gateway: MgmtIPv6Gateway: MacAddress: ContainerID: TLSCert: TLSKey: TLSAnchor: Certificate:0xc000aeb680 Healthcheck:<nil> Publish:[] ExtraHosts:[] Labels:map[] Sandbox: Kernel: Runtime: CPU:0 CPUSet: Memory: Extras:<nil> Stages:0xc000aeb6b0 DNS:0xc0005505a0 IsRootNamespaceBased:false SkipUniquenessCheck:false} 
DEBU[0000] node config: &{ShortName:ceos2 LongName:clab-test-ceos2 Fqdn:ceos2.test.io LabDir:/home/ra1n/containerlab/clab-test/ceos2 Index:1 Group: Kind:arista_ceos StartupConfig: StartupDelay:0 EnforceStartupConfig:false SuppressStartupConfig:false AutoRemove:false ResStartupConfig: Config:<nil> ResConfig: NodeType: Position: License: Image:localhost/ceos:4.31.2F ImagePullPolicy:Never Sysctls:map[] User: Entrypoint: Cmd: Exec:[] Env:map[] Binds:[] PortBindings:map[] ResultingPortBindings:[] PortSet:map[] NetworkMode: MgmtNet: MgmtIntf: MgmtIPv4Address: MgmtIPv4PrefixLength:0 MgmtIPv6Address: MgmtIPv6PrefixLength:0 MgmtIPv4Gateway: MgmtIPv6Gateway: MacAddress: ContainerID: TLSCert: TLSKey: TLSAnchor: Certificate:0xc000aebef0 Healthcheck:<nil> Publish:[] ExtraHosts:[] Labels:map[] Sandbox: Kernel: Runtime: CPU:0 CPUSet: Memory: Extras:<nil> Stages:0xc000aebf20 DNS:0xc000550be0 IsRootNamespaceBased:false SkipUniquenessCheck:false} 
DEBU[0000] Env: CLAB_VERSION_CHECK=                     
DEBU[0000] Number of Node workers: 1                    
DEBU[0000] lab Conf: &{Name:test Prefix:0xc0005df1e0 Mgmt:0xc0005a9290 Settings:<nil> Topology:0xc000aea030 Debug:false} 
DEBU[0000] DoRequest Method: GET URI: http://d/v4.9.4/libpod/_ping 
DEBU[0000] Trying to create a management network with params &{Network:clab Bridge: IPv4Subnet:172.20.20.0/24 IPv4Gw: IPv4Range: IPv6Subnet:2001:172:20:20::/64 IPv6Gw: IPv6Range: MTU:0 ExternalAccess:0xc000a8979a} 
DEBU[0000] DoRequest Method: GET URI: http://d/v4.9.4/libpod/networks/clab/exists 
DEBU[0000] DoRequest Method: GET URI: http://d/v4.9.4/libpod/networks/clab/json 
DEBU[0000] DoRequest Method: GET URI: http://d/v4.9.4/libpod/_ping 
DEBU[0000] DoRequest Method: GET URI: http://d/v4.9.4/libpod/images/docker.io%2Flocalhost%2Fceos:4.31.2F/exists 
Error: image localhost/ceos:4.31.2F not found locally, but image-pull-policy is Never
```

This change is intended to support podman prefixing for local images which is not identical to that of docker.  