### PR TITLE
Added grpc config to the mgmt grpc server

### DIFF
--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -327,6 +327,17 @@ IP Address:172.20.20.3, IP Address:2001:172:20:20:0:0:0:3
 
 Nokia SR Linux nodes support setting of [SANs](../nodes.md#subject-alternative-names-san).
 
+### gRPC server
+
+Starting with SR Linux 24.3.1, the gRPC server config block is used to configure gRPC-based services such as gNMI, gNOI, gRIBI and P4RT. The factory configuration includes the `mgmt` gRPC server block to which containerlab adds all those services and:
+
+* generated TLS profile
+* unix-socket access for gRPC services
+* increased rate limit
+* trace options
+
+These additions are meant to make all gRPC services available to the user out of the box with the enabled tracing and a custom TLS profile.
+
 ### License
 
 SR Linux container can run without a license emulating the datacenter types (7220 IXR) :partying_face:.  

--- a/nodes/srl/version.go
+++ b/nodes/srl/version.go
@@ -22,15 +22,6 @@ set / system gnmi-server rate-limit 65000
 set / system gnmi-server trace-options [ request response common ]
 set / system gnmi-server unix-socket admin-state enable`
 
-	// grpc contains the grpc server(s) configuration for srlinux versions >= 24.3.
-	grpcConfig = `set / system grpc-server clab services [ gnmi gnoi gribi p4rt ]
-set / system grpc-server clab tls-profile clab-profile
-set / system grpc-server clab rate-limit 65000
-set / system grpc-server clab network-instance mgmt
-set / system grpc-server clab trace-options [ request response common ]
-set / system grpc-server clab unix-socket admin-state enable
-set / system grpc-server clab admin-state enable`
-
 	// aclConfig contains the ACL configuration for srlinux versions >= 24.3 to enable
 	// non secure telnet and http access to the router which are useful for labs.
 	aclConfig = `set / acl acl-filter cpm type ipv4 entry 88 description "Containerlab-added rule: Accept incoming Telnet when the other host initiates the TCP connection"
@@ -63,6 +54,16 @@ set / acl acl-filter cpm type ipv6 entry 188 match ipv6 next-header tcp
 set / acl acl-filter cpm type ipv6 entry 188 match transport destination-port operator eq
 set / acl acl-filter cpm type ipv6 entry 188 match transport destination-port value 80
 set / acl acl-filter cpm type ipv6 entry 188 action accept`
+
+	// grpc contains the grpc server(s) configuration for srlinux versions >= 24.3.
+	grpcConfig = `set / system grpc-server mgmt services [ gnmi gnoi gribi p4rt ]
+set / system grpc-server mgmt tls-profile clab-profile
+set / system grpc-server mgmt rate-limit 65000
+set / system grpc-server mgmt network-instance mgmt
+set / system grpc-server mgmt trace-options [ request response common ]
+set / system grpc-server mgmt unix-socket admin-state enable
+set / system grpc-server mgmt admin-state enable
+set / system grpc-server mgmt default-tls-profile`
 )
 
 // SrlVersion represents an sr linux version as a set of fields.

--- a/nodes/srl/version.go
+++ b/nodes/srl/version.go
@@ -63,7 +63,7 @@ set / system grpc-server mgmt network-instance mgmt
 set / system grpc-server mgmt trace-options [ request response common ]
 set / system grpc-server mgmt unix-socket admin-state enable
 set / system grpc-server mgmt admin-state enable
-set / system grpc-server mgmt default-tls-profile`
+delete / system grpc-server mgmt default-tls-profile`
 )
 
 // SrlVersion represents an sr linux version as a set of fields.


### PR DESCRIPTION
SR Linux 24.3.1 introduces a default grpc server under the name `mgmt`.
The old config pushed by clab conflicted with the other grpc server, this PR "merges" the two under the `mgmt` name.