### PR TITLE
Support for Border0 Connector / Docker Exec

### DIFF
--- a/border0_api/border0.go
+++ b/border0_api/border0.go
@@ -11,19 +11,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/cenkalti/backoff"
-	"github.com/golang-jwt/jwt"
 	log "github.com/sirupsen/logrus"
-	"github.com/skratchdot/open-golang/open"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/utils"
 	"gopkg.in/yaml.v2"
@@ -31,10 +24,8 @@ import (
 
 const (
 	apiUrl                       = "https://api.border0.com/api/v1"
-	portalUrl                    = "https://portal.border0.com"
 	ENV_NAME_BORDER0_ADMIN_TOKEN = "BORDER0_ADMIN_TOKEN"
 	ENV_NAME_BORDER0_API         = "BORDER0_API"
-	ENV_NAME_BORDER0_PORTAL      = "BORDER0_PORTAL"
 )
 
 var supportedSockTypes = []string{"ssh", "tls", "http", "https"}
@@ -42,165 +33,11 @@ var supportedSockTypes = []string{"ssh", "tls", "http", "https"}
 // to avoid multiple token lookups etc. we'll cache the token.
 var tokenCache = ""
 
-type deviceAuthorization struct {
-	Token string `json:"token,omitempty"`
-}
-
-type deviceAuthorizationStatus struct {
-	Token string `json:"token,omitempty"`
-	State string `json:"state,omitempty"`
-}
-
-func createDeviceAuthorization(ctx context.Context) (string, error) {
-	deviceAuthResp := &deviceAuthorization{}
-	err := Request(ctx, http.MethodPost, "device_authorizations", deviceAuthResp, nil, false, "")
-	if err != nil {
-		return "", err
-	}
-
-	return deviceAuthResp.Token, nil
-}
-
-func getDeviceAuthorizationStatus(ctx context.Context, deviceAuthToken string) (*deviceAuthorizationStatus, error) {
-	deviceAuthStatusResp := &deviceAuthorizationStatus{}
-
-	err := Request(ctx, http.MethodGet, "device_authorizations", deviceAuthStatusResp, nil, false, deviceAuthToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Border0 device authorization status: %v", err)
-	}
-
-	return deviceAuthStatusResp, nil
-}
-
-func handleDeviceAuthorization(ctx context.Context, deviceAuthToken string, disableBrowser bool) (string, error) {
-	deviceAuthJWT, _ := jwt.Parse(deviceAuthToken, nil)
-	if deviceAuthJWT == nil {
-		return "", fmt.Errorf("failed to decode Border0 device authorization token")
-	}
-	claims := deviceAuthJWT.Claims.(jwt.MapClaims)
-	deviceIdentifier := fmt.Sprint(claims["identifier"])
-
-	// Try opening the system's browser automatically. The error is ignored because the desired behavior of the
-	// handler is the same regardless of whether opening the browser fails or succeeds -- we still print the URL.
-	// This is desirable because in the event opening the browser succeeds, the customer may still accidentally
-	// close the new tab / browser session, or may want to authenticate in a different browser / session. In the
-	// event that opening the browser fails, the customer may still complete authenticating by navigating to the
-	// URL in a different device.
-
-	url := fmt.Sprintf("%s/login?device_identifier=%v", getPortalUrl(), url.QueryEscape(deviceIdentifier))
-
-	fmt.Printf("Please navigate to the URL below in order to complete the login process:\n%s\n", url)
-
-	// check if the disableBrowser flag is set
-	if !disableBrowser {
-		// check if we're on DARWIN and if we're running as sudo, if so, make sure we open the browser as the user
-		// this prevents folks from not having access to credentials , sessions, etc
-		sudoUsername := os.Getenv("SUDO_USER")
-		sudoAttempt := false
-		if runtime.GOOS == "darwin" && sudoUsername != "" {
-			err := exec.Command("sudo", "-u", sudoUsername, "open", url).Run()
-			if err == nil {
-				// If for some reason this failed, we'll try again to standard way
-				sudoAttempt = true
-			}
-		}
-		if !sudoAttempt {
-			_ = open.Run(url)
-		}
-	}
-
-	exponentialBackoff := backoff.NewExponentialBackOff()
-	exponentialBackoff.InitialInterval = 1 * time.Second
-	exponentialBackoff.MaxInterval = 5 * time.Second
-	exponentialBackoff.Multiplier = 1.3
-	exponentialBackoff.MaxElapsedTime = 3 * time.Minute
-
-	var token *deviceAuthorizationStatus
-
-	retryFn := func() error {
-		var err error
-		token, err = getDeviceAuthorizationStatus(ctx, deviceAuthToken)
-		if err != nil {
-			return err
-		}
-		if token.Token == "" || token.State == "not_authorized" {
-			return fmt.Errorf("device authorization code is not authorized")
-		}
-		return nil
-	}
-
-	err := backoff.Retry(retryFn, exponentialBackoff)
-	if err != nil {
-		return "", fmt.Errorf("failed to log you in, make sure that you have authenticated using the link above: %v", err)
-	}
-
-	fmt.Println("Login successful!")
-
-	return token.Token, nil
-}
-
-// Login performs a login to border0.com and stores the retrieved the access-token in the cwd.
-func Login(ctx context.Context, email, password string, disableBrowser, writeToCWD bool) (string, error) {
-	var token string
-
-	// if email is not set, we default to Border0's OAuth2 Device Authorization Flow.
-	if email == "" {
-		deviceAuthToken, err := createDeviceAuthorization(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed to initiate Border0 device authorization flow: %v", err)
-		}
-
-		token, err = handleDeviceAuthorization(ctx, deviceAuthToken, disableBrowser)
-		if err != nil {
-			return "", fmt.Errorf("failed to authenticate you against Border0: %v", err)
-		}
-	} else {
-		// if password not set read from terminal
-		if password == "" {
-			var err error
-			password, err = utils.ReadPasswordFromTerminal()
-			if err != nil {
-				return "", err
-			}
-		}
-		// prepare a LoginRequest
-		loginReq := &LoginRequest{
-			Email:    email,
-			Password: password,
-		}
-		// init a LoginResponse
-		loginResp := &LoginResponse{}
-
-		// execute the request
-		err := Request(ctx, http.MethodPost, "login", loginResp, loginReq, false, "")
-		if err != nil {
-			return "", err
-		}
-
-		token = loginResp.Token
-	}
-
-	if writeToCWD {
-		if err := writeToken(token); err != nil {
-			return "", err
-		}
-	}
-	return token, nil
-}
-
 func getApiUrl() string {
 	if os.Getenv(ENV_NAME_BORDER0_API) != "" {
 		return os.Getenv(ENV_NAME_BORDER0_API)
 	} else {
 		return apiUrl
-	}
-}
-
-func getPortalUrl() string {
-	if os.Getenv(ENV_NAME_BORDER0_PORTAL) != "" {
-		return os.Getenv(ENV_NAME_BORDER0_PORTAL)
-	} else {
-		return portalUrl
 	}
 }
 
@@ -243,7 +80,7 @@ func checkPoliciesExist(ctx context.Context, policyNames map[string]struct{}) er
 		return err
 	}
 	// keep track of the non-found policy names
-	notFound := []string{}
+	var notFound []string
 OUTER:
 	// iterate over the given policy names
 	for name := range policyNames {
@@ -289,8 +126,8 @@ func tokenfile() (string, error) {
 	return "", fmt.Errorf("no access-token found, please login to border0.com first e.g use `containerlab tools border0 login`")
 }
 
-// cwdTokenFilePath get the abspath of the token file in the current working directory.
-func cwdTokenFilePath() string {
+// CwdTokenFilePath get the abspath of the token file in the current working directory.
+func CwdTokenFilePath() string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
@@ -393,7 +230,7 @@ func RefreshLogin(ctx context.Context) error {
 
 // writeToken writes the given token to a file.
 func writeToken(token string) error {
-	absPathToken := cwdTokenFilePath()
+	absPathToken := CwdTokenFilePath()
 
 	err := os.WriteFile(absPathToken, []byte(token), 0600)
 	if err != nil {

--- a/border0_api/border0_test.go
+++ b/border0_api/border0_test.go
@@ -55,7 +55,7 @@ func TestLogin(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-			if err := Login(ctx, tt.args.email, tt.args.password, false); (err != nil) != tt.wantErr {
+			if _, err := Login(ctx, tt.args.email, tt.args.password, false, false); (err != nil) != tt.wantErr {
 				t.Errorf("Login() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/border0_api/border0_test.go
+++ b/border0_api/border0_test.go
@@ -6,7 +6,6 @@ package border0_api
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -16,51 +15,6 @@ import (
 	"github.com/srl-labs/containerlab/types"
 	"go.uber.org/mock/gomock"
 )
-
-func TestLogin(t *testing.T) {
-	type args struct {
-		email    string
-		password string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "test login fail",
-			args: args{
-				email:    "fgsdfg@dfgsdfg.fr",
-				password: "1defsdffgd",
-			},
-			wantErr: true,
-		},
-		// // re-add this line and create a seperate file in this folder
-		// // defining the two variables BORDER0USER and BORDER0PASSWORD with
-		// // valid border0 credentials to test again live api
-		// // e.g.:
-		// // package border0_api
-		// // const BORDER0USER = "e@mail.address"
-		// // const BORDER0PASSWORD = "PASSWORD"
-		// //
-		// {
-		// 	name: "test login fail",
-		// 	args: args{
-		// 		email:    BORDER0USER,
-		// 		password: BORDER0PASSWORD,
-		// 	},
-		// 	wantErr: false,
-		// },
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
-			if _, err := Login(ctx, tt.args.email, tt.args.password, false, false); (err != nil) != tt.wantErr {
-				t.Errorf("Login() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func Test_createBorder0Config(t *testing.T) {
 	type args struct {
@@ -137,10 +91,7 @@ func Test_createBorder0Config(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// set the token variable first
-			err := os.Setenv(ENV_NAME_BORDER0_ADMIN_TOKEN, "SomeValueOtherThenNil")
-			if err != nil {
-				t.Error(err)
-			}
+			t.Setenv(ENV_NAME_BORDER0_ADMIN_TOKEN, "SomeValueOtherThenNil")
 
 			// mock the http client, to be able to inject responses
 			defer gock.Off()
@@ -195,7 +146,7 @@ func Test_createBorder0Config(t *testing.T) {
 			mockerNodes := tt.args.nodesMap(mockCtrl)
 
 			// call function under test
-			_, err = CreateBorder0Config(tt.args.ctx, mockerNodes, tt.args.labname)
+			_, err := CreateBorder0Config(tt.args.ctx, mockerNodes, tt.args.labname)
 
 			// signal finish to mock
 			mockCtrl.Finish()

--- a/cmd/border0.go
+++ b/cmd/border0.go
@@ -6,9 +6,41 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/borderzero/border0-go"
+	"github.com/borderzero/border0-go/client"
+	"github.com/borderzero/border0-go/types/service"
+	"github.com/gosimple/slug"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/border0_api"
+)
+
+const (
+	border0NodeClabConfigWithTokenVolumeFmt = `
+    border0:
+      kind: linux
+      image: ghcr.io/borderzero/border0
+      cmd: connector start --config /etc/border0/border0.yaml
+      binds:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - %s:/etc/border0/border0.yaml
+`
+
+	// used when writing connector token file fails
+	border0NodeClabConfigWithTokenEnvFmt = `
+    border0:
+      kind: linux
+      image: ghcr.io/borderzero/border0
+      cmd: connector start
+      binds:
+        - /var/run/docker.sock:/var/run/docker.sock
+      env:
+        BORDER0_TOKEN: %s
+`
 )
 
 var (
@@ -16,13 +48,17 @@ var (
 	border0Password string
 
 	border0DisableBrowser bool
+
+	border0LabName string
 )
 
 func init() {
 	toolsCmd.AddCommand(border0Cmd)
 
-	border0Cmd.AddCommand(border0LoginCmd)
+	border0Cmd.AddCommand(border0InitCmd)
+	border0InitCmd.Flags().StringVarP(&border0LabName, "lab-name", "l", "", "Lab name")
 
+	border0Cmd.AddCommand(border0LoginCmd)
 	border0LoginCmd.Flags().BoolVarP(&border0DisableBrowser, "disable-browser", "b", false, "Disable opening the browser")
 
 	// Programmatic user authentication for the Border0 service was deprecated on 11/2023,
@@ -47,12 +83,107 @@ var border0Cmd = &cobra.Command{
 // border0LoginCmd represents the border0-login command.
 var border0LoginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Logs in to border0.com service and saves a token to current working directory",
+	Short: "Logs in to the border0.com service and saves a token to current working directory",
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(cmd.Context())
 		defer cancel()
 
-		return border0_api.Login(ctx, border0Email, border0Password, border0DisableBrowser)
+		_, err := border0_api.Login(ctx, border0Email, border0Password, border0DisableBrowser, true)
+		return err
 	},
+}
+
+var border0InitCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Provisions a border0.com organization with resources for a new ContainerLab environment",
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
+		if border0LabName == "" {
+			border0LabName = fmt.Sprintf("border0-clab-%d", time.Now().Unix()%10000)
+		}
+		if !slug.IsSlug(border0LabName) {
+			return fmt.Errorf("lab-name must be in slug format e.g. my-border0-clab-123")
+		}
+
+		// always force a fresh login for now...
+		token, err := border0_api.Login(ctx, border0Email, border0Password, border0DisableBrowser, false)
+		if err != nil {
+			return fmt.Errorf("failed to authenticate with Border0: %v", err)
+		}
+
+		// initialize border0 sdk
+		api := border0.NewAPIClient(
+			client.WithAuthToken(token),
+			client.WithRetryMax(2),
+		)
+
+		// create new connector
+		connector, err := api.CreateConnector(ctx, &client.Connector{
+			Name:                     border0LabName,
+			Description:              "ContainerLab Connector",
+			BuiltInSshServiceEnabled: false,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create new Border0 connector: %v", err)
+		}
+
+		// create new docker_exec socket
+		socket, err := api.CreateSocket(ctx, &client.Socket{
+			Name:             fmt.Sprintf("%s-containers", border0LabName),
+			Description:      "Docker Exec socket for ContainerLab environment",
+			RecordingEnabled: true,
+			ConnectorID:      connector.ConnectorID,
+			SocketType:       service.ServiceTypeSsh,
+			UpstreamConfig: &service.Configuration{
+				ServiceType: service.ServiceTypeSsh,
+				SshServiceConfiguration: &service.SshServiceConfiguration{
+					SshServiceType:                    service.SshServiceTypeDockerExec,
+					DockerExecSshServiceConfiguration: &service.DockerExecSshServiceConfiguration{
+						// no filters (expose all containers)
+					},
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create new Border0 socket: %v", err)
+		}
+
+		// create token for new connector
+		connectorToken, err := api.CreateConnectorToken(ctx, &client.ConnectorToken{
+			Name:        fmt.Sprintf("%s-token-%d", border0LabName, time.Now().Unix()%10000),
+			ExpiresAt:   client.FlexibleTime{Time: time.Time{}},
+			ConnectorID: connector.ConnectorID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create new Border0 socket: %v", err)
+		}
+
+		fmt.Printf("\nNew lab initialized with the Border0 service 🚀\n")
+
+		localConnectorTokenFilePath := fmt.Sprintf("/etc/border0/%s-config.yaml", connector.Name)
+
+		config := fmt.Sprintf(border0NodeClabConfigWithTokenVolumeFmt, localConnectorTokenFilePath)
+		if err = writeConnectorConfig(localConnectorTokenFilePath, connectorToken.Token); err != nil {
+			fmt.Printf("Warning: failed to write Border0 connector configuration file (will use BORDER0_TOKEN env instead of mount): %v\n", err)
+			config = fmt.Sprintf(border0NodeClabConfigWithTokenEnvFmt, connectorToken.Token)
+		}
+
+		fmt.Println("Add the following configuration to your *.clab.yaml file:")
+		fmt.Println(config)
+
+		fmt.Printf("\nOnce you deploy your ContainerLab environment, your containers will be available at:\nhttps://client.border0.com/#/ssh/%s\n\n\n", socket.DNS)
+
+		return nil
+	},
+}
+
+func writeConnectorConfig(filePath, token string) error {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0750); err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, []byte(fmt.Sprintf("token: %s", token)), 0644)
 }

--- a/docs/cmd/tools/border0/setup.md
+++ b/docs/cmd/tools/border0/setup.md
@@ -1,0 +1,41 @@
+# border0 setup
+
+### Description
+
+The `setup` sub-command under the `tools border0` command provisions a Border0 organization with resources to expose a new ContainerLab environment over the Border0 service.
+
+### Usage
+
+`clab tools border0 setup [local-flags]`
+
+### Flags
+
+#### lab-name
+
+The `--lab-name | -l` flag allows providing a name to associate with all resources created in Border0.
+
+### Examples
+
+```bash
+clab tools border0 setup
+
+Please navigate to the URL below in order to complete the login process:
+https://portal.border0.com/login?device_identifier=IjdhYmEwYWEwLTNkYT...HhWK5aMnmxtZNDc
+Login successful!
+
+New lab initialized with the Border0 service 🚀
+Add the following configuration to your *.clab.yaml file:
+
+    border0:
+      kind: linux
+      image: ghcr.io/borderzero/border0
+      cmd: connector start --config /etc/border0/border0.yaml
+      binds:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - /etc/border0/border-clab-9650-config.yaml:/etc/border0/border0.yaml
+
+
+Once you deploy your ContainerLab enviroment, your containers will be available at:
+https://client.border0.com/#/ssh/border-clab-9650-containers-somerandomname.border0.io
+
+```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
+	github.com/borderzero/border0-go v1.4.29
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containernetworking/plugins v1.4.1
 	github.com/containers/common v0.58.1
@@ -61,6 +62,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.5 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cilium/ebpf v0.12.3 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
@@ -208,7 +210,7 @@ require (
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/schema v1.2.1 // indirect
-	github.com/gosimple/slug v1.12.0 // indirect
+	github.com/gosimple/slug v1.12.0
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hairyhenderson/go-fsimpl v0.0.0-20220529183339-9deae3e35047 // indirect
 	github.com/hairyhenderson/toml v0.4.2-0.20210923231440-40456b8e66cf // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.21
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
-	github.com/borderzero/border0-go v1.4.29
-	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/borderzero/border0-go v1.4.30
 	github.com/containernetworking/plugins v1.4.1
 	github.com/containers/common v0.58.1
 	github.com/containers/podman/v5 v5.0.1
@@ -17,7 +16,6 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/florianl/go-tc v0.4.3
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/google/nftables v0.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -37,7 +35,6 @@ require (
 	github.com/pmorjan/kmod v1.1.1
 	github.com/scrapli/scrapligo v1.2.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.8.0
 	github.com/steiler/acls v0.1.1
 	github.com/stretchr/testify v1.9.0
@@ -62,6 +59,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.5 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cilium/ebpf v0.12.3 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
@@ -86,6 +84,7 @@ require (
 	github.com/go-openapi/strfmt v0.22.2 // indirect
 	github.com/go-openapi/swag v0.22.10 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-containerregistry v0.19.0 // indirect
@@ -112,6 +111,7 @@ require (
 	github.com/sigstore/rekor v1.2.2 // indirect
 	github.com/sigstore/sigstore v1.8.2 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/vbauerster/mpb/v8 v8.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -918,8 +918,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/borderzero/border0-go v1.4.29 h1:HN7PjGPTx+h1ZZ6Kr4B2O4Yi3h7GwpBSyB4Tg80LSNU=
-github.com/borderzero/border0-go v1.4.29/go.mod h1:zZ2GT3L67Nko//ZL5gyQd2elEwAOBTtT0b71oy/abcc=
+github.com/borderzero/border0-go v1.4.30 h1:jzJ3k4fEoOwpa6eb1KZok7ckjOo8U2KImLqvbE67jYI=
+github.com/borderzero/border0-go v1.4.30/go.mod h1:b8ndNeJmwx1l7N19N+p5EqvjzcmYqGXbiiHZ76dCSW4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/go.sum
+++ b/go.sum
@@ -918,6 +918,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/borderzero/border0-go v1.4.29 h1:HN7PjGPTx+h1ZZ6Kr4B2O4Yi3h7GwpBSyB4Tg80LSNU=
+github.com/borderzero/border0-go v1.4.29/go.mod h1:zZ2GT3L67Nko//ZL5gyQd2elEwAOBTtT0b71oy/abcc=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -935,8 +937,8 @@ github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
-github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,8 @@ nav:
           - netem:
               - set: cmd/tools/netem/set.md
               - show: cmd/tools/netem/show.md
+          - border0:
+              - setup: cmd/tools/border0/setup.md
       - completions: cmd/completion.md
   - Lab examples:
       - About: lab-examples/lab-examples.md


### PR DESCRIPTION
## Support for Border0 Connector / Docker Exec

This PR introduces the ability to deploy the [Border0 Connector](https://docs.border0.com/docs/border0-connector#connectors) as a node in a containerlab environment (lab)... connecting all nodes without the need to expose nodes' SSH ports or manage/provision any nodes with secrets.

This makes for a seamless experience for containerlab users who wish to expose their labs over the internet (behind their authentication method of choice: Google/GitHub/Microsoft/Email-Link).

The nicest thing about it is users can talk to their nodes from any web browser using our [web client](https://www.border0.com/blogs/introducing-the-border0-client-portal). 

### Video Demo

https://github.com/srl-labs/containerlab/assets/16856511/13fd9f2f-3c2a-469b-a64b-0111997918df

---

I alluded to this feature being in the works in  https://github.com/srl-labs/containerlab/pull/1768:

> @hellt Let's talk next year. We maaaaay (no promises) have something in the works to simplify the integration and make the experience much nicer for clab users.

We are excited to hear your thoughts and collaborate on making the containerlab x border0 experience as best as it can be!

cc:// @steiler @hellt @atoonk