### PR TITLE
add cookie consent and option to manage cookies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -262,7 +262,7 @@ extra:
       - accept
       - manage
       - reject
-    description: >- 
+    description: >-
       We use cookies to recognize your repeated visits and preferences, as well
       as to measure the effectiveness of our documentation and whether users
       find what they're searching for. With your consent, you're helping us to
@@ -272,7 +272,7 @@ extra:
     property: G-368XR9X5MG
 
 copyright: >
-  &#x1F36A;&nbsp;<a href="#__consent">Change cookie settings</a>
+  <span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.87 9.5C20.6 9 20 9 20 9h-2V8c0-1-1-1-1-1h-2V6c0-1-1-1-1-1h-1V3c0-1-1-1-1-1a9 9 0 1 0 9 9c0-.5-.04-1-.13-1.5M6.5 12c-.83 0-1.5-.67-1.5-1.5S5.67 9 6.5 9 8 9.67 8  10.5 7.33 12 6.5 12M8 6.5C8 5.67 8.67 5 9.5 5s1.5.67 1.5 1.5S10.33 8 9.5 8 8 7.33 8 6.5M11 18c-.83 0-1.5-.67-1.5-1.5S10.17 15 11 15s1.5.67 1.5 1.5S11.83 18 11 18m.5-5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5m5 2c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5M7 22h2v2H7v-2m4 0h2v2h-2v-2m4 0h2v2h-2v-2Z"></path></svg></span> <a href="#__consent">Cookie settings</a>
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,9 +255,24 @@ extra:
       link: https://twitter.com/ntdvps
     - icon: fontawesome/brands/discord
       link: https://discord.gg/vAyddtaEV9
+  consent:
+    title: Cookie consent
+    consent:
+    actions:
+      - accept
+      - manage
+      - reject
+    description: >- 
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
   analytics:
     provider: google
     property: G-368XR9X5MG
+
+copyright: >
+  &#x1F36A;&nbsp;<a href="#__consent">Change cookie settings</a>
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
Containerlab MkDocs is using Google Analytics, which is not necessarily GDPR compliant. While this goes against engineering common sense and is very theoretical concern - you never know if it will hit or not. Legal world is weird. I'd suggest at least adding an explicit cookie consent and an option to change cookie settings as it's documented in [MkDocs privacy section](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/).  
GDPR and Google Analytics is a long read that can certainly not be covered in a single PR.
To add more fun, German court decided Jan 2022, that Google Fonts are not GDPR compliant as well. There is a MkDocs knob for that (privacy plugin): https://github.com/squidfunk/mkdocs-material/issues/739
However I'll not add it as part of this PR as it looks a bit theoretical to me and every MkDocs site is using gFonts anyway.  
I believe that Containerlab community is sane and have nothing to worry about, but as it's also quite popular - some basic guards may be helpful.