### PR TITLE
Fix GetNSPath for ignite

### DIFF
--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -154,6 +154,8 @@ func (*IgniteRuntime) PullImage(_ context.Context, imageName string, _ types.Pul
 	return nil
 }
 
+// StartContainer starts a container with the provided node configuration.
+// skipcq: GO-R1005
 func (c *IgniteRuntime) StartContainer(ctx context.Context, _ string, node runtime.Node) (interface{}, error) {
 	vm := c.baseVM.DeepCopy()
 
@@ -225,7 +227,7 @@ func (c *IgniteRuntime) StartContainer(ctx context.Context, _ string, node runti
 	}
 	defer os.Remove(udevFile.Name())
 
-	if _, err := udevFile.Write([]byte(strings.Join(udevRules, "\n") + "\n")); err != nil {
+	if _, err := udevFile.WriteString(strings.Join(udevRules, "\n") + "\n"); err != nil {
 		return nil, err
 	}
 	if err := udevFile.Close(); err != nil {
@@ -465,7 +467,7 @@ func (*IgniteRuntime) GetContainerStatus(_ context.Context, containerID string) 
 }
 
 // IsHealthy returns true is the container is reported as being healthy, false otherwise.
-func (c *IgniteRuntime) IsHealthy(_ context.Context, _ string) (bool, error) {
+func (*IgniteRuntime) IsHealthy(_ context.Context, _ string) (bool, error) {
 	log.Errorf("function GetContainerHealth(...) not implemented in the Containerlab IgniteRuntime")
 	return true, nil
 }

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -8,10 +8,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/containerlab/clab/exec"
-	"github.com/srl-labs/containerlab/runtime"
-	"github.com/srl-labs/containerlab/types"
-	"github.com/srl-labs/containerlab/utils"
 	api "github.com/weaveworks/ignite/pkg/apis/ignite"
 	meta "github.com/weaveworks/ignite/pkg/apis/meta/v1alpha1"
 	igniteConstants "github.com/weaveworks/ignite/pkg/constants"
@@ -25,6 +21,11 @@ import (
 	"github.com/weaveworks/ignite/pkg/providers/ignite"
 	igniteRuntimes "github.com/weaveworks/ignite/pkg/runtime"
 	"github.com/weaveworks/ignite/pkg/util"
+
+	"github.com/srl-labs/containerlab/clab/exec"
+	"github.com/srl-labs/containerlab/runtime"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
 )
 
 const (
@@ -264,7 +265,7 @@ func (c *IgniteRuntime) StartContainer(ctx context.Context, _ string, node runti
 		return nil, err
 	}
 
-	nspath, err := c.GetNSPath(ctx, vm.PrefixedID())
+	nspath, err := c.ctrRuntime.GetNSPath(ctx, vm.PrefixedID())
 	if err != nil {
 		return nil, err
 	}
@@ -396,12 +397,12 @@ func (ir *IgniteRuntime) produceGenericContainerList(input []*api.VM) ([]runtime
 	return result, nil
 }
 
-func (c *IgniteRuntime) GetNSPath(ctx context.Context, ctrId string) (string, error) {
-	result, err := c.ctrRuntime.GetNSPath(ctx, ctrId)
+func (c *IgniteRuntime) GetNSPath(ctx context.Context, vmName string) (string, error) {
+	vm, err := providers.Client.VMs().Find(filter.NewVMFilter(vmName))
 	if err != nil {
 		return "", err
 	}
-	return result, nil
+	return c.ctrRuntime.GetNSPath(ctx, vm.PrefixedID())
 }
 
 func (*IgniteRuntime) Exec(_ context.Context, _ string, _ *exec.ExecCmd) (*exec.ExecResult, error) {


### PR DESCRIPTION
Containerlab is unable to find the network namespace path using ignite runtime since 0.53.0.
```
INFO[0001] Networking is handled by "docker-bridge"     
INFO[0001] Started Firecracker VM "5166f4a61292d357" in a container with ID "aad296f2246e7022153a54462c890b8d955218ee8e0501cdf3277b618a879f5c" 
ERRO[0001] Unable to determine NetNS Path for node leaf02: Error response from daemon: No such container: leaf02 
ERRO[0001] failed deploy links for node "leaf02": Error response from daemon: No such container: leaf02 
INFO[0003] Networking is handled by "docker-bridge"     
INFO[0003] Started Firecracker VM "b92c63db14bfbfad" in a container with ID "1c2d5a8b21c99d35a553eaa3c0cffbfee007e4940b8b71ea23ce848d6deaf7f9" 
ERRO[0003] Unable to determine NetNS Path for node leaf01: Error response from daemon: No such container: leaf01 
ERRO[0003] failed deploy links for node "leaf01": Error response from daemon: No such container: leaf01 
```

Before the refactoring, the ns path was saved in the configuration of the node. Now it is retrieved from the runtime using the LongName, which is the name of the ignite VM.

See: https://github.com/srl-labs/containerlab/pull/1906/files#diff-d25cfdb9022b8a280a3cf87aa5a83926d393e4d5d28c550dd57cca87c9130359R169

Caused by #1906