### PR TITLE
Change shebang to sh for Alpine Liunux

### DIFF
--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -3,8 +3,8 @@
 # this post install script is used to count the number of installations of containerlab
 # when the installation is done via apt or yum package manager
 
-# exit if bash shell is not found
-if [ ! -e /bin/bash ]; then
+# exit if sh shell is not found
+if [ ! -e /bin/sh ]; then
     exit 0
 fi
 
@@ -25,10 +25,10 @@ rel_version=v${version}
 
 REPO_URL="https://github.com/srl-labs/containerlab/releases/download/${rel_version}/checksums.txt"
 
-if type "curl" &>/dev/null; then
-    curl --max-time 2 -sL -o /dev/null $REPO_URL || true
+if type "curl" > /dev/null 2>&1; then
+    curl --max-time 2 -sL -o /dev/null "$REPO_URL" || true
     exit 0
-elif type "wget" &>/dev/null; then
-    wget -T 2 -q -O /dev/null $REPO_URL || true
+elif type "wget" > /dev/null 2>&1; then
+    wget -T 2 -q -O /dev/null "$REPO_URL" || true
     exit 0
 fi

--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # this post install script is used to count the number of installations of containerlab
 # when the installation is done via apt or yum package manager


### PR DESCRIPTION
APK release file can't be installed on minimal Alpine images because of missing bash. Testing if /bin/bash exists doesn't make much sense if the script requires bash to execute in the first place. Changing shebang to /bin/sh should make the script portable to all distributions.