### PR TITLE
Add knob to skip adding extended ACL to labdir

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -996,11 +996,15 @@ func (c *CLab) Deploy(ctx context.Context, options *DeployOptions) ([]runtime.Ge
 
 	log.Info("Creating lab directory: ", c.TopoPaths.TopologyLabDir())
 	utils.CreateDirectory(c.TopoPaths.TopologyLabDir(), 0755)
-	// adjust ACL for Labdir such that SUDO_UID Users will
-	// also have access to lab directory files
-	err = utils.AdjustFileACLs(c.TopoPaths.TopologyLabDir())
-	if err != nil {
-		log.Infof("unable to adjust Labdir file ACLs: %v", err)
+
+	// check if the ACL Adjustment is to be skipped.
+	if !options.skipACLAdjustment {
+		// adjust ACL for Labdir such that SUDO_UID Users will
+		// also have access to lab directory files
+		err = utils.AdjustFileACLs(c.TopoPaths.TopologyLabDir())
+		if err != nil {
+			log.Infof("unable to adjust Labdir file ACLs: %v", err)
+		}
 	}
 
 	// create an empty ansible inventory file that will get populated later

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -997,8 +997,7 @@ func (c *CLab) Deploy(ctx context.Context, options *DeployOptions) ([]runtime.Ge
 	log.Info("Creating lab directory: ", c.TopoPaths.TopologyLabDir())
 	utils.CreateDirectory(c.TopoPaths.TopologyLabDir(), 0755)
 
-	// check if the ACL Adjustment is to be skipped.
-	if !options.skipACLAdjustment {
+	if !options.skipLabDirFileACLs {
 		// adjust ACL for Labdir such that SUDO_UID Users will
 		// also have access to lab directory files
 		err = utils.AdjustFileACLs(c.TopoPaths.TopologyLabDir())

--- a/clab/deploy_options.go
+++ b/clab/deploy_options.go
@@ -7,12 +7,12 @@ import (
 
 // DeployOptions represents the options for deploying a lab.
 type DeployOptions struct {
-	reconfigure       bool   // reconfigure indicates whether to reconfigure the lab.
-	skipPostDeploy    bool   // skipPostDeploy indicates whether to skip post-deployment steps.
-	graph             bool   // graph indicates whether to generate a graph of the lab.
-	maxWorkers        uint   // maxWorkers is the maximum number of workers for node creation.
-	exportTemplate    string // exportTemplate is the path to the export template.
-	skipACLAdjustment bool   // skip setting the extended ACL entries on the lab directory.
+	reconfigure        bool   // reconfigure indicates whether to reconfigure the lab.
+	skipPostDeploy     bool   // skipPostDeploy indicates whether to skip post-deployment steps.
+	graph              bool   // graph indicates whether to generate a graph of the lab.
+	maxWorkers         uint   // maxWorkers is the maximum number of workers for node creation.
+	exportTemplate     string // exportTemplate is the path to the export template.
+	skipLabDirFileACLs bool   // skip setting the extended File ACL entries on the lab directory.
 }
 
 // NewDeployOptions creates a new DeployOptions instance with the specified maxWorkers value.
@@ -39,9 +39,9 @@ func (d *DeployOptions) SetSkipPostDeploy(b bool) *DeployOptions {
 	return d
 }
 
-// SetSkipACLAdjustment skip setting the extended ACL entries on the lab directory.
-func (d *DeployOptions) SetSkipACLAdjustment(b bool) *DeployOptions {
-	d.skipACLAdjustment = b
+// SetSkipLabDirFileACLs sets the skipLabDirFileACLs deployment option.
+func (d *DeployOptions) SetSkipLabDirFileACLs(b bool) *DeployOptions {
+	d.skipLabDirFileACLs = b
 	return d
 }
 

--- a/clab/deploy_options.go
+++ b/clab/deploy_options.go
@@ -7,11 +7,12 @@ import (
 
 // DeployOptions represents the options for deploying a lab.
 type DeployOptions struct {
-	reconfigure    bool   // reconfigure indicates whether to reconfigure the lab.
-	skipPostDeploy bool   // skipPostDeploy indicates whether to skip post-deployment steps.
-	graph          bool   // graph indicates whether to generate a graph of the lab.
-	maxWorkers     uint   // maxWorkers is the maximum number of workers for node creation.
-	exportTemplate string // exportTemplate is the path to the export template.
+	reconfigure       bool   // reconfigure indicates whether to reconfigure the lab.
+	skipPostDeploy    bool   // skipPostDeploy indicates whether to skip post-deployment steps.
+	graph             bool   // graph indicates whether to generate a graph of the lab.
+	maxWorkers        uint   // maxWorkers is the maximum number of workers for node creation.
+	exportTemplate    string // exportTemplate is the path to the export template.
+	skipACLAdjustment bool   // skip setting the extended ACL entries on the lab directory.
 }
 
 // NewDeployOptions creates a new DeployOptions instance with the specified maxWorkers value.
@@ -35,6 +36,12 @@ func (d *DeployOptions) Reconfigure() bool {
 // SetSkipPostDeploy sets the skipPostDeploy option and returns the updated DeployOptions instance.
 func (d *DeployOptions) SetSkipPostDeploy(b bool) *DeployOptions {
 	d.skipPostDeploy = b
+	return d
+}
+
+// SetSkipACLAdjustment skip setting the extended ACL entries on the lab directory.
+func (d *DeployOptions) SetSkipACLAdjustment(b bool) *DeployOptions {
+	d.skipACLAdjustment = b
 	return d
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,8 +47,8 @@ var deployFormat string
 // subset of nodes to work with.
 var nodeFilter []string
 
-// skipACLAdjustment skip the adjustemnt of the lab directory with extended ACLs
-var skipACLAdjustment bool
+// skipLabDirFileACLs skips provisioning of extended File ACLs for the Lab directory.
+var skipLabDirFileACLs bool
 
 // deployCmd represents the deploy command.
 var deployCmd = &cobra.Command{
@@ -77,7 +77,7 @@ func init() {
 		defaultExportTemplateFPath, "template file for topology data export")
 	deployCmd.Flags().StringSliceVarP(&nodeFilter, "node-filter", "", []string{},
 		"comma separated list of nodes to include")
-	deployCmd.Flags().BoolVarP(&skipACLAdjustment, "skip-labdir-acl", "", false, "skip the adjustemnt of the lab directory with extended ACLs")
+	deployCmd.Flags().BoolVarP(&skipLabDirFileACLs, "skip-labdir-acl", "", false, "skip the lab directory extended ACLs provisioning")
 }
 
 // deployFn function runs deploy sub command.
@@ -137,7 +137,7 @@ func deployFn(_ *cobra.Command, _ []string) error {
 		SetReconfigure(reconfigure).
 		SetGraph(graph).
 		SetSkipPostDeploy(skipPostDeploy).
-		SetSkipACLAdjustment(skipACLAdjustment)
+		SetSkipLabDirFileACLs(skipLabDirFileACLs)
 
 	containers, err := c.Deploy(ctx, deploymentOptions)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -47,6 +47,9 @@ var deployFormat string
 // subset of nodes to work with.
 var nodeFilter []string
 
+// skipACLAdjustment skip the adjustemnt of the lab directory with extended ACLs
+var skipACLAdjustment bool
+
 // deployCmd represents the deploy command.
 var deployCmd = &cobra.Command{
 	Use:          "deploy",
@@ -74,6 +77,7 @@ func init() {
 		defaultExportTemplateFPath, "template file for topology data export")
 	deployCmd.Flags().StringSliceVarP(&nodeFilter, "node-filter", "", []string{},
 		"comma separated list of nodes to include")
+	deployCmd.Flags().BoolVarP(&skipACLAdjustment, "skip-labdir-acl", "", false, "skip the adjustemnt of the lab directory with extended ACLs")
 }
 
 // deployFn function runs deploy sub command.
@@ -132,7 +136,8 @@ func deployFn(_ *cobra.Command, _ []string) error {
 	deploymentOptions.SetExportTemplate(exportTemplate).
 		SetReconfigure(reconfigure).
 		SetGraph(graph).
-		SetSkipPostDeploy(skipPostDeploy)
+		SetSkipPostDeploy(skipPostDeploy).
+		SetSkipACLAdjustment(skipACLAdjustment)
 
 	containers, err := c.Deploy(ctx, deploymentOptions)
 	if err != nil {

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -135,6 +135,14 @@ Read more about [node filtering](../manual/node-filtering.md) in the documentati
 
 The `--skip-post-deploy` flag can be used to skip the post-deploy phase of the lab deployment. This is a global flag that affects all nodes in the lab.
 
+#### skip-labdir-acl
+
+The `--skip-labdir-acl` flag can be used to skip the lab directory access control list (ACL) provisioning.
+
+The extended File ACLs are provisioned for the lab directory by default, unless this flag is set. Extended File ACLs allow a sudo user to access the files in the lab directory that might be created by the `root` user from within the container node.
+
+While this is useful in most cases, sometimes extended File ACLs might prevent your lab from working, especially when your lab directory end up being mounted from the network filesystem (NFS, CIFS, etc.). In such cases, you can use this flag to skip the ACL provisioning.
+
 ### Environment variables
 
 #### `CLAB_RUNTIME`

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -34,7 +34,7 @@ Create linux bridge
 
 Deploy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy --skip-labdir-acl -t ${CURDIR}/${lab-file}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 


### PR DESCRIPTION
This PR adds the "--skip-labdir-acl" knob to the deploy call. Setting it will skip adding extended ACL to the lab dir.