### PR TITLE
replaced apt repo for an IPv6 capable one in documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ curl -sL https://containerlab.dev/setup | sudo bash -s "install-docker"
 Containerlab can be installed using the [installation script](https://github.com/srl-labs/containerlab/blob/main/get.sh) that detects the operating system type and installs the relevant package:
 
 /// note
-Containerlab is distributed via deb/rpm packages, thus only Debian- and RHEL-like distributives can leverage package installation.  
+Containerlab is distributed via deb/rpm packages, thus only Debian- and RHEL-like distributives can leverage package installation.
 Other systems can follow the [manual installation](#manual-installation) procedure.
 ///
 
@@ -88,7 +88,7 @@ It is possible to install official containerlab releases via public APT/YUM repo
 /// tab | APT
 
 ```bash
-echo "deb [trusted=yes] https://apt.fury.io/netdevops/ /" | \
+echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
 sudo tee -a /etc/apt/sources.list.d/netdevops.list
 
 sudo apt update && sudo apt install containerlab
@@ -236,7 +236,7 @@ By running this command you will download the `clab_debian12.utm` file which is 
 
 Open the downloaded image with UTM **File -> Open -> select .utm file** and start the VM.
 
-Once the VM is started, you can log in using `debian:debian` credentials. Run `ip -4 addr` in the terminal to find out which IP got assigned to this VM.  
+Once the VM is started, you can log in using `debian:debian` credentials. Run `ip -4 addr` in the terminal to find out which IP got assigned to this VM.
 Now you can use this IP for your Mac terminal to connect to the VM via SSH[^10].
 
 When logged in, you can upgrade the containerlab to the latest version with:
@@ -439,14 +439,14 @@ Now you can launch the lab, as containerlab is already part of the image:
 
 ```
 root@docker-desktop:/Users/romandodin/clab# clab dep -t 2srl.clab.yml
-INFO[0000] Parsing & checking topology file: 2srl.clab.yml 
-INFO[0000] Creating lab directory: /Users/romandodin/clab/clab-2srl 
-INFO[0000] Creating root CA                             
-INFO[0000] Creating docker network: Name='clab', IPv4Subnet='172.20.20.0/24', IPv6Subnet='2001:172:20:20::/64', MTU='1500' 
-INFO[0000] Creating container: srl1                     
-INFO[0000] Creating container: srl2                     
-INFO[0001] Creating virtual wire: srl1:e1-1 <--> srl2:e1-1 
-INFO[0001] Adding containerlab host entries to /etc/hosts file 
+INFO[0000] Parsing & checking topology file: 2srl.clab.yml
+INFO[0000] Creating lab directory: /Users/romandodin/clab/clab-2srl
+INFO[0000] Creating root CA
+INFO[0000] Creating docker network: Name='clab', IPv4Subnet='172.20.20.0/24', IPv6Subnet='2001:172:20:20::/64', MTU='1500'
+INFO[0000] Creating container: srl1
+INFO[0000] Creating container: srl2
+INFO[0001] Creating virtual wire: srl1:e1-1 <--> srl2:e1-1
+INFO[0001] Adding containerlab host entries to /etc/hosts file
 +---+----------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
 | # |      Name      | Container ID |         Image         | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+----------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
@@ -478,7 +478,7 @@ To build containerlab from source, clone the repository and issue `go build` at 
 ///
 
 /// tab | with goreleaser
-When we release containerlab we use [goreleaser](https://goreleaser.com/) project to build binaries for all supported platforms as well as the deb/rpm packages.  
+When we release containerlab we use [goreleaser](https://goreleaser.com/) project to build binaries for all supported platforms as well as the deb/rpm packages.
 Users can install `goreleaser` and do the same locally by issuing the following command:
 
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ curl -sL https://containerlab.dev/setup | sudo bash -s "install-docker"
 Containerlab can be installed using the [installation script](https://github.com/srl-labs/containerlab/blob/main/get.sh) that detects the operating system type and installs the relevant package:
 
 /// note
-Containerlab is distributed via deb/rpm packages, thus only Debian- and RHEL-like distributives can leverage package installation.
+Containerlab is distributed via deb/rpm packages, thus only Debian- and RHEL-like distributives can leverage package installation.  
 Other systems can follow the [manual installation](#manual-installation) procedure.
 ///
 
@@ -236,7 +236,7 @@ By running this command you will download the `clab_debian12.utm` file which is 
 
 Open the downloaded image with UTM **File -> Open -> select .utm file** and start the VM.
 
-Once the VM is started, you can log in using `debian:debian` credentials. Run `ip -4 addr` in the terminal to find out which IP got assigned to this VM.
+Once the VM is started, you can log in using `debian:debian` credentials. Run `ip -4 addr` in the terminal to find out which IP got assigned to this VM.  
 Now you can use this IP for your Mac terminal to connect to the VM via SSH[^10].
 
 When logged in, you can upgrade the containerlab to the latest version with:
@@ -478,7 +478,7 @@ To build containerlab from source, clone the repository and issue `go build` at 
 ///
 
 /// tab | with goreleaser
-When we release containerlab we use [goreleaser](https://goreleaser.com/) project to build binaries for all supported platforms as well as the deb/rpm packages.
+When we release containerlab we use [goreleaser](https://goreleaser.com/) project to build binaries for all supported platforms as well as the deb/rpm packages.  
 Users can install `goreleaser` and do the same locally by issuing the following command:
 
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -98,7 +98,7 @@ sudo apt update && sudo apt install containerlab
 /// tab | YUM
 
 ```
-yum-config-manager --add-repo=https://yum.fury.io/netdevops/ && \
+yum-config-manager --add-repo=https://netdevops.fury.site/yum/ && \
 echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/yum.fury.io_netdevops_.repo
 
 sudo yum install containerlab

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -796,11 +796,11 @@ func (s *srl) CheckInterfaceName() error {
 func (s *srl) createRepoFiles() error {
 	yumRepo := `[srlinux]
 name=SR Linux NDK apps
-baseurl=https://yum.fury.io/srlinux/
+baseurl=https://srlinux.fury.site/yum/
 enabled=1
 gpgcheck=0`
 
-	aptRepo := `deb [trusted=yes] https://apt.fury.io/srlinux/ /`
+	aptRepo := `deb [trusted=yes] https://srlinux.fury.site/apt/ /`
 
 	yumPath := s.Cfg.LabDir + "/yum.repo"
 	err := utils.CreateFile(yumPath, yumRepo)

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -89,7 +89,7 @@ function install-gh-cli {
 }
 
 function install-containerlab {
-    echo "deb [trusted=yes] https://apt.fury.io/netdevops/ /" | \
+    echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
     sudo tee -a /etc/apt/sources.list.d/netdevops.list
 
     sudo apt update && sudo apt install -y containerlab


### PR DESCRIPTION
There is another hit for apt.fury.io in nodes/srl/srl.go. I know too little about got to touch this.