### PR TITLE
Standardize on ceos:4.32.0F

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -223,7 +223,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull ceos image
-        run: docker pull ghcr.io/srl-labs/ceos:4.28.0F && docker tag ghcr.io/srl-labs/ceos:4.28.0F ceos:4.28.0F
+        run: docker pull ghcr.io/srl-labs/ceos:4.32.0F && docker tag ghcr.io/srl-labs/ceos:4.32.0F ceos:4.32.0F
       - name: Run ceos tests
         run: |
           bash ./tests/rf-run.sh ${{ matrix.runtime }} ./tests/03-basic-ceos

--- a/docs/cmd/generate.md
+++ b/docs/cmd/generate.md
@@ -52,9 +52,9 @@ containerlab gen -n 3tier --nodes 4,2,1
 #### image
 Use `--image` flag to specify the container image that should be used by a given kind.
 
-The value of this flag follows the `kind=image` pattern. For example, to set the container image `ceos:4.21.F` for the `ceos` kind the flag will be: `--image ceos=ceos:4.21.F`.
+The value of this flag follows the `kind=image` pattern. For example, to set the container image `ceos:4.32.0F` for the `ceos` kind the flag will be: `--image ceos=ceos:4.32.0F`.
 
-To set images for multiple kinds repeat the flag: `--image srl=srlinux:latest --image ceos=ceos:4.21.F` or use the comma separated form: `--image srl=srlinux:latest,ceos=ceos:latest`
+To set images for multiple kinds repeat the flag: `--image srl=srlinux:latest --image ceos=ceos:4.32.0F` or use the comma separated form: `--image srl=srlinux:latest,ceos=ceos:latest`
 
 If the kind information is not provided in the `image` flag, the kind value will be taken from the `--kind` flag.
 

--- a/docs/lab-examples/srl-ceos.md
+++ b/docs/lab-examples/srl-ceos.md
@@ -5,7 +5,7 @@
 | **Resource requirements**[^1] | :fontawesome-solid-microchip: 2 <br/>:fontawesome-solid-memory: 2 GB             |
 | **Topology file**             | [srlceos01.clab.yml][topofile]                                                   |
 | **Name**                      | srlceos01                                                                        |
-| **Version information**[^2]   | `containerlab:0.9.0`, `srlinux:20.6.3-145`, `ceos:4.25.0F`, `docker-ce:19.03.13` |
+| **Version information**[^2]   | `containerlab:0.9.0`, `srlinux:20.6.3-145`, `ceos:4.32.0F`, `docker-ce:19.03.13` |
 
 ## Description
 A lab consists of an SR Linux node connected with Arista cEOS via a point-to-point ethernet link. Both nodes are also connected with their management interfaces to the `containerlab` docker network.

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -20,8 +20,8 @@ Arista requires its users to register with arista.com before downloading any ima
 Once downloaded, import the archive with docker:
 
 ```bash
-# import container image and save it under ceos:4.28.0F name
-docker import cEOS64-lab-4.28.0F.tar.xz ceos:4.28.0F
+# import container image and save it under ceos:4.32.0F name
+docker import cEOS64-lab-4.32.0F.tar.xz ceos:4.32.0F
 ```
 
 ## Managing ceos nodes
@@ -137,12 +137,12 @@ With the following topology file, containerlab is instructed to take a `mymappin
       nodes:
         ceos1:
           kind: ceos
-          image: ceos:4.28.0F
+          image: ceos:4.32.0F
           binds:
             - mymapping.json:/mnt/flash/EosIntfMapping.json:ro # (1)!
-        ceos2: 
+        ceos2:
           kind: ceos
-          image: ceos:4.28.0F
+          image: ceos:4.32.0F
           binds:
             - mymapping.json:/mnt/flash/EosIntfMapping.json:ro
       links:
@@ -160,10 +160,10 @@ With the following topology file, containerlab is instructed to take a `mymappin
           nodes:
             ceos1:
               kind: ceos
-              image: ceos:4.28.0F
-            ceos2: 
+              image: ceos:4.32.0F
+            ceos2:
               kind: ceos
-              image: ceos:4.28.0F
+              image: ceos:4.32.0F
     ```
 
     This way the bind is set only once, and nodes of `ceos` kind will have these binds applied.
@@ -197,10 +197,10 @@ topology:
   nodes:
     ceos1:
       kind: ceos
-      image: ceos:4.28.0F
-    ceos2: 
+      image: ceos:4.32.0F
+    ceos2:
       kind: ceos
-      image: ceos:4.28.0F
+      image: ceos:4.32.0F
   links:
     - endpoints: ["ceos1:eth1_1", "ceos2:eth2_1_1"]
 ```
@@ -293,11 +293,11 @@ It is possible to change the default config which every ceos node will start wit
         # ceos1 will boot with ceos-custom-startup.cfg as set in the kind parameters
         ceos1:
           kind: ceos
-          image: ceos:4.25.0F
+          image: ceos:4.32.0F
         # ceos2 will boot with its own specific startup config, as it overrides the kind variables
-        ceos2: 
+        ceos2:
           kind: ceos
-          image: ceos:4.25.0F
+          image: ceos:4.32.0F
           startup-config: node-specific-startup.cfg
       links:
         - endpoints: ["ceos1:eth1", "ceos2:eth1"]
@@ -314,13 +314,13 @@ To start an Arista cEOS node containerlab uses the following configuration:
 === "Startup command"
     `/sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=1 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MAPETH0=1 systemd.setenv=MGMT_INTF=eth0`
 === "Environment variables"
-    `CEOS:1`  
-    `EOS_PLATFORM":ceoslab`  
-    `container:docker`  
-    `ETBA:1`  
-    `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`  
-    `INTFTYPE:eth`  
-    `MAPETH0:1`  
+    `CEOS:1`
+    `EOS_PLATFORM":ceoslab`
+    `container:docker`
+    `ETBA:1`
+    `SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT:1`
+    `INTFTYPE:eth`
+    `MAPETH0:1`
     `MGMT_INTF:eth0`
 
 ### File mounts
@@ -384,11 +384,11 @@ The following labs feature a cEOS node:
 
 ### cgroups v1
 
-In versions prior to EOS-4.28.0F, the ceos-lab image requires a cgroups v1 environment. For many users, this should not require any changes to the runtime environment. However, some Linux distributions (ref: [#467](https://github.com/srl-labs/containerlab/issues/467)) may be configured to use cgroups v2 out-of-the-box[^4], which will prevent ceos-lab image from booting. In such cases, the users will need to configure their system to utilize a cgroups v1 environment.  
+In versions prior to EOS-4.32.0F, the ceos-lab image requires a cgroups v1 environment. For many users, this should not require any changes to the runtime environment. However, some Linux distributions (ref: [#467](https://github.com/srl-labs/containerlab/issues/467)) may be configured to use cgroups v2 out-of-the-box[^4], which will prevent ceos-lab image from booting. In such cases, the users will need to configure their system to utilize a cgroups v1 environment.
 
 Consult your distribution's documentation for details regarding configuring cgroups v1 in case you see similar startup issues as indicated in [#467](https://github.com/srl-labs/containerlab/issues/467).
 
-Starting with EOS-4.28.0F, ceos-lab will automatically determine whether the container host is using cgroups v1 or cgroups v2 and act appropriately. No configuration is required.
+Starting with EOS-4.32.0F, ceos-lab will automatically determine whether the container host is using cgroups v1 or cgroups v2 and act appropriately. No configuration is required.
 
 ??? "Switching to cgroup v1 in Ubuntu 21.04"
     To switch back to cgroup v1 in Ubuntu 21+ users need to add a kernel parameter `systemd.unified_cgroup_hierarchy=0` to GRUB config. Below is a snippet of `/etc/default/grub` file with the added `systemd.unified_cgroup_hierarchy=0` parameter.
@@ -425,7 +425,7 @@ sudo ip6tables -P INPUT ACCEPT
 
 ### Scale
 
-From version 4.28.0F, the ceos-lab image supports up to 50 nodes per host. On previous releases and/or with higher scale there might be issues cores inside the ceos-lab nodes and errors like `Error: Too many open files`.
+From version 4.32.0F, the ceos-lab image supports up to 50 nodes per host. On previous releases and/or with higher scale there might be issues cores inside the ceos-lab nodes and errors like `Error: Too many open files`.
 
 Example solution for 60 ceos-lab nodes:
 

--- a/docs/manual/kinds/ceos.md
+++ b/docs/manual/kinds/ceos.md
@@ -425,7 +425,7 @@ sudo ip6tables -P INPUT ACCEPT
 
 ### Scale
 
-From version 4.28.0F, the ceos-lab image supports up to 50 nodes per host. On previous releases and/or with higher scale there might be issues cores inside the ceos-lab nodes and erros like `Error: Too many open files`.
+From version 4.28.0F, the ceos-lab image supports up to 50 nodes per host. On previous releases and/or with higher scale there might be issues cores inside the ceos-lab nodes and errors like `Error: Too many open files`.
 
 Example solution for 60 ceos-lab nodes:
 

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -21,7 +21,7 @@ topology:
       image: ghcr.io/nokia/srlinux
     node2:
       kind: ceos             # node2 is of ceos kind
-      image: ceos:4.25F
+      image: ceos:4.32.0F
 
   links:
     - endpoints: ["node1:e1-1", "node2:eth1"]

--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -18,7 +18,7 @@ topology:
       image: ghcr.io/nokia/srlinux
     ceos:
       kind: ceos
-      image: ceos:4.25.0F
+      image: ceos:4.32.0F
 
   links:
     - endpoints: ["srl:e1-1", "ceos:eth1"]
@@ -105,7 +105,7 @@ topology:
       image: ghcr.io/nokia/srlinux
     ceos:                   # this is a name of the 2nd node
       kind: ceos
-      image: ceos:4.25.0F
+      image: ceos:4.32.0F
 ```
 
 We defined individual nodes under the `topology.nodes` container. The name of the node is the key under which it is defined. Following the example, our two nodes are named `srl` and `ceos` respectively.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,7 +44,7 @@ topology:
       image: ghcr.io/nokia/srlinux
     ceos:
       kind: ceos
-      image: ceos:4.25.0F
+      image: ceos:4.32.0F
 
   links:
     - endpoints: ["srl:e1-1", "ceos:eth1"]
@@ -88,9 +88,9 @@ srlceos01.clab.yml
 
 # checking that container images are available
 docker images | grep -E "srlinux|ceos"
-REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-ghcr.io/nokia/srlinux  latest              79019d14cfc7        3 months ago        1.32GB
-ceos                   4.25.0F             15a5f97fe8e8        3 months ago        1.76GB
+REPOSITORY                        TAG        IMAGE ID       CREATED         SIZE
+ceos                              4.32.0F    40d39e1a92c2   24 hours ago    2.4GB
+ghcr.io/nokia/srlinux             latest     b4daaa73edd1   4 weeks ago     2.73GB
 
 # start the lab deployment
 containerlab deploy # (1)!
@@ -108,7 +108,7 @@ After a couple of seconds you will see the summary of the deployed nodes:
 +---+---------------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
 | # |        Name         | Container ID |       Image           | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+---------------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
-| 1 | clab-srlceos01-ceos | 2e2e04a42cea | ceos:4.25.0F          | ceos |       | running | 172.20.20.3/24 | 2001:172:20:20::3/80 |
+| 1 | clab-srlceos01-ceos | 2e2e04a42cea | ceos:4.32.0F          | ceos |       | running | 172.20.20.3/24 | 2001:172:20:20::3/80 |
 | 2 | clab-srlceos01-srl  | 1b9568fcdb01 | ghcr.io/nokia/srlinux | srl  |       | running | 172.20.20.4/24 | 2001:172:20:20::4/80 |
 +---+---------------------+--------------+-----------------------+------+-------+---------+----------------+----------------------+
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -120,7 +120,7 @@ The node name presented in the summary table is the fully qualified node name, i
 Since the topology nodes are regular containers, you can connect to them just like to any other container.
 
 ```bash
-docker exec -it clab-srlceos01-srl1 bash
+docker exec -it clab-srlceos01-srl bash
 ```
 
 !!!info

--- a/lab-examples/srlceos01/srlceos01.clab.yml
+++ b/lab-examples/srlceos01/srlceos01.clab.yml
@@ -8,7 +8,7 @@ topology:
       image: ghcr.io/nokia/srlinux
     ceos:
       kind: arista_ceos
-      image: ceos:4.25.0F
+      image: ceos:4.32.0F
 
   links:
     - endpoints: ["srl:e1-1", "ceos:eth1"]

--- a/tests/03-basic-ceos/03-ceos01-clab.yml
+++ b/tests/03-basic-ceos/03-ceos01-clab.yml
@@ -7,7 +7,7 @@ name: 03-01-two-ceos
 topology:
   kinds:
     ceos:
-      image: ceos:4.28.0F
+      image: ceos:4.32.0F
       env:
         CLAB_MGMT_VRF: MGMT
   nodes:


### PR DESCRIPTION
Fixes https://github.com/srl-labs/containerlab/issues/2033

Arista (4.25.0F) is not present on the Arista website for download. The closest available seems to be 4.25.11M.

In testing 4.25.11M did not have the Cli come up, and it would hang while initializing. The standardizes all Arista labs and docs to reference version 4.32.0F, which is working.