### PR TITLE
Implement Dummy Interface

### DIFF
--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -281,8 +281,9 @@ In addition to these interfaces, tc rules are being provisioned to stitch the vx
 
 ###### dummy
 
-The dummy type creates an interface thats basically wired to /dev/null.
-It can be set up or down, it does not require, neither have a peer interface to be operational up. 
+The dummy type creates a dummy interface that provides a virtual network device to route packets through without actually transmitting them.
+
+Such interfaces are useful for testing and debugging purposes where we want to make sure that the NOS detects network ports, but doesn't actually need to send or receive packets via these ports.
 
 ```yaml
   links:

--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -279,6 +279,23 @@ In addition to these interfaces, tc rules are being provisioned to stitch the vx
       labels: <link-labels>                  # optional (used in templating)
 ```
 
+###### dummy
+
+The dummy type creates an interface thats basically wired to /dev/null.
+It can be set up or down, it does not require, neither have a peer interface to be operational up. 
+
+```yaml
+  links:
+  - type: dummy
+    endpoint:
+      node: <NodeA-Name>                    # mandatory
+      interface: <NodeA-Interface-Name>     # mandatory
+      mac: <NodeA-Interface-Mac>            # optional
+    mtu: <link-mtu>                         # optional
+    vars: <link-variables>                  # optional (used in templating)
+    labels: <link-labels>                   # optional (used in templating)
+```
+
 #### Kinds
 
 Kinds define the behavior and the nature of a node, it says if the node is a specific containerized Network OS, virtualized router or something else. We go into details of kinds in its own [document section](kinds/index.md), so here we will discuss what happens when `kinds` section appears in the topology definition:

--- a/links/endpoint_dummy.go
+++ b/links/endpoint_dummy.go
@@ -1,0 +1,26 @@
+package links
+
+import "context"
+
+type EndpointDummy struct {
+	EndpointGeneric
+}
+
+func NewEndpointDummy(eg *EndpointGeneric) *EndpointDummy {
+	return &EndpointDummy{
+		EndpointGeneric: *eg,
+	}
+}
+
+// Verify verifies the veth based deployment pre-conditions.
+func (e *EndpointDummy) Verify(_ context.Context, _ *VerifyLinkParams) error {
+	return CheckEndpointUniqueness(e)
+}
+
+func (e *EndpointDummy) Deploy(ctx context.Context) error {
+	return e.GetLink().Deploy(ctx, e)
+}
+
+func (e *EndpointDummy) IsNodeless() bool {
+	return false
+}

--- a/links/endpoint_dummy.go
+++ b/links/endpoint_dummy.go
@@ -21,6 +21,6 @@ func (e *EndpointDummy) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
 
-func (e *EndpointDummy) IsNodeless() bool {
+func (*EndpointDummy) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_raw.go
+++ b/links/endpoint_raw.go
@@ -65,8 +65,11 @@ func (er *EndpointRaw) Resolve(params *ResolveParams, l Link) (Endpoint, error) 
 
 	case LinkEndpointTypeVeth:
 		e = NewEndpointVeth(genericEndpoint)
-	}
 
+	}
+	if l.GetType() == LinkTypeDummy {
+		e = NewEndpointDummy(genericEndpoint)
+	}
 	// also add the endpoint to the node
 	node.AddEndpoint(e)
 

--- a/links/link.go
+++ b/links/link.go
@@ -201,6 +201,7 @@ func (ld *LinkDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error
 		if err != nil {
 			return err
 		}
+		l.LinkVxlanRaw.LinkType = LinkTypeVxlanStitch
 		ld.Link = &l.LinkVxlanRaw
 
 	case LinkTypeDummy:

--- a/links/link.go
+++ b/links/link.go
@@ -293,6 +293,15 @@ func (r *LinkDefinition) MarshalYAML() (interface{}, error) {
 			Type:         string(LinkTypeMacVLan),
 		}
 		return x, nil
+	case LinkTypeDummy:
+		x := struct {
+			Type         string `yaml:"type"`
+			LinkDummyRaw `yaml:",inline"`
+		}{
+			LinkDummyRaw: *r.Link.(*LinkDummyRaw),
+			Type:         string(LinkTypeDummy),
+		}
+		return x, nil
 	case LinkTypeBrief:
 		return r.Link, nil
 	}

--- a/links/link.go
+++ b/links/link.go
@@ -56,6 +56,7 @@ const (
 	LinkTypeHost        LinkType = "host"
 	LinkTypeVxlan       LinkType = "vxlan"
 	LinkTypeVxlanStitch LinkType = "vxlan-stitch"
+	LinkTypeDummy       LinkType = "dummy"
 
 	// LinkTypeBrief is a link definition where link types
 	// are encoded in the endpoint definition as string and allow users
@@ -86,6 +87,9 @@ func parseLinkType(s string) (LinkType, error) {
 
 	case string(LinkTypeVxlanStitch):
 		return LinkTypeVxlanStitch, nil
+
+	case string(LinkTypeDummy):
+		return LinkTypeDummy, nil
 
 	default:
 		return "", fmt.Errorf("unable to parse %q as LinkType", s)
@@ -197,8 +201,18 @@ func (ld *LinkDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error
 		if err != nil {
 			return err
 		}
-		l.LinkVxlanRaw.LinkType = LinkTypeVxlanStitch
 		ld.Link = &l.LinkVxlanRaw
+
+	case LinkTypeDummy:
+		var l struct {
+			Type         string `yaml:"type"`
+			LinkDummyRaw `yaml:",inline"`
+		}
+		err := unmarshal(&l)
+		if err != nil {
+			return err
+		}
+		ld.Link = &l.LinkDummyRaw
 
 	case LinkTypeBrief:
 		// brief link's endpoint format

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -61,9 +61,8 @@ func (*LinkDummy) GetType() LinkType {
 	return LinkTypeDummy
 }
 
-// Deploy deploys the dummy link
+// Deploy deploys the dummy link.
 func (l *LinkDummy) Deploy(ctx context.Context, ep Endpoint) error {
-
 	log.Debugf("Creating Endpoint: %s ( --> dummy )", ep)
 
 	// build the netlink.Dummy struct for the link provisioning

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -1,0 +1,118 @@
+package links
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// LinkVEthRaw is the raw (string) representation of a veth link as defined in the topology file.
+type LinkDummyRaw struct {
+	LinkCommonParams `yaml:",inline"`
+	Endpoint         *EndpointRaw `yaml:"endpoint"`
+}
+
+func (*LinkDummyRaw) GetType() LinkType {
+	return LinkTypeVEth
+}
+
+// Resolve resolves the raw veth link definition into a Link interface that is implemented
+// by a concrete LinkVEth struct.
+// Resolving a veth link resolves its endpoints.
+func (r *LinkDummyRaw) Resolve(params *ResolveParams) (Link, error) {
+	// filtered true means the link is in the filter provided by a user
+	// aka it should be resolved/created/deployed
+	filtered := isInFilter(params, []*EndpointRaw{r.Endpoint})
+	if !filtered {
+		return nil, nil
+	}
+
+	// create LinkVEth struct
+	l := NewLinkDummy()
+	l.LinkCommonParams = r.LinkCommonParams
+
+	// resolve raw endpoints (epr) to endpoints (ep)
+	ep, err := r.Endpoint.Resolve(params, l)
+	if err != nil {
+		return nil, err
+	}
+	// add endpoint to the link endpoints
+	l.Endpoints = append(l.Endpoints, ep)
+
+	// set default link mtu if MTU is unset
+	if l.MTU == 0 {
+		l.MTU = DefaultLinkMTU
+	}
+
+	return l, nil
+}
+
+type LinkDummy struct {
+	LinkCommonParams
+	Endpoints []Endpoint
+}
+
+func NewLinkDummy() *LinkDummy {
+	return &LinkDummy{}
+}
+
+func (*LinkDummy) GetType() LinkType {
+	return LinkTypeDummy
+}
+
+// Deploy deploys the veth link by creating the A and B sides of the veth pair independently
+// based on the calling endpoint.
+func (l *LinkDummy) Deploy(ctx context.Context, ep Endpoint) error {
+
+	log.Debugf("Creating Endpoint: %s ( --> dummy )", ep)
+
+	// build the netlink.Veth struct for the link provisioning
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: ep.GetRandIfaceName(),
+			MTU:  l.MTU,
+			// Mac address is set later on
+		},
+	}
+
+	// add the link
+	err := netlink.LinkAdd(link)
+	if err != nil {
+		return err
+	}
+
+	// the link needs to be moved to the relevant network namespace
+	// and enabled (up). This is done via linkSetupFunc.
+	// based on the endpoint type the link setup function is different.
+	// linkSetupFunc is executed in a netns of a node.
+	// if the node is a regular namespace node
+	// add link to node, rename, set mac and Up
+	err = ep.GetNode().AddLinkToContainer(ctx, link,
+		SetNameMACAndUpInterface(link, ep))
+	if err != nil {
+		return err
+	}
+
+	l.DeploymentState = LinkDeploymentStateHalfDeployed
+
+	return nil
+}
+
+func (l *LinkDummy) Remove(ctx context.Context) error {
+	if l.DeploymentState == LinkDeploymentStateRemoved {
+		return nil
+	}
+	for _, ep := range l.GetEndpoints() {
+		err := ep.Remove(ctx)
+		if err != nil {
+			log.Debug(err)
+		}
+	}
+	l.DeploymentState = LinkDeploymentStateRemoved
+	return nil
+}
+
+func (l *LinkDummy) GetEndpoints() []Endpoint {
+	return l.Endpoints
+}

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// LinkVEthRaw is the raw (string) representation of a veth link as defined in the topology file.
+// LinkDummyRaw is the raw (string) representation of a dummy link as defined in the topology file.
 type LinkDummyRaw struct {
 	LinkCommonParams `yaml:",inline"`
 	Endpoint         *EndpointRaw `yaml:"endpoint"`
@@ -18,8 +18,8 @@ func (*LinkDummyRaw) GetType() LinkType {
 }
 
 // Resolve resolves the raw veth link definition into a Link interface that is implemented
-// by a concrete LinkVEth struct.
-// Resolving a veth link resolves its endpoints.
+// by a concrete LinkDummyRaw struct.
+// Resolving a dummy links endpoints.
 func (r *LinkDummyRaw) Resolve(params *ResolveParams) (Link, error) {
 	// filtered true means the link is in the filter provided by a user
 	// aka it should be resolved/created/deployed
@@ -28,7 +28,7 @@ func (r *LinkDummyRaw) Resolve(params *ResolveParams) (Link, error) {
 		return nil, nil
 	}
 
-	// create LinkVEth struct
+	// create LinkDummyRaw struct
 	l := NewLinkDummy()
 	l.LinkCommonParams = r.LinkCommonParams
 
@@ -61,13 +61,12 @@ func (*LinkDummy) GetType() LinkType {
 	return LinkTypeDummy
 }
 
-// Deploy deploys the veth link by creating the A and B sides of the veth pair independently
-// based on the calling endpoint.
+// Deploy deploys the dummy link
 func (l *LinkDummy) Deploy(ctx context.Context, ep Endpoint) error {
 
 	log.Debugf("Creating Endpoint: %s ( --> dummy )", ep)
 
-	// build the netlink.Veth struct for the link provisioning
+	// build the netlink.Dummy struct for the link provisioning
 	link := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: ep.GetRandIfaceName(),

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -55,6 +55,7 @@ func (r *LinkVEthRaw) Resolve(params *ResolveParams) (Link, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		// add endpoint to the link endpoints
 		l.Endpoints = append(l.Endpoints, ep)
 	}

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -139,29 +139,39 @@ Verify links in node l2
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${runtime-cli-exec-cmd} clab-${lab-name}-l2 ip link show eth2
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${runtime-cli-exec-cmd} clab-${lab-name}-l2 ip link show eth3
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
     Should Contain    ${output}    02:00:00:00:00:01
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${runtime-cli-exec-cmd} clab-${lab-name}-l2 ip link show eth4
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
     Should Contain    ${output}    02:00:00:00:00:04
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${runtime-cli-exec-cmd} clab-${lab-name}-l2 ip link show eth5
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
     Should Contain    ${output}    02:00:00:00:00:05
+
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime-cli-exec-cmd} clab-${lab-name}-l2 ip link show somedummy
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    LOWER_UP
 
 Verify links on host
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -30,6 +30,7 @@ topology:
         retries: 1
         interval: 5
         timeout: 2
+
     l2:
       kind: linux
       image: nginx:stable-alpine
@@ -77,3 +78,7 @@ topology:
         node: l2
         interface: eth5
         mac: 02:00:00:00:00:05
+    - type: dummy
+      endpoint:
+        node: l2
+        interface: somedummy


### PR DESCRIPTION
The Linux Dummy interface is the /dev/null of network interfaces.
It can be used if you need a certain amount of interfaces. They can be set to operational up without requiring a peer endpoint.