### PR TITLE
Add vJunos-Router kind based on existing vJunos-switch implementation

### DIFF
--- a/clab/register.go
+++ b/clab/register.go
@@ -36,6 +36,7 @@ import (
 	vr_sros "github.com/srl-labs/containerlab/nodes/vr_sros"
 	vr_veos "github.com/srl-labs/containerlab/nodes/vr_veos"
 	vr_vjunosevolved "github.com/srl-labs/containerlab/nodes/vr_vjunosevolved"
+	vr_vjunosrouter "github.com/srl-labs/containerlab/nodes/vr_vjunosrouter"
 	vr_vjunosswitch "github.com/srl-labs/containerlab/nodes/vr_vjunosswitch"
 	vr_vmx "github.com/srl-labs/containerlab/nodes/vr_vmx"
 	vr_vqfx "github.com/srl-labs/containerlab/nodes/vr_vqfx"
@@ -76,6 +77,7 @@ func (c *CLab) RegisterNodes() {
 	vr_vmx.Register(c.Reg)
 	vr_vsrx.Register(c.Reg)
 	vr_vqfx.Register(c.Reg)
+	vr_vjunosrouter.Register(c.Reg)
 	vr_vjunosswitch.Register(c.Reg)
 	vr_vjunosevolved.Register(c.Reg)
 	vr_xrv.Register(c.Reg)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -39,7 +39,7 @@ var interfaceFormat = map[string]string{
 
 var supportedKinds = []string{
 	"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros", "vr-vmx", "vr-vsrx",
-	"vr-vqfx", "vr-vjunosevo", "vr-vjunosrouter", "vr-vjunosswitch", "vr-xrv9k", "vr-veos",
+	"vr-vqfx", "vr-vjunosevolved", "vr-vjunosrouter", "vr-vjunosswitch", "vr-xrv9k", "vr-veos",
 	"xrd", "rare", "openbsd", "cisco_ftdv", "freebsd",
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -39,8 +39,8 @@ var interfaceFormat = map[string]string{
 
 var supportedKinds = []string{
 	"srl", "ceos", "linux", "bridge", "sonic-vs", "crpd", "vr-sros", "vr-vmx", "vr-vsrx",
-	"vr-vqfx", "vr-vjunosswitch", "vr-xrv9k", "vr-veos", "xrd", "rare", "openbsd", "cisco_ftdv",
-	"freebsd",
+	"vr-vqfx", "vr-vjunosevo", "vr-vjunosrouter", "vr-vjunosswitch", "vr-xrv9k", "vr-veos",
+	"xrd", "rare", "openbsd", "cisco_ftdv", "freebsd",
 }
 
 const (

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,8 +36,9 @@ In addition to native containerized NOSes, containerlab can launch traditional v
 * [Juniper vMX](manual/kinds/vr-vmx.md)
 * [Juniper vQFX](manual/kinds/vr-vqfx.md)
 * [Juniper vSRX](manual/kinds/vr-vsrx.md)
-* [Juniper vJunos Switch](manual/kinds/vr-vjunosswitch.md)
-* [Juniper vJunos Evolved](manual/kinds/vr-vjunosevolved.md)
+* [Juniper vJunos-Router](manual/kinds/vr-vjunosrouter.md)
+* [Juniper vJunos-Switch](manual/kinds/vr-vjunosswitch.md)
+* [Juniper vJunosEvolved](manual/kinds/vr-vjunosevolved.md)
 * [Cisco IOS XRv9k](manual/kinds/vr-xrv9k.md)
 * [Cisco Nexus 9000v](manual/kinds/vr-n9kv.md)
 * [Cisco c8000v](manual/kinds/vr-c8000v.md)
@@ -68,38 +69,38 @@ This short clip briefly demonstrates containerlab features and explains its purp
 
 ## Features
 
-* **IaaC approach**  
+* **IaaC approach**
     Declarative way of defining the labs by means of the topology definition [`clab` files](manual/topo-def-file.md).
-* **Network Operating Systems centric**  
+* **Network Operating Systems centric**
     Focus on containerized Network Operating Systems. The sophisticated startup requirements of various NOS containers are abstracted with [kinds](manual/kinds/index.md) which allows the user to focus on the use cases, rather than infrastructure hurdles.
-* **VM based nodes friendly**  
+* **VM based nodes friendly**
     With the [vrnetlab integration](manual/vrnetlab.md) it is possible to get the best of two worlds - running virtualized and containerized nodes alike with the same IaaC approach and workflows.
-* **Multi-vendor and open**  
+* **Multi-vendor and open**
     Although being kick-started by Nokia engineers, containerlab doesn't take sides and supports NOSes from other vendors and opensource projects.
-* **Lab orchestration**  
+* **Lab orchestration**
     Starting the containers and interconnecting them alone is already good, but containerlab packages even more features like managing lab lifecycle: [deploy](cmd/deploy.md), [destroy](cmd/destroy.md), [save](cmd/save.md), [inspect](cmd/inspect.md), [graph](cmd/graph.md) operations.
-* **Scaled labs generator**  
+* **Scaled labs generator**
     With [`generate`](cmd/generate.md) capabilities of containerlab it possible to define/launch CLOS-based topologies of arbitrary scale. Just say how many tiers you need and how big each tier is, the rest will be done in a split second.
-* **Simplicity and convenience**  
+* **Simplicity and convenience**
     Starting from frictionless [installation](install.md) and [upgrade](install.md#upgrade) capabilities and ranging to the behind-the-scenes [link wiring machinery](manual/network.md), containerlab does its best for you to enjoy the tool.
-* **Fast**  
+* **Fast**
     Blazing fast way to create container based labs on any Linux system with Docker.
-* **Automated TLS certificates provisioning**  
+* **Automated TLS certificates provisioning**
     The nodes which require TLS certs will get them automatically on boot.
-* **Documentation is a first-class citizen**  
+* **Documentation is a first-class citizen**
     We do not let our users guess by making a complete, concise and clean [documentation](https://containerlab.dev).
-* **Lab catalog**  
+* **Lab catalog**
    The "most-wanted" lab topologies are [documented and included](lab-examples/lab-examples.md) with containerlab installation. Based on this cherry-picked selection you can start crafting the labs answering your needs.
 
 ## Use cases
 
-* **Labs and demos**  
+* **Labs and demos**
     Containerlab was meant to be a tool for provisioning networking labs built with containers. It is free, open and ubiquitous. No software apart from Docker is required!
     As with any lab environment it allows the users to validate features, topologies, perform interop testing, datapath testing, etc.
     It is also a perfect companion for your next demo. Deploy the lab fast, with all its configuration stored as a code -> destroy when done. Easily and [securely share lab access](manual/published-ports.md) if needed.
-* **Testing and CI**  
+* **Testing and CI**
     Because of the containerlab's single-binary packaging and code-based lab definition files, it was never that easy to spin up a test bed for CI. Gitlab CI, Github Actions and virtually any CI system will be able to spin up containerlab topologies in a single simple command.
-* **Telemetry validation**  
+* **Telemetry validation**
     Coupling modern telemetry stacks with containerlab labs make a perfect fit for Telemetry use cases validation. Spin up a lab with containerized network functions with a telemetry on the side, and run comprehensive telemetry use cases.
 
 ## Join us

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -41,6 +41,7 @@ Within each predefined kind, we store the necessary information that is used to 
 | **Juniper vMX**            | [`vr-vmx/vr-juniper_vmx`](vr-vmx.md)                            | supported |    VM     |
 | **Juniper vQFX**           | [`vr-vqfx/vr-juniper_vqfx`](vr-vqfx.md)                         | supported |    VM     |
 | **Juniper vSRX**           | [`vr-vsrx/vr-juniper_vsrx`](vr-vsrx.md)                         | supported |    VM     |
+| **Juniper vJunos-router**  | [`vr-vjunosrouter/juniper_vjunosrouter`](vr-vjunosrouter.md)    | supported |    VM     |
 | **Juniper vJunos-switch**  | [`vr-vjunosswitch/juniper_vjunosswitch`](vr-vjunosswitch.md)    | supported |    VM     |
 | **Juniper vJunosEvolved**  | [`vr-vjunosevolved/juniper_vjunosevolved`](vr-vjunosevolved.md) | supported |    VM     |
 | **Cisco XRd**              | [`xrd/cisco_xrd'](xrd.md)                                       | supported | container |

--- a/docs/manual/kinds/vr-vjunosrouter.md
+++ b/docs/manual/kinds/vr-vjunosrouter.md
@@ -1,0 +1,79 @@
+---
+search:
+  boost: 4
+---
+# Juniper vJunos-router
+
+[Juniper vJunos-router](https://support.juniper.net/support/downloads/?p=vjunos) is a virtualized MX router, a single-VM version of the vMX that can be freely downloaded, requires no feature licenses and is meant for lab/testing use. It is identified with `juniper_vjunosrouter` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a Qemu VM packaged in a docker container format.
+
+Juniper vJunos-router nodes launched with containerlab come up pre-provisioned with SSH, SNMP, NETCONF and gNMI services enabled.
+
+## How to obtain the image
+
+The qcow2 image can be downloaded from [Juniper website](https://support.juniper.net/support/downloads/?p=vjunos-router) and built with [vrnetlab](../vrnetlab.md).
+
+## Managing Juniper vJunos-router nodes
+
+!!!note
+    Containers with vJunos-router inside can take up to ~5-10min to fully boot.
+    You can monitor the progress with `docker logs -f <container-name>`.
+
+Juniper vJunos-router node launched with containerlab can be managed via the following interfaces:
+
+=== "bash"
+    to connect to a `bash` shell of a running Juniper vJunos-router container:
+    ```bash
+    docker exec -it <container-name/id> bash
+    ```
+=== "CLI via SSH"
+    to connect to the vJunos-router CLI
+    ```bash
+    ssh admin@<container-name/id>
+    ```
+=== "NETCONF"
+    NETCONF server is running over port 830
+    ```bash
+    ssh admin@<container-name> -p 830 -s netconf
+    ```
+
+!!!info
+    Default user credentials: `admin:admin@123`
+
+## Interfaces mapping
+
+Juniper vJunos-router container can have up to 11 interfaces and uses the following mapping rules:
+
+* `eth0` - management interface connected to the containerlab management network
+* `eth1` - first data interface, mapped to a first data port of vJunos-router VM
+* `eth2+` - second and subsequent data interface
+
+When containerlab launches Juniper vJunos-router node, it will assign IPv4/6 address to the `eth0` interface. These addresses can be used to reach the management plane of the router.
+
+Data interfaces `eth1+` need to be configured with IP addressing manually using CLI/management protocols or via a startup-config text file.
+
+## Features and options
+
+### Node configuration
+
+Juniper vJunos-router nodes come up with a basic configuration supplied by a mountable configuration disk to the main VM image. Users, management interfaces, and protocols such as SSH and NETCONF are configured.
+
+#### Startup configuration
+
+It is possible to make vJunos-router nodes boot up with a user-defined startup-config instead of a built-in one. With a [`startup-config`](../nodes.md#startup-config) property of the node/kind user sets the path to the config file that will be mounted to a container and used as a startup-config:
+
+```yaml
+topology:
+  nodes:
+    node:
+      kind: juniper_vjunosrouter
+      startup-config: myconfig.txt
+```
+
+With this knob containerlab is instructed to take a file `myconfig.txt` from the directory that hosts the topology file, and copy it to the lab directory for that specific node under the `/config/startup-config.cfg` name. Then the directory that hosts the startup-config dir is mounted to the container. This will result in this config being applied at startup by the node.
+
+Configuration is applied after the node is started, thus it can contain partial configuration snippets that you desire to add on top of the default config that a node boots up with.
+
+## Known issues and limitations
+
+* vJunos-router requires Linux kernel 4.17+
+* To check the boot log, use `docker logs -f <node-name>`.

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -53,8 +53,8 @@ The following table provides a link between the version combinations:
 | `0.54.0`         | [`0.16.0`](https://github.com/hellt/vrnetlab/releases/tag/v0.16.0) | Added support for Cisco c8000v                                                                                                                                       |
 
 ???note "how to understand version inter-dependency between containerlab and vrnetlab?"
-    When new VM-based platform support is added to vrnetlab, it is usually accompanied by a new containerlab version. In this case the table row will have both containerlab and vrnetlab versions.  
-    When vrnetlab adds new features that don't require containerlab changes, the table will have only vrnetlab version.  
+    When new VM-based platform support is added to vrnetlab, it is usually accompanied by a new containerlab version. In this case the table row will have both containerlab and vrnetlab versions.
+    When vrnetlab adds new features that don't require containerlab changes, the table will have only vrnetlab version.
     When containerlab adds new features that don't require vrnetlab changes, the table will not list containerlab version.
 
     It is worth noting, that you can use the latest containerlab version with a given vrnetlab version, even if the table doesn't list the latest containerlab version.
@@ -67,7 +67,7 @@ To build a vrnetlab image compatible with containerlab, users first need to ensu
 
    ```bash
    git clone https://github.com/hellt/vrnetlab && cd vrnetlab
-   
+
    # assuming we are running containerlab 0.11.0,
    # the latest compatible vrnetlab version is 0.2.3
    # at the moment of this writing
@@ -92,6 +92,7 @@ The images that work with containerlab will appear in the supported list as we i
 | Juniper vMX           | [juniper_vmx](kinds/vr-vmx.md)                          | [SRL & vMX](../lab-examples/vr-vmx.md)     |                                                                                                                                                                                                              |
 | Juniper vQFX          | [juniper_vqfx](kinds/vr-vqfx.md)                        |                                            |                                                                                                                                                                                                              |
 | Juniper vSRX          | [juniper_vsrx](kinds/vr-vsrx.md)                        |                                            |                                                                                                                                                                                                              |
+| Juniper vJunos-Router | [juniper_vjunosrouter](kinds/vr-vjunosrouter.md)        |                                            |                                                                                                                                                                                                              |
 | Juniper vJunos-Switch | [juniper_vjunosswitch](kinds/vr-vjunosswitch.md)        |                                            |                                                                                                                                                                                                              |
 | Juniper vJunosEvolved | [juniper_vjunosevolved](kinds/vr-vjunosevolved.md)      |                                            |                                                                                                                                                                                                              |
 | Cisco XRv             | [cisco_xrv](kinds/vr-xrv.md)                            | [SRL & XRv](../lab-examples/vr-xrv.md)     |                                                                                                                                                                                                              |
@@ -117,7 +118,7 @@ Containerlab offers several ways of connecting VM-based routers with the rest of
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:6,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/vrnetlab.drawio&quot;}"></div>
 
 ??? "Any other datapaths?"
-    Although `tc` based datapath should cover all the needed connectivity requirements, if other bridge-like datapaths are needed, Containerlab offers OpenvSwitch and Linux bridge modes.  
+    Although `tc` based datapath should cover all the needed connectivity requirements, if other bridge-like datapaths are needed, Containerlab offers OpenvSwitch and Linux bridge modes.
     Users can plug in those datapaths by specifying `CONNECTION_MODE` env variable:
     ```yaml
     # the env variable can also be set in the defaults section

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
           - Juniper vMX: manual/kinds/vr-vmx.md
           - Juniper vQFX: manual/kinds/vr-vqfx.md
           - Juniper vSRX: manual/kinds/vr-vsrx.md
+          - Juniper vJunos-router: manual/kinds/vr-vjunosrouter.md
           - Juniper vJunos-switch: manual/kinds/vr-vjunosswitch.md
           - Juniper vJunosEvolved: manual/kinds/vr-vjunosevolved.md
           - Cisco XRd: manual/kinds/xrd.md

--- a/nodes/vr_vjunosevolved/vr-vjunosevolved.go
+++ b/nodes/vr_vjunosevolved/vr-vjunosevolved.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"juniper_vjunosevolved"}
+	kindnames          = []string{"juniper_vjunosevolved", "vr-juniper_vjunosevolved", "vr-vjunosevolved"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 )
 

--- a/nodes/vr_vjunosrouter/vr-vjunosrouter.go
+++ b/nodes/vr_vjunosrouter/vr-vjunosrouter.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vr_vjunosrouter
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/netconf"
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindnames          = []string{"juniper_vjunosrouter"}
+	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
+)
+
+const (
+	scrapliPlatformName = "juniper_junos"
+
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
+		return new(vrVJUNOSROUTER)
+	}, defaultCredentials)
+}
+
+type vrVJUNOSROUTER struct {
+	nodes.DefaultNode
+}
+
+func (n *vrVJUNOSROUTER) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init DefaultNode
+	n.DefaultNode = *nodes.NewDefaultNode(n)
+	// set virtualization requirement
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+	// env vars are used to set launch.py arguments in vrnetlab container
+	defEnv := map[string]string{
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
+		"CONNECTION_MODE":    nodes.VrDefConnMode,
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+	}
+	n.Cfg.Env = utils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	// mount config dir to support startup-config functionality
+	n.Cfg.Binds = append(n.Cfg.Binds, fmt.Sprint(path.Join(n.Cfg.LabDir, configDirName), ":/config"))
+
+	if n.Cfg.Env["CONNECTION_MODE"] == "macvtap" {
+		// mount dev dir to enable macvtap
+		n.Cfg.Binds = append(n.Cfg.Binds, "/dev:/dev")
+	}
+
+	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
+		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), n.Cfg.ShortName, n.Cfg.Env["CONNECTION_MODE"])
+
+	return nil
+}
+
+func (n *vrVJUNOSROUTER) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
+	utils.CreateDirectory(n.Cfg.LabDir, 0777)
+	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
+	if err != nil {
+		return nil
+	}
+	return nodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
+}
+
+func (n *vrVJUNOSROUTER) SaveConfig(_ context.Context) error {
+	err := netconf.SaveConfig(n.Cfg.LongName,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
+		scrapliPlatformName,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("saved %s running configuration to startup configuration file\n", n.Cfg.ShortName)
+	return nil
+}
+
+// CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
+func (n *vrVJUNOSROUTER) CheckInterfaceName() error {
+	return nodes.GenericVMInterfaceCheck(n.Cfg.ShortName, n.Endpoints)
+}

--- a/nodes/vr_vjunosrouter/vr-vjunosrouter.go
+++ b/nodes/vr_vjunosrouter/vr-vjunosrouter.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"juniper_vjunosrouter"}
+	kindnames          = []string{"juniper_vjunosrouter", "vr-juniper_vjunosrouter", "vr-vjunosrouter"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 )
 

--- a/nodes/vr_vjunosswitch/vr-vjunosswitch.go
+++ b/nodes/vr_vjunosswitch/vr-vjunosswitch.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"juniper_vjunosswitch"}
+	kindnames          = []string{"juniper_vjunosswitch", "vr-juniper_vjunosswitch", "vr-vjunosswitch"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 )
 

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -56,6 +56,8 @@
                         "vr-vjunosswitch",
                         "vr-juniper_vjunosswitch",
                         "juniper_vjunosswitch",
+                        "vr-vjunosevolved",
+                        "vr-juniper_vjunosevolved",
                         "juniper_vjunosevolved",
                         "vr-xrv",
                         "vr-cisco_xrv",

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -50,6 +50,9 @@
                         "vr-vsrx",
                         "vr-juniper_vsrx",
                         "juniper_vsrx",
+                        "vr-vjunosrouter",
+                        "vr-juniper_vjunosrouter",
+                        "juniper_vjunosrouter",
                         "vr-vjunosswitch",
                         "vr-juniper_vjunosswitch",
                         "juniper_vjunosswitch",
@@ -900,6 +903,9 @@
                             "$ref": "#/definitions/node-config"
                         },
                         "vr-vsrx": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "juniper_vjunosrouter": {
                             "$ref": "#/definitions/node-config"
                         },
                         "juniper_vjunosswitch": {


### PR DESCRIPTION
This PR adds a vJunos-Router kind to match the recently added vrnetlab image: https://github.com/hellt/vrnetlab/pull/196

Since both vJunos-Switch and vJunos-Router images are handled identically by containerlab, alternatively the two kinds could be merged into a "vJunos-Classic" image; however, this difference in naming might be more confusing to users.

This PR also contains some minor fixes to syntactic fixes to the documentation and adds short name support for other vJunos kinds.