### PR TITLE
Patch 0.55.1

### DIFF
--- a/docs/rn/0.55.md
+++ b/docs/rn/0.55.md
@@ -67,3 +67,11 @@ Netconf has been enabled by default for cRPD. #2015
 - cEOS examples have been updated to use 4.32.0F version #2034
 - package repo links have been updated to enable v6 access #2032
 - codespaces image have been added #2058 #2059 #2064 #2067
+
+## Patches
+
+### 0.55.1
+
+- fixed ACL rules generation for SR Linux in cases where no ssh keys are present #2103
+- switched to D2L platform as the default for SR Linux #2094
+- added impairments docs section

--- a/nodes/srl/version.go
+++ b/nodes/srl/version.go
@@ -159,7 +159,7 @@ func (n *srl) setVersionSpecificParams(tplData *srlTemplateData) {
 
 	// in srlinux >= v24.3+ we add ACL rules to enable http and telnet access
 	// that are useful for labs and were removed as a security hardening measure.
-	if len(n.sshPubKeys) > 0 && (semver.Compare(v, "v24.3") >= 0 || n.swVersion.major == "0") {
+	if semver.Compare(v, "v24.3") >= 0 || n.swVersion.major == "0" {
 		tplData.ACLConfig = aclConfig
 	}
 


### PR DESCRIPTION
Remove erroneous dependency on ssh keys when deciding to generate ACL rules for SR Linux >=24.3