### PR TITLE
Add Ostinato traffic generator as a supported node

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Containerlab focuses on the containerized Network Operating Systems which are ty
 * [Cumulus VX](https://containerlab.dev/manual/kinds/cvx/)
 * [Keysight IXIA-C](https://containerlab.dev/manual/kinds/keysight_ixia-c-one/)
 * [RARE/FreeRtr](https://containerlab.dev/manual/kinds/rare-freertr/)
+* [Ostinato](https://containerlab.dev/manual/kinds/ostinato/)
 
 In addition to native containerized NOSes, containerlab can launch traditional virtual machine based routers using [vrnetlab or boxen integration](https://containerlab.dev/manual/vrnetlab/):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Containerlab focuses on the containerized Network Operating Systems which are ty
 * [Cumulus VX](manual/kinds/cvx.md)
 * [Keysight IXIA-C](manual/kinds/keysight_ixia-c-one.md)
 * [RARE/freeRtr](manual/kinds/rare-freertr.md)
+* [Ostinato](manual/kinds/ostinato.md)
 
 In addition to native containerized NOSes, containerlab can launch traditional virtual machine based routers using [vrnetlab or boxen integration](manual/vrnetlab.md):
 

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -59,6 +59,7 @@ Within each predefined kind, we store the necessary information that is used to 
 | **IPInfusion OcNOS**       | [`ipinfusion_ocnos`](ipinfusion-ocnos.md)                       | supported |    VM     |
 | **OpenBSD**                | [`openbsd`](openbsd.md)                                         | supported |    VM     |
 | **Keysight ixia-c-one**    | [`keysight_ixia-c-one`](keysight_ixia-c-one.md)                 | supported | container |
+| **Ostinato**               | [`linux`](ostinato.md)                                          | supported | container |
 | **Check Point Cloudguard** | [`checkpoint_cloudguard`](checkpoint_cloudguard.md)             | supported |    VM     |
 | **Fortinet Fortigate**     | [`fortinet_fortigate`](fortinet_fortigate.md)                   | supported |    VM     |
 | **Palo Alto PAN**          | [`vr-panos/vr-paloalto_panos`](vr-pan.md)                       | supported |    VM     |

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -44,7 +44,7 @@ Within each predefined kind, we store the necessary information that is used to 
 | **Juniper vJunos-router**  | [`vr-vjunosrouter/juniper_vjunosrouter`](vr-vjunosrouter.md)    | supported |    VM     |
 | **Juniper vJunos-switch**  | [`vr-vjunosswitch/juniper_vjunosswitch`](vr-vjunosswitch.md)    | supported |    VM     |
 | **Juniper vJunosEvolved**  | [`vr-vjunosevolved/juniper_vjunosevolved`](vr-vjunosevolved.md) | supported |    VM     |
-| **Cisco XRd**              | [`xrd/cisco_xrd'](xrd.md)                                       | supported | container |
+| **Cisco XRd**              | [`xrd/cisco_xrd`](xrd.md)                                       | supported | container |
 | **Cisco XRv9k**            | [`vr-xrv9k/vr-cisco_xrv9k`](vr-xrv9k.md)                        | supported |    VM     |
 | **Cisco XRv**              | [`vr-xrv/vr-cisco_xrv`](vr-xrv.md)                              | supported |    VM     |
 | **Cisco CSR1000v**         | [`vr-csr/vr-cisco_csr1000v`](vr-csr.md)                         | supported |    VM     |

--- a/docs/manual/kinds/ostinato.md
+++ b/docs/manual/kinds/ostinato.md
@@ -7,12 +7,14 @@ search:
 [Ostinato](https://ostinato.org/) network traffic generator is currently identified with `linux` kind in the [topology file](../topo-def-file.md). This will change to its own kind in the future.
 
 ## Getting Ostinato image
+
 Ostinato for containerlab image is a paid (_but inexpensive_) offering and can be obtained from the [Ostinato for Containerlab](https://ostinato.org/pricing/clab) section of the Ostinato website. Follow the instructions on the page to install the image.
 
 ## Topology definition
+
 Add a topology definition for the Ostinato node in `.clab.yml` as shown below -
-```
-. . .
+
+```yaml
 topology:
   nodes:
     ost:
@@ -21,12 +23,12 @@ topology:
       ports:
         - 5900:5900/tcp
         - 7878:7878/tcp
-. . .
 ```
 
 Replace `{tag}` above with the tag shown in the output of `docker images`
 
 ## Managing Ostinato nodes
+
 Ostinato has a GUI and a Python API. The Ostinato image includes both the Ostinato agent (called _Drone_) which does the actual traffic generation and the Ostinato GUI that is used to configure and monitor the Drone agent.
 
 The GUI is the primary way to work with Ostinato and is accessible over VNC. To use the Ostinato API, you will need [Ostinato PyApi](https://ostinato.org/pricing/pyapi).
@@ -46,23 +48,26 @@ To manage the Ostinato node using the Ostinato Python API, you will typically wr
 /// tab | shell
 You can login to the shell of the Ostinato node for any troubleshooting, if required.
 Ostinato **does not have any CLI or commands to generate traffic - use the GUI** (or API).
+
 ```
 docker exec -it <container-name/id> bash
 ```
+
 Credentials: `ostinatotg/ostinatotg`
 ///
 
-
 ## Interfaces mapping
+
 Ostinato container includes the following interfaces -
 
 * `eth0` - management interface (should NOT be used for data traffic)
 * `eth1+` - data interfaces to connect to other nodes for traffic generation
 
 ## File mounts
+
 Ostinato allows you to save and load files - traffic streams, pcaps and session files. To ensure persistence of these files (after a lab is destroyed), mount a directory on the host to a directory inside the container as shown in the example below -
-```
-. . .
+
+```yaml
 topology:
   nodes:
     ost:
@@ -73,13 +78,14 @@ topology:
         - 7878:7878/tcp
       binds:
         - /some/dir/on/host:/some/path/in/container
-. . .
 ```
 
-You can read more about [node binds](../nodes/#binds)
+You can read more about [node binds](../nodes.md#binds)
 
 ## Lab examples
-TODO
+
+Coming soon...
 
 ## More
+
 You can find more information including how to run the Ostinato GUI natively on your Windows/MacOS laptop to manage the Ostinato agent running inside containterlab on the [Ostinato for Containerlab](https://ostinato.org/pricing/clab) page.

--- a/docs/manual/kinds/ostinato.md
+++ b/docs/manual/kinds/ostinato.md
@@ -1,0 +1,85 @@
+---
+search:
+  boost: 4
+---
+# Ostinato
+
+[Ostinato](https://ostinato.org/) network traffic generator is currently identified with `linux` kind in the [topology file](../topo-def-file.md). This will change to its own kind in the future.
+
+## Getting Ostinato image
+Ostinato for containerlab image is a paid (_but inexpensive_) offering and can be obtained from the [Ostinato for Containerlab](https://ostinato.org/pricing/clab) section of the Ostinato website. Follow the instructions on the page to install the image.
+
+## Topology definition
+Add a topology definition for the Ostinato node in `.clab.yml` as shown below -
+```
+. . .
+topology:
+  nodes:
+    ost:
+      kind: linux
+      image: ostinato/ostinato:{tag}
+      ports:
+        - 5900:5900/tcp
+        - 7878:7878/tcp
+. . .
+```
+
+Replace `{tag}` above with the tag shown in the output of `docker images`
+
+## Managing Ostinato nodes
+Ostinato has a GUI and a Python API. The Ostinato image includes both the Ostinato agent (called _Drone_) which does the actual traffic generation and the Ostinato GUI that is used to configure and monitor the Drone agent.
+
+The GUI is the primary way to work with Ostinato and is accessible over VNC. To use the Ostinato API, you will need [Ostinato PyApi](https://ostinato.org/pricing/pyapi).
+
+/// tab | Using GUI
+Once the lab is deployed, connect any VNC client to `<host-ip>:5900` - this will bring up the Ostinato GUI.
+
+![Ostinato GUI](https://ostinato.org/images/ostinato-clab.png)
+
+The GUI only lists the data interfaces and hence, `eth0` will not be included
+///
+
+/// tab | Using Python API
+To manage the Ostinato node using the Ostinato Python API, you will typically write a script using the API and run it on the same or different host connecting to the Drone agent via the management interface
+///
+
+/// tab | shell
+You can login to the shell of the Ostinato node for any troubleshooting, if required.
+Ostinato **does not have any CLI or commands to generate traffic - use the GUI** (or API).
+```
+docker exec -it <container-name/id> bash
+```
+Credentials: `ostinatotg/ostinatotg`
+///
+
+
+## Interfaces mapping
+Ostinato container includes the following interfaces -
+
+* `eth0` - management interface (should NOT be used for data traffic)
+* `eth1+` - data interfaces to connect to other nodes for traffic generation
+
+## File mounts
+Ostinato allows you to save and load files - traffic streams, pcaps and session files. To ensure persistence of these files (after a lab is destroyed), mount a directory on the host to a directory inside the container as shown in the example below -
+```
+. . .
+topology:
+  nodes:
+    ost:
+      kind: linux
+      image: ostinato/ostinato:{tag}
+      ports:
+        - 5900:5900/tcp
+        - 7878:7878/tcp
+      binds:
+        - /some/dir/on/host:/some/path/in/container
+. . .
+```
+
+You can read more about [node binds](../nodes/#binds)
+
+## Lab examples
+TODO
+
+## More
+You can find more information including how to run the Ostinato GUI natively on your Windows/MacOS laptop to manage the Ostinato agent running inside containterlab on the [Ostinato for Containerlab](https://ostinato.org/pricing/clab) page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
           - OpenBSD: manual/kinds/openbsd.md
           - FreeBSD: manual/kinds/freebsd.md
           - Keysight IXIA-C One: manual/kinds/keysight_ixia-c-one.md
+          - Ostinato: manual/kinds/ostinato.md
           - Check Point Cloudguard: manual/kinds/checkpoint_cloudguard.md
           - Fortinet Fortigate: manual/kinds/fortinet_fortigate.md
           - Palo Alto PAN: manual/kinds/vr-pan.md


### PR DESCRIPTION
Added documentation on how to use the Ostinato traffic generator with Containerlab.

A future PR will include a lab example