### PR TITLE
Add documentation page to developers guide

### DIFF
--- a/docs/htmltest.yml
+++ b/docs/htmltest.yml
@@ -20,6 +20,7 @@ IgnoreURLs:
   - https://gist.githubusercontent.com/hellt/abc/raw/def/linux.clab.yml # test link used in docs
   - serverfault.com # returns 403
   - askubuntu.com # returns 403
+  - localhost
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreSSLVerify: true

--- a/docs/lab-examples/frr01.md
+++ b/docs/lab-examples/frr01.md
@@ -1,7 +1,7 @@
 |                               |                                                                      |
 | ----------------------------- | -------------------------------------------------------------------- |
 | **Description**               | A 3-node ring of FRR routers with OSPF IGP                           |
-| **Components**                | [FRR](http://docs.frrouting.org/en/latest/overview.html)             |
+| **Components**                | [FRR](https://docs.frrouting.org/en/stable-7.5/overview.html)        |
 | **Resource requirements**[^1] | :fontawesome-solid-microchip: 2 <br/>:fontawesome-solid-memory: 2 GB |
 | **Topology file**             | [frr01.clab.yml][topofile]                                           |
 | **Name**                      | frr01                                                                |

--- a/docs/lab-examples/peering-lab.md
+++ b/docs/lab-examples/peering-lab.md
@@ -51,7 +51,6 @@ The Route Servers receive NLRIs from peers and pass them over to the other IXP m
 
 Every component of this lab is openly available and can be downloaded from public repositories, but Nokia SR OS, which has to be obtained from Nokia representatives. In this lab SR OS container image name is `sros:23.3.R1`.
 
-
 ## Topology definition
 
 The topology definition file for this lab is available in the [lab repository][lab]. The topology file - [`ixp.clab.yml`][lab-file] - declaratively describes the lab topology and is used by containerlab to create the lab environment.
@@ -381,7 +380,7 @@ The following resources were used to create this lab:
 [obgpd-container]: https://quay.io/openbgpd/openbgpd:7.9
 [rd-twitter]: https://twitter.com/ntdvps
 [rd-linkedin]: https://www.linkedin.com/in/romandodin/
-[frr-container]: https://quay.io/openbgpd/openbgpd:7.9
+[frr-container]: https://quay.io/repository/frrouting/frr:8.4.1
 [lab-file]: https://github.com/hellt/sros-frr-ixp-lab/blob/euro-ix/ixp.clab.yml
 [sros-partial-cfg]: https://github.com/hellt/sros-frr-ixp-lab/blob/euro-ix/configs/sros.partial.cfg
 [frr-conf-basic]: https://github.com/hellt/sros-frr-ixp-lab/blob/euro-ix/configs/frr.conf

--- a/docs/lab-examples/srl-frr.md
+++ b/docs/lab-examples/srl-frr.md
@@ -1,24 +1,25 @@
 |                               |                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------- |
 | **Description**               | A Nokia SR Linux connected back-to-back FRR router                                       |
-| **Components**                | [Nokia SR Linux][srl], [FRR](http://docs.frrouting.org/en/latest/overview.html)          |
+| **Components**                | [Nokia SR Linux][srl], [FRR](https://docs.frrouting.org/en/stable-7.5/overview.html)     |
 | **Resource requirements**[^1] | :fontawesome-solid-microchip: 2 <br/>:fontawesome-solid-memory: 2 GB                     |
 | **Topology file**             | [srlfrr01.clab.yml][topofile]                                                            |
 | **Name**                      | srlfrr01                                                                                 |
 | **Version information**[^2]   | `containerlab:0.9.0`, `srlinux:20.6.3-145`, `frrouting/frr:v7.5.0`, `docker-ce:19.03.13` |
 
 ## Description
+
 A lab consists of an SR Linux node connected with FRR router via a point-to-point ethernet link. Both nodes are also connected with their management interfaces to the `clab` docker network.
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:2,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/srlsonic01.drawio&quot;}"></div>
 
 ## Use cases
+
 This lab allows users to launch basic control plane interoperability scenarios between Nokia SR Linux and FRR network operating systems.
 
 The lab directory [contains](https://github.com/srl-labs/containerlab/tree/main/lab-examples/srlfrr01) files with essential configurations which can be used to jumpstart the interop demonstration. There you will find the config files to demonstrate a classic iBGP peering use case:
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:3,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/srlsonic01.drawio&quot;}"></div>
-
 
 - `daemons`: frr daemons config that is bind mounted to the frr container to trigger the start of the relevant FRR services
 - `frr.cfg`: vtysh config lines to configure a basic iBGP peering

--- a/docs/manual/dev/doc.md
+++ b/docs/manual/dev/doc.md
@@ -1,17 +1,30 @@
 # Containerlab Documentation
 
-The containerlab website and documentation is part of the same monorepo as the code.
+Contributing documentation is as valuable as contributing code; it is also a great way to start contributing to the project.  
+The containerlab documentation is part of the same repo that contains the code.
 
-To edit or add to the Containerlab website and manual make sure you have docker installed and then follow these steps -
+We tried to make it as easy as possible to contribute to the documentation. Starting from small edits that can be solely done in the browser, to more complex and thorough changes with a live dev server running on your machine to control the development process.
+
+## Online editing
+
+If you found a typo, or want to add a little piece of documentation you can do this all in your browser! On each documentation page you will find an "Edit this page" icon in the top right corner. Clicking on it will take you to the markdown file in the GitHub repository where you can make your changes. Once you are done, you can submit a pull request with your changes.
+
+Sometimes you might want to have a change that spans more than one file, in that case you use GitHub's online VS Code experience and opening the repo in your browser by following the [**`github.dev/srl-labs/containerlab`**](https://github.dev/srl-labs/containerlab) link.
+
+## Offline editing
+
+While online editing makes it easy to make small changes, it doesn't offer you a preview of the changes you're making, and this might be a bit cumbersome for larger changes. For this reason, we recommend setting up a local development environment to preview your changes when you feel like your changes are more substantial than a typo fix.
+
+To setup the dev environment you have to have Docker installed, which is a requirement for containerlab anyway. Once you have Docker installed, you can run the following command to start the development server:
 
 1. Fork the [srl-labs/containerlab](https://github.com/srl-labs/containerlab) repo
 2. Clone your fork of the repo locally
 3. Change to the local repo top level directory - `cd containerlab`
 4. Run `make serve-docs-full PUBLIC=yes`
 
-You can access the local website content from your browser at http://127.0.0.1:8001
+You can access the local website content from your browser at http://localhost:8001
 
-Look at the `nav` key in the `mkdocs.yml` file  to identify the markdown file that corresponds to the page you want to edit.
+Look at the `nav` key in the [`mkdocs.yml`](https://github.com/srl-labs/containerlab/blob/main/mkdocs.yml) file to identify the markdown file that corresponds to the page you want to edit.
 
 Any new content page should be added as a markdown file at a suitable location in the `docs` hierarchy and added under the `nav` key in `mkdocs.yml` to be reflected in the website documentation.
 
@@ -21,9 +34,9 @@ Once the documentation changes are complete, commit the changes and raise a pull
 
 ## Diagrams
 
-We prefer scalable vector diagrams for crisp sharp images.
+We prefer scalable vector diagrams for crisp sharp images checked into the repository. But you probably already noticed that.
 
-Use [diagrams.net](https://diagrams.net) to create a draw.io vector diagram. If you have multiple diagrams, create multiple pages in your diagram file - one per diagram.
+Containerlab drawings are made using the free online diagramming tool called [diagrams.net](https://diagrams.net). If you have multiple diagrams, create multiple pages in your diagram file - one per diagram.
 
 Diagrams are stored in the [diagrams :octicons-link-external-16:](https://github.com/srl-labs/containerlab/tree/diagrams){:target="\_blank"} branch, not the `main` branch. Create a fork of the `diagrams` branch to commit your draw.io file and raise a pull request targeting the `srl-labs/containerlab:diagrams` branch.
 

--- a/docs/manual/dev/doc.md
+++ b/docs/manual/dev/doc.md
@@ -18,3 +18,29 @@ Any new content page should be added as a markdown file at a suitable location i
 Consult the [mkdocs](https://www.mkdocs.org/) and [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) for more information.
 
 Once the documentation changes are complete, commit the changes and raise a pull request.
+
+## Diagrams
+
+We prefer scalable vector diagrams for crisp sharp images.
+
+Use [diagrams.net](https://diagrams.net) to create a draw.io vector diagram. If you have multiple diagrams, create multiple pages in your diagram file - one per diagram.
+
+Diagrams are stored in the [diagrams :octicons-link-external-16:](https://github.com/srl-labs/containerlab/tree/diagrams){:target="\_blank"} branch, not the `main` branch. Create a fork of the `diagrams` branch to commit your draw.io file and raise a pull request targeting the `srl-labs/containerlab:diagrams` branch.
+
+Once your diagram PR is merged, you can embed it in any markdown document using the below markup -
+
+```html
+<div class='mxgraph'
+  style='max-width:100%;border:1px solid transparent;margin:0 auto; display:block;'
+  data-mxgraph='{"page":0,"zoom":1,"highlight":"#0000ff","nav":true,"resize":true,"edit":"_blank",
+      "url":"https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/YOUR-DIAGRAM.drawio"}'>
+</div>
+```
+
+Replace `YOUR-DIAGRAM` with the name of your diagram file in the above markup. If your file has multiple pages, you can specify the required page number in the above markup. Each diagram will need a markup like the above. You can add multiple markups for different diagrams in the same markdown file.
+
+You MUST also add the below HTML markup at the bottom of your markdown file so that the diagrams are viewable -
+
+```html
+<script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
+```

--- a/docs/manual/dev/doc.md
+++ b/docs/manual/dev/doc.md
@@ -1,0 +1,20 @@
+# Containerlab Documentation
+
+The containerlab website and documentation is part of the same monorepo as the code.
+
+To edit or add to the Containerlab website and manual make sure you have docker installed and then follow these steps -
+
+1. Fork the [srl-labs/containerlab](https://github.com/srl-labs/containerlab) repo
+2. Clone your fork of the repo locally
+3. Change to the local repo top level directory - `cd containerlab`
+4. Run `make serve-docs-full PUBLIC=yes`
+
+You can access the local website content from your browser at http://127.0.0.1:8001
+
+Look at the `nav` key in the `mkdocs.yml` file  to identify the markdown file that corresponds to the page you want to edit.
+
+Any new content page should be added as a markdown file at a suitable location in the `docs` hierarchy and added under the `nav` key in `mkdocs.yml` to be reflected in the website documentation.
+
+Consult the [mkdocs](https://www.mkdocs.org/) and [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) for more information.
+
+Once the documentation changes are complete, commit the changes and raise a pull request.

--- a/docs/manual/dev/index.md
+++ b/docs/manual/dev/index.md
@@ -1,3 +1,7 @@
 # Developers Guide
 
-This is a start of the developers documentation. Stay tuned for more content!
+Containerlab relies on contributions from the community to improve existing functionality and add new features. The developers guide provides information on how to contribute to various bits of the project.
+
+Remember, that all contributions are welcome and important, no matter how big or small they are. Spot a typo in the documentation? Found a bug? Have an idea for a new feature? Want to improve the performance of the code? All of these are valuable contributions to the project.
+
+Thank you for considering contributing to containerlab!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Link Impairments: manual/impairments.md
       - Developers guide:
           - manual/dev/index.md
+          - Documentation: manual/dev/doc.md
           - Testing: manual/dev/test.md
   - Command reference:
       - deploy: cmd/deploy.md


### PR DESCRIPTION
Thank you @hellt for your help over discord on how to add to the containerlab documetnation.

Here's a small token of thanks by adding those instructions you gave me as a documentation page under developer's guide