### PR TITLE
Fix bullet list indentation in ost-srl lab example

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,4 @@
+"MD007": false # allow 4 spaced indentation for ul as this is used by mkdocs for nested lists
 "MD026": false # allow trailing punctuation to support icons shortcodes at the end of a sentence
 "MD038": false
 "MD033": false # inline html

--- a/docs/lab-examples/ost-srl.md
+++ b/docs/lab-examples/ost-srl.md
@@ -87,8 +87,8 @@ Here are some suggestions -
 
 - Override the IPv4 checksum to an invalid value and verify the DUT silently discards the packets (some DUTs may send an ICMP parameter problem)
 - Try setting IPv4 TTL to 1 and verify
-  - traffic is not forwarded by the DUT
-  - DUT sends back ICMP TTL Exceeded (you can capture and view captured packets)
+    - traffic is not forwarded by the DUT
+    - DUT sends back ICMP TTL Exceeded (you can capture and view captured packets)
 - Try IPv6 traffic streams
 
 Learn more about [Ostinato traffic streams][ostinato-streams].


### PR DESCRIPTION
The editorial changes in #2111 inadvertently removed indentation of some bullet list items