### PR TITLE
Fix XRv9k username and password env vars

### DIFF
--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -70,7 +70,7 @@ func (n *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	}
 
 	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --vcpu %s --ram %s --trace",
-		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), n.Cfg.ShortName,
+		n.Cfg.Env["USERNAME"], n.Cfg.Env["PASSWORD"], n.Cfg.ShortName,
 		n.Cfg.Env["CONNECTION_MODE"], n.Cfg.Env["VCPU"], n.Cfg.Env["RAM"])
 
 	return nil


### PR DESCRIPTION
Currently supplying `USERNAME` and `PASSWORD` environment variables in the topology definition file do nothing. 

Current code doesn't uses the hardcoded credentials (clab:clab@123) for the command argument, the proposed change fixes this and respects the value of the environment variable.

(was discussed in the containerlab discord)