### PR TITLE
Specify in XRv9K documentation that at least one dataplane interface is required.

### DIFF
--- a/docs/manual/kinds/vr-xrv9k.md
+++ b/docs/manual/kinds/vr-xrv9k.md
@@ -68,6 +68,9 @@ When containerlab launches Cisco XRv9k node, it will assign IPv4/6 address to th
 
 Data interfaces `eth1+` needs to be configured with IP addressing manually using CLI/management protocols.
 
+!!!info
+    You must have at least one data interface defined for the XRv9k boot process to complete successfully. 
+
 ## Features and options
 
 ### Node configuration

--- a/docs/manual/kinds/vr-xrv9k.md
+++ b/docs/manual/kinds/vr-xrv9k.md
@@ -68,8 +68,9 @@ When containerlab launches Cisco XRv9k node, it will assign IPv4/6 address to th
 
 Data interfaces `eth1+` needs to be configured with IP addressing manually using CLI/management protocols.
 
-!!!info
-    You must have at least one data interface defined for the XRv9k boot process to complete successfully. 
+/// note
+You must have at least one data interface defined for the XRv9k boot process to complete successfully.
+///
 
 ## Features and options
 


### PR DESCRIPTION
If the XRv9k doesn't have at minimum one data-plane interface defined in the topology file, the bootstrap process will fail and infinitely loop meaning the node will not boot properly and can't be accessed via ssh.

This adds a callout in the docs for the xrv9k which specifies this requirement.

Should this be an 'info' or 'note' callout?