### PR TITLE
Replace XRv9k minimum data interface note

### DIFF
--- a/docs/manual/kinds/vr-xrv9k.md
+++ b/docs/manual/kinds/vr-xrv9k.md
@@ -69,7 +69,7 @@ When containerlab launches Cisco XRv9k node, it will assign IPv4/6 address to th
 Data interfaces `eth1+` needs to be configured with IP addressing manually using CLI/management protocols.
 
 /// note
-You must have at least one data interface defined for the XRv9k boot process to complete successfully.
+Data interfaces may take 10+ minutes to come up, please be patient.
 ///
 
 ## Features and options


### PR DESCRIPTION
As per https://github.com/hellt/vrnetlab/pull/221. There is no longer a minimum interface requirement for the bootstrap process to complete successfully.

As per that change the user is required to wait for the interface to come up after the bootstrap is complete (and they can telnet or ssh in). 

 I've reflected this change in the docs as per this PR.