### PR TITLE
Add support for Cisco Catalyst 9000v kind.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ site:
 serve-docs-full:
 ifeq ($(PUBLIC),yes)
 	@{ 	\
-		sed -i 's/^  - typeset/#- typeset/g; s/^  - glightbox/#- glightbox/g' mkdocs.yml; \
+		sed -i 's/^  - typeset/#- typeset/g' mkdocs.yml; \
 	}
-	@docker run -it --rm -p 8001:8000 -v $(CURDIR):/docs squidfunk/mkdocs-material:$(MKDOCS_VER)
+	@docker run -it --rm -p 8001:8000 -v $(CURDIR):/docs --entrypoint "" squidfunk/mkdocs-material:$(MKDOCS_VER) ash -c "pip install mkdocs-macros-plugin==0.7.0 mkdocs-glightbox==0.4.0 && mkdocs serve -a 0.0.0.0:8000"
 else
 	@docker run -it --rm -p 8001:8000 -v $(CURDIR):/docs ghcr.io/srl-labs/mkdocs-material-insiders:$(MKDOCS_INS_VER)
 endif

--- a/clab/register.go
+++ b/clab/register.go
@@ -28,6 +28,7 @@ import (
 	srl "github.com/srl-labs/containerlab/nodes/srl"
 	vr_aoscx "github.com/srl-labs/containerlab/nodes/vr_aoscx"
 	vr_c8000v "github.com/srl-labs/containerlab/nodes/vr_c8000v"
+	vr_cat9kv "github.com/srl-labs/containerlab/nodes/vr_cat9kv"
 	vr_csr "github.com/srl-labs/containerlab/nodes/vr_csr"
 	vr_freebsd "github.com/srl-labs/containerlab/nodes/vr_freebsd"
 	vr_ftdv "github.com/srl-labs/containerlab/nodes/vr_ftdv"
@@ -86,6 +87,7 @@ func (c *CLab) RegisterNodes() {
 	vr_xrv.Register(c.Reg)
 	vr_xrv9k.Register(c.Reg)
 	vr_sonic.Register(c.Reg)
+	vr_cat9kv.Register(c.Reg)
 	xrd.Register(c.Reg)
 	rare.Register(c.Reg)
 	c8000.Register(c.Reg)

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ In addition to native containerized NOSes, containerlab can launch traditional v
 * [Juniper vJunos-switch](manual/kinds/vr-vjunosswitch.md)
 * [Juniper vJunos Evolved](manual/kinds/vr-vjunosevolved.md)
 * [Cisco IOS XRv9k](manual/kinds/vr-xrv9k.md)
+* [Cisco Catalyst 9000v](manual/kinds/vr-cat9kv.md)
 * [Cisco Nexus 9000v](manual/kinds/vr-n9kv.md)
 * [Cisco c8000v](manual/kinds/vr-c8000v.md)
 * [Cisco CSR 1000v](manual/kinds/vr-csr.md)

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -50,6 +50,7 @@ Within each predefined kind, we store the necessary information that is used to 
 | **Cisco CSR1000v**         | [`vr-csr/vr-cisco_csr1000v`](vr-csr.md)                         | supported |    VM     |
 | **Cisco Nexus 9000v**      | [`vr-n9kv/vr-cisco_n9kv`](vr-n9kv.md)                           | supported |    VM     |
 | **Cisco 8000**             | [`c8000/cisco_c8000`](c8000.md)                                 | supported |    VM+    |
+| **Cisco Catalyst 9000v**   | [`cat9kv/vr-cisco_cat9kv`](vr-cat9kv.md)                        | supported |    VM     |
 | **Cisco FTDv**             | [`cisco_ftdv`](vr-ftdv.md)                                      | supported |    VM     |
 | **Cumulus VX**             | [`cvx/cumulus_cvx`](cvx.md)                                     | supported | container |
 | **Aruba ArubaOS-CX**       | [`vr-aoscx/vr-aruba_aoscx`](vr-aoscx.md)                        | supported |    VM     |

--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -60,7 +60,7 @@ Default credentials: `admin:admin`
 
 ## Interface naming convention
 
-You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in [[[ kind_display_name ]]].
+You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in the [[[ kind_display_name ]]] CLI.
 
 The interface naming convention is: `GigabitEthernet1/0/X` (or `Gi1/0/X`), where `X` is the port number.
 
@@ -75,10 +75,32 @@ The example ports above would be mapped to the following Linux interfaces inside
 - `eth1` - First data-plane interface. Mapped to `GigabitEthernet1/0/1` interface.
 - `eth2` - Second data-plane interface. Mapped to `GigabitEthernet1/0/2` interface and so on.
 
-Regardless of how many links are defined in your containerlab topology, the Catalyst 9000v will always display 8 data-plane interfaces. Links/interfaces that you did not define in your containerlab topology will *not* pass any traffic.
-
 /// note
-Data interfaces may take 5+ minutes to come up after the node boots.
+Data interfaces may take 5+ minutes to function correctly after the node boots.
+///
+
+You must define interfaces in a contigous manner in your toplogy file. For example, if you want to use `Gi1/0/4` you must define `Gi1/0/1`, `Gi1/0/2` and `Gi1/0/3`. See the example below.
+
+```yaml
+name: my-cat9kv-lab
+topology:
+  nodes:
+    cat9kv1:
+      kind: cisco_cat9kv
+      image: vrnetlab/vr-cat9kv:17.12.01p
+    cat9kv2:
+      kind: cisco_cat9kv
+      image: vrnetlab/vr-cat9kv:17.12.01p
+
+  links:
+    - endpoints: ["cat9kv1:Gi1/0/1","cat9kv2:GigabitEthernet1/0/1"] 
+    - endpoints: ["cat9kv1:Gi1/0/2","cat9kv2:GigabitEthernet1/0/2"]
+    - endpoints: ["cat9kv1:Gi1/0/3", "cat9kv2:GigabitEthernet1/0/3"]
+    - endpoints: ["cat9kv1:Gi1/0/4", "cat9kv2:GigabitEthernet1/0/4"]
+```
+
+/// warning
+Regardless of how many links are defined in your containerlab topology, the Catalyst 9000v will always display 8 data-plane interfaces. Links/interfaces that you did not define in your containerlab topology will *not* pass any traffic.
 ///
 
 ## Features and options

--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -1,0 +1,92 @@
+---
+search:
+  boost: 4
+---
+# Cisco Catalyst 9000v
+
+The Cisco Catalyst 9000v (or Cat9kv for short) is a virtualised form of the Cisco Catalyst 9000 series switches. It is identified with `cisco_cat9kv` or `cisco_c9000v` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a Qsimu VM packaged in a docker container format.
+
+The Catalyst 9000v performs simulation of the dataplane ASICs that are present in the physical hardware. The two simulated ASICs are:
+
+- Cisco UADP (Unified Access Data-Plane). This is the default ASIC that's simulated.
+- Silicon One Q200 (referred to as Q200).
+
+/// note
+The Q200 simulation has a limited featureset compared to the UADP simulation.
+///
+
+## Resource requirements
+
+|           | UADP  | Q200  |
+| --------- | ----- | ----- |
+| vCPU      | 4     | 4     |
+| RAM (MB)  | 18432 | 12288 |
+| Disk (GB) | 4     | 4     |
+
+## Managing Cisco Catalyst 9000v nodes
+
+You can manage the Catalyst 9000v with containerlab via the following interfaces:
+
+=== "bash"
+    to connect to a `bash` shell of a running Cisco CSR1000v container:
+    ```bash
+    docker exec -it <container-name/id> bash
+    ```
+=== "CLI"
+    to connect to the Catalyst 9000v CLI
+    ```bash
+    ssh admin@<container-name/id>
+    ```
+=== "NETCONF"
+    NETCONF server is running over port 830
+    ```bash
+    ssh admin@<container-name> -p 830 -s netconf
+    ```
+
+/// note
+Default credentials: `admin:admin`
+///
+
+## Interface naming convention
+
+The Cisco Catalyst 9000v container uses the following naming convention for its management and data interfaces:
+
+- `eth0` - management interface connected to the containerlab management network.
+- `eth1` - GigabitEthernet1/0/1 interface.
+- `eth2` - GigabitEthernet1/0/2 interface and so on.
+
+Regardless of how many links are defined in your containerlab topology, the Catalyst 9000v will always display 8 data-plane interfaces. Links/interfaces that you did not define in your containerlab topology will *not* pass any traffic.
+
+/// note
+Data interfaces may take 5+ minutes to come up after the node boots.
+///
+
+## Features and options
+
+### ASIC data-plane simulation configuration
+
+The default ASIC simulation of the node will be UADP. To enable the Q200 simulation or to enable specific features for the UADP simulation, you must provide a `vswitch.xml` file (with the relevant configuration) when building the image using [vrnetlab](../vrnetlab.md).
+
+Once the node has been built you are unable to chang the simulation type. Please refer to the README file in vrnetlab/cat9kv for more information.
+
+/// note
+You can obtain a `vswitch.xml` file from the relevant Cisco CML node definitions.
+///
+
+### Environment variables
+
+There are `VCPU` and `RAM` environment variables defined. It is not recommended reduce the resources below the required amount. The node will be unable to boot in this case.
+
+The example below assigns 6vCPUs and 20 gigabytes of RAM to the node.
+
+```yaml
+name: my-cat9kv-lab
+topology:
+  nodes:
+    node1:
+      kind: cisco_cat9kv
+      image: vrnetlab/vr-cat9kv:17.12.01p-UADP
+    env:
+     VCPU: 6
+     RAM: 20480
+```

--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -118,7 +118,7 @@ topology:
   nodes:
     node1:
       kind: cisco_cat9kv
-      image: vrnetlab/vr-cat9kv:17.12.01p-UADP
+      image: vrnetlab/vr-cat9kv:17.12.01p
     env:
      VCPU: 6
      RAM: 20480

--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -1,12 +1,15 @@
 ---
 search:
   boost: 4
+kind_code_name: cisco_cat9kv
+kind_display_name: Cisco Catalyst 9000v
+kind_short_display_name: Cat9kv
 ---
 # Cisco Catalyst 9000v
 
-The Cisco Catalyst 9000v (or Cat9kv for short) is a virtualised form of the Cisco Catalyst 9000 series switches. It is identified with `cisco_cat9kv` or `cisco_c9000v` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a Qsimu VM packaged in a docker container format.
+The [[[ kind_display_name ]]] (or [[[ kind_short_display_name ]]] for short) is a virtualised form of the Cisco Catalyst 9000 series switches. It is identified with `[[[ kind_code_name ]]]` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a Qemu VM packaged in a docker container format.
 
-The Catalyst 9000v performs simulation of the dataplane ASICs that are present in the physical hardware. The two simulated ASICs are:
+The [[[ kind_display_name ]]] performs simulation of the dataplane ASICs that are present in the physical hardware. The two simulated ASICs are:
 
 - Cisco UADP (Unified Access Data-Plane). This is the default ASIC that's simulated.
 - Silicon One Q200 (referred to as Q200).
@@ -23,26 +26,34 @@ The Q200 simulation has a limited featureset compared to the UADP simulation.
 | RAM (MB)  | 18432 | 12288 |
 | Disk (GB) | 4     | 4     |
 
-## Managing Cisco Catalyst 9000v nodes
+## Managing [[[ kind_display_name ]]] nodes
 
-You can manage the Catalyst 9000v with containerlab via the following interfaces:
+You can manage the [[[ kind_display_name ]]] with containerlab via the following interfaces:
 
-=== "bash"
-    to connect to a `bash` shell of a running Cisco CSR1000v container:
-    ```bash
-    docker exec -it <container-name/id> bash
-    ```
-=== "CLI"
-    to connect to the Catalyst 9000v CLI
-    ```bash
-    ssh admin@<container-name/id>
-    ```
-=== "NETCONF"
-    NETCONF server is running over port 830
-    ```bash
-    ssh admin@<container-name> -p 830 -s netconf
-    ```
+/// tab | bash
+to connect to a `bash` shell of a running Cisco CSR1000v container:
 
+```bash
+docker exec -it <container-name/id> bash
+```
+
+///
+/// tab | CLI
+to connect to the Catalyst 9000v CLI
+
+```bash
+ssh admin@<container-name/id>
+```
+
+///
+/// tab | NETCONF
+NETCONF server is running over port 830
+
+```bash
+ssh admin@<container-name> -p 830 -s netconf
+```
+
+///
 /// note
 Default credentials: `admin:admin`
 ///

--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -60,11 +60,20 @@ Default credentials: `admin:admin`
 
 ## Interface naming convention
 
-The Cisco Catalyst 9000v container uses the following naming convention for its management and data interfaces:
+You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in [[[ kind_display_name ]]].
+
+The interface naming convention is: `GigabitEthernet1/0/X` (or `Gi1/0/X`), where `X` is the port number.
+
+With that naming convention in mind:
+
+* `Gi1/0/1` - first data port available
+* `Gi1/0/2` - second data port, and so on...
+
+The example ports above would be mapped to the following Linux interfaces inside the container running the [[[ kind_display_name ]]] VM:
 
 - `eth0` - management interface connected to the containerlab management network.
-- `eth1` - GigabitEthernet1/0/1 interface.
-- `eth2` - GigabitEthernet1/0/2 interface and so on.
+- `eth1` - First data-plane interface. Mapped to `GigabitEthernet1/0/1` interface.
+- `eth2` - Second data-plane interface. Mapped to `GigabitEthernet1/0/2` interface and so on.
 
 Regardless of how many links are defined in your containerlab topology, the Catalyst 9000v will always display 8 data-plane interfaces. Links/interfaces that you did not define in your containerlab topology will *not* pass any traffic.
 
@@ -76,9 +85,22 @@ Data interfaces may take 5+ minutes to come up after the node boots.
 
 ### ASIC data-plane simulation configuration
 
-The default ASIC simulation of the node will be UADP. To enable the Q200 simulation or to enable specific features for the UADP simulation, you must provide a `vswitch.xml` file (with the relevant configuration) when building the image using [vrnetlab](../vrnetlab.md).
+The default ASIC simulation of the node will be UADP. To enable the Q200 simulation or to enable specific features for the UADP simulation, you must provide a `vswitch.xml` file (with the relevant configuration).
 
-Once the node has been built you are unable to chang the simulation type. Please refer to the README file in vrnetlab/cat9kv for more information.
+You can do this when building the image with [vrnetlab](../vrnetlab.md), Please refer to the README file in vrnetlab/cat9kv for more information.
+
+You can also use supply the vswitch.xml file via `binds` in the containerlab topology file. Refer to the example below.
+
+```yaml
+name: my-cat9kv-lab
+topology:
+  nodes:
+    node1:
+      kind: cisco_cat9kv
+      image: vrnetlab/vr-cat9kv:17.12.01p
+    binds:
+      - /path/to/vswitch.xml:/vswitch.xml
+```
 
 /// note
 You can obtain a `vswitch.xml` file from the relevant Cisco CML node definitions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,7 +260,7 @@ plugins:
       redirect_maps:
         lab-examples/tls-cert.md: https://clabs.netdevops.me/security/gnmitls/
         lab-examples/ixp-lab.md: lab-examples/peering-lab.md
-  - typeset
+#- typeset
   - glightbox
   - macros:
       j2_block_start_string: "[[[%"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
               - Cisco Nexus 9000v: manual/kinds/vr-n9kv.md
               - Cisco 8000: manual/kinds/c8000.md
               - Cisco c8000v: manual/kinds/vr-c8000v.md
+              - Cisco Catalyst 9000v: manual/kinds/vr-cat9kv.md
               - Cisco FTDv: manual/kinds/vr-ftdv.md
           - Juniper:
               - Juniper cRPD: manual/kinds/crpd.md

--- a/nodes/vr_cat9kv/vr-cat9kv.go
+++ b/nodes/vr_cat9kv/vr-cat9kv.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	kindnames          = []string{"cisco_cat9kv", "cisco_c9000v", "vr-cat9kv", "vr-c9000v"}
+	kindnames          = []string{"cisco_cat9kv"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
 
 	InterfaceRegexp = regexp.MustCompile(`(?:Gi|GigabitEthernet)\s?1/0/(?P<port>\d+)$`)

--- a/nodes/vr_cat9kv/vr-cat9kv.go
+++ b/nodes/vr_cat9kv/vr-cat9kv.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package vr_cat9kv
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/netconf"
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindnames          = []string{"cisco_cat9kv", "cisco_c9000v", "vr-cat9kv", "vr-c9000v"}
+	defaultCredentials = nodes.NewCredentials("admin", "admin")
+)
+
+const (
+	scrapliPlatformName = "cisco_iosxe"
+
+	configDirName   = "config"
+	startupCfgFName = "startup-config.cfg"
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *nodes.NodeRegistry) {
+	r.Register(kindnames, func() nodes.Node {
+		return new(vrcat9kv)
+	}, defaultCredentials)
+}
+
+type vrcat9kv struct {
+	nodes.DefaultNode
+}
+
+func (n *vrcat9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init DefaultNode
+	n.DefaultNode = *nodes.NewDefaultNode(n)
+	// set virtualization requirement
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+	// env vars are used to set launch.py arguments in vrnetlab container
+	defEnv := map[string]string{
+		"CONNECTION_MODE":    nodes.VrDefConnMode,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+		"VCPU":               "4",
+		"RAM":                "18432",
+	}
+	n.Cfg.Env = utils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	// mount config dir to support startup-config functionality
+	n.Cfg.Binds = append(n.Cfg.Binds, fmt.Sprint(path.Join(n.Cfg.LabDir, configDirName), ":/config"))
+
+	if n.Cfg.Env["CONNECTION_MODE"] == "macvtap" {
+		// mount dev dir to enable macvtap
+		n.Cfg.Binds = append(n.Cfg.Binds, "/dev:/dev")
+	}
+
+	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --vcpu %s --ram %s --trace",
+		n.Cfg.Env["USERNAME"], n.Cfg.Env["PASSWORD"], n.Cfg.ShortName, n.Cfg.Env["CONNECTION_MODE"], n.Cfg.Env["VCPU"], n.Cfg.Env["RAM"])
+
+	return nil
+}
+
+func (s *vrcat9kv) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
+	utils.CreateDirectory(s.Cfg.LabDir, 0777)
+	_, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
+	if err != nil {
+		return nil
+	}
+	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
+}
+
+func (n *vrcat9kv) SaveConfig(_ context.Context) error {
+	err := netconf.SaveConfig(n.Cfg.LongName,
+		defaultCredentials.GetUsername(),
+		defaultCredentials.GetPassword(),
+		scrapliPlatformName,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("saved %s running configuration to startup configuration file\n", n.Cfg.ShortName)
+	return nil
+}
+
+// CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
+func (n *vrcat9kv) CheckInterfaceName() error {
+	return nodes.GenericVMInterfaceCheck(n.Cfg.ShortName, n.Endpoints)
+}

--- a/nodes/vr_cat9kv/vr-cat9kv.go
+++ b/nodes/vr_cat9kv/vr-cat9kv.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/netconf"
@@ -19,6 +20,10 @@ import (
 var (
 	kindnames          = []string{"cisco_cat9kv", "cisco_c9000v", "vr-cat9kv", "vr-c9000v"}
 	defaultCredentials = nodes.NewCredentials("admin", "admin")
+
+	InterfaceRegexp = regexp.MustCompile(`(?:Gi|GigabitEthernet)\s?1/0/(?P<port>\d+)$`)
+	InterfaceOffset = 1
+	InterfaceHelp   = "Gi1/0/X or GigabitEthernet1/0/X (where X >= 1) or ethX (where X >= 1)"
 )
 
 const (
@@ -31,17 +36,17 @@ const (
 // Register registers the node in the NodeRegistry.
 func Register(r *nodes.NodeRegistry) {
 	r.Register(kindnames, func() nodes.Node {
-		return new(vrcat9kv)
+		return new(vrCat9kv)
 	}, defaultCredentials)
 }
 
-type vrcat9kv struct {
-	nodes.DefaultNode
+type vrCat9kv struct {
+	nodes.VRNode
 }
 
-func (n *vrcat9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
-	// Init DefaultNode
-	n.DefaultNode = *nodes.NewDefaultNode(n)
+func (n *vrCat9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init VRNode
+	n.VRNode = *nodes.NewVRNode(n)
 	// set virtualization requirement
 	n.HostRequirements.VirtRequired = true
 
@@ -72,10 +77,14 @@ func (n *vrcat9kv) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --vcpu %s --ram %s --trace",
 		n.Cfg.Env["USERNAME"], n.Cfg.Env["PASSWORD"], n.Cfg.ShortName, n.Cfg.Env["CONNECTION_MODE"], n.Cfg.Env["VCPU"], n.Cfg.Env["RAM"])
 
+	n.InterfaceRegexp = InterfaceRegexp
+	n.InterfaceOffset = InterfaceOffset
+	n.InterfaceHelp = InterfaceHelp
+
 	return nil
 }
 
-func (s *vrcat9kv) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
+func (s *vrCat9kv) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
 	utils.CreateDirectory(s.Cfg.LabDir, 0777)
 	_, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
@@ -84,7 +93,7 @@ func (s *vrcat9kv) PreDeploy(_ context.Context, params *nodes.PreDeployParams) e
 	return nodes.LoadStartupConfigFileVr(s, configDirName, startupCfgFName)
 }
 
-func (n *vrcat9kv) SaveConfig(_ context.Context) error {
+func (n *vrCat9kv) SaveConfig(_ context.Context) error {
 	err := netconf.SaveConfig(n.Cfg.LongName,
 		defaultCredentials.GetUsername(),
 		defaultCredentials.GetPassword(),
@@ -96,9 +105,4 @@ func (n *vrcat9kv) SaveConfig(_ context.Context) error {
 
 	log.Infof("saved %s running configuration to startup configuration file\n", n.Cfg.ShortName)
 	return nil
-}
-
-// CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
-func (n *vrcat9kv) CheckInterfaceName() error {
-	return nodes.GenericVMInterfaceCheck(n.Cfg.ShortName, n.Endpoints)
 }

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -96,6 +96,10 @@
                         "c8000",
                         "cisco_c8000",
                         "cisco_c8000v",
+                        "cisco_cat9kv", 
+                        "cisco_c9000v", 
+                        "vr-cat9kv", 
+                        "vr-c9000v",
                         "cvx",
                         "cumulus_cvx",
                         "openbsd",
@@ -948,6 +952,18 @@
                             "$ref": "#/definitions/node-config"
                         },
                         "vr-csr": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "cisco_cat9kv": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "cisco_c9000v": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "vr-cat9kv": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "vr-c9000v": {
                             "$ref": "#/definitions/node-config"
                         },
                         "cisco_ftdv": {

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -96,10 +96,7 @@
                         "c8000",
                         "cisco_c8000",
                         "cisco_c8000v",
-                        "cisco_cat9kv", 
-                        "cisco_c9000v", 
-                        "vr-cat9kv", 
-                        "vr-c9000v",
+                        "cisco_cat9kv",
                         "cvx",
                         "cumulus_cvx",
                         "openbsd",
@@ -955,15 +952,6 @@
                             "$ref": "#/definitions/node-config"
                         },
                         "cisco_cat9kv": {
-                            "$ref": "#/definitions/node-config"
-                        },
-                        "cisco_c9000v": {
-                            "$ref": "#/definitions/node-config"
-                        },
-                        "vr-cat9kv": {
-                            "$ref": "#/definitions/node-config"
-                        },
-                        "vr-c9000v": {
                             "$ref": "#/definitions/node-config"
                         },
                         "cisco_ftdv": {


### PR DESCRIPTION
https://github.com/hellt/vrnetlab/pull/225 adds support for the Catalyst 9000v image. This PR adds the relevant definitions to support the cat9kv in containerlab topologies.

Copied from the c8000v files, i've added `VCPU` and `RAM` environment variables since the cat9kv is a resource hungry VM.

I've added 4 kind names of `cisco_cat9kv`, `cisco_c9000v`, `vr-cat9kv` and `vr-c9000v`

Please let me know if you would prefer to keep it as one or the other (cat9kv versus c9000v).

Documentation is also going to be added.