### PR TITLE
Add suport for EL distros in one-liner install script.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -36,7 +36,7 @@ To install all components at once, run the following command on any of the suppo
 curl -sL https://containerlab.dev/setup | sudo bash -s "all"
 ```
 /// note
-Please log out and log back in after execution of the script to complete the installation.
+To complete installation please execute `newgrp docker` or logout and log back in.
 ///
 
 To install an individual component, specify the function name as an argument to the script. For example, to install only `docker`:

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,9 @@ To install all components at once, run the following command on any of the suppo
 ```bash
 curl -sL https://containerlab.dev/setup | sudo bash -s "all"
 ```
+/// note
+Please log out and log back in after execution of the script to complete the installation.
+///
 
 To install an individual component, specify the function name as an argument to the script. For example, to install only `docker`:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,10 +20,15 @@ The easiest way to get started with containerlab is to use the [quick setup scri
 * Containerlab (using the package repository)
 * [`gh` CLI tool](https://cli.github.com/)
 
-The script supports the following OSes:
+The script officially supports the following OSes:
 
 * Ubuntu 20.04, 22.04, 23.10
 * Debian 11, 12
+* Red Hat Enterprise Linux 9
+* CentOS Stream 9
+* Fedora Server 40 (should work on other variants of Fedora)
+* Rocky Linux 9.3, 8.8 (should work on any 9.x and 8.x release)
+
 
 To install all components at once, run the following command on any of the supported OSes:
 

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -7,7 +7,7 @@ function check_os {
             DISTRO_TYPE="debian"
         elif [ "$ID" = "ubuntu" ]; then
             DISTRO_TYPE="ubuntu"
-        elif [ "$ID" = "rocky" ]; then
+        elif [[ "$ID" = "rocky" || "$ID" = "rhel" || "$ID" = "centos"  || "$ID" = "fedora" ]]; then
             DISTRO_TYPE="rhel"
         else
             echo "This is not Debian or Ubuntu"
@@ -78,7 +78,7 @@ function install-docker-ubuntu {
 function install-docker-rhel {
     # using instructions from:
     # https://docs.docker.com/engine/install/rhel/#install-using-the-repository
-    sudo yum remove docker \
+    sudo yum remove -y docker \
                   docker-client \
                   docker-client-latest \
                   docker-common \
@@ -90,9 +90,9 @@ function install-docker-rhel {
                   runc
 
     sudo yum install -y yum-utils
-    sudo yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+    sudo yum-config-manager -y --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 
-    sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    sudo yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
     # diverges from the instructions. This means docker daemon starts on each boot.
     sudo systemctl enable --now docker
@@ -126,16 +126,13 @@ function install-gh-cli-debian {
 }
 
 function install-gh-cli-rhel {
-    sudo dnf install 'dnf-command(config-manager)'
-    sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+    sudo dnf install -y 'dnf-command(config-manager)'
+    sudo dnf config-manager -y --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+    sudo dnf install git -y
     sudo dnf install -y gh --repo gh-cli
 }
 
 function install-containerlab {
-    # echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
-    # sudo tee -a /etc/apt/sources.list.d/netdevops.list
-
-    # sudo apt update && sudo apt install -y containerlab
     sudo bash -c "$(curl -sL https://get.containerlab.dev)"
 }
 

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -122,6 +122,13 @@ function install-docker-fedora {
     sudo systemctl enable --now docker
 }
 
+function post-install-docker {
+    # instructions from:
+    # https://docs.docker.com/engine/install/linux-postinstall/
+    sudo groupadd docker
+    sudo usermod -aG docker "$SUDO_USER"
+}
+
 function setup-sshd {
     # increase max auth tries so unknown keys don't lock ssh attempts
     sudo sed -i 's/^#*MaxAuthTries.*/MaxAuthTries 50/' /etc/ssh/sshd_config
@@ -130,6 +137,14 @@ function setup-sshd {
         sudo systemctl restart sshd
     else
         sudo systemctl restart ssh
+    fi
+}
+
+function install-make {
+    if [[ "${DISTRO_TYPE}" = "rhel"  || "${DISTRO_TYPE}" = "fedora" ]]; then
+        sudo dnf install -y make
+    else
+        sudo apt install -y make
     fi
 }
 
@@ -183,8 +198,13 @@ function all {
     check_os
 
     setup-sshd
+
     install-docker
+    post-install-docker
+
+    install-make
     install-gh-cli
+
     install-containerlab
 }
 


### PR DESCRIPTION
This PR enables the one liner install script to support RHEL & other EL counterparts like Fedora, Rocky and CentOS to name a few.

Currently tested on Rocky 9.3. This is in draft PR status while I test other distros & versions.