### PR TITLE
Add support for --drawio-args flag in graph command

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -33,6 +33,7 @@ var (
 	mermaidDirection string
 	drawio           bool
 	drawioVersion    string
+	drawioArgs       []string
 	staticDir        string
 )
 
@@ -79,7 +80,7 @@ func graphFn(_ *cobra.Command, _ []string) error {
 	}
 
 	if drawio {
-		return c.GenerateDrawioDiagram(drawioVersion)
+		return c.GenerateDrawioDiagram(drawioVersion, drawioArgs)
 	}
 
 	gtopo := clab.GraphTopo{
@@ -153,6 +154,8 @@ func init() {
 	graphCmd.Flags().BoolVarP(&dot, "dot", "", false, "generate dot file")
 	graphCmd.Flags().BoolVarP(&mermaid, "mermaid", "", false, "print mermaid flowchart to stdout")
 	graphCmd.Flags().StringVarP(&mermaidDirection, "mermaid-direction", "", "TD", "specify direction of mermaid dirgram")
+	graphCmd.Flags().StringSliceVar(&drawioArgs, "drawio-args", []string{},
+		"Additional flags to pass to the drawio diagram generation tool (can be specified multiple times)")
 	graphCmd.Flags().BoolVarP(&drawio, "drawio", "", false, "generate drawio diagram file")
 	graphCmd.Flags().StringVarP(&drawioVersion, "drawio-version", "", "latest",
 		"version of the clab-io-draw container to use for generating drawio diagram file")

--- a/docs/cmd/graph.md
+++ b/docs/cmd/graph.md
@@ -64,6 +64,12 @@ The `group` property set to the predefined value will automatically auto-align t
 
 When `graph` command is called with the `--drawio` flag, containerlab will leverage the [`clab-io-draw`](https://github.com/srl-labs/clab-io-draw) project to generate the drawio file that represents the topology in a graphical form and can be imported into [draw.io](https://draw.io).
 
+You can pass additional arguments to the `clab-io-draw` tool using the `--drawio-args=` flag. For example:
+
+```
+containerlab graph --drawio --drawio-args="--theme nokia_dark --layout horizontal" -t topo.yaml
+```
+
 ### Mermaid
 
 When `graph` is called with the `--mermaid` flag containerlab generates a graph description file in [Mermaid graph format](https://mermaid.js.org/syntax/flowchart.html). Several [Markdown renders](https://mermaid.js.org/ecosystem/integrations-community.html) such as Github, Gitlab, and Notion support rendering embeded mermaid graphs in code blocks. If the results of the render are not satisfying the result can be imported into [draw.io](https://draw.io) and further edited.


### PR DESCRIPTION
This PR introduces the --drawio-args flag to the graph command, allowing users to pass additional arguments to the clab-io-draw tool when generating drawio diagrams.

Changes:
1. Modified cmd/graph.go:
   - Added support for the new --drawio-args flag
   - Implemented logic to pass these arguments to the clab-io-draw tool

2. Updated cmd/generate.go:
   - Integrated the --drawio-args flag with the existing graph generation logic

3. Updated README.md:
   - Added a brief explanation of the --drawio flag functionality
   - Introduced the --drawio-args flag and its usage
   - Provided an example of how to use the --drawio-args flag


Example usage:
containerlab graph --drawio --drawio-args="--theme grafana_dark --layout horizontal"