### PR TITLE
Add owner column to inspect command with local flag

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -133,7 +133,7 @@ func toTableData(det []types.ContainerDetails) [][]string {
 
 		if all {
 			tabData = append(tabData, []string{
-				fmt.Sprintf("%d", i+1), d.LabPath,
+				fmt.Sprintf("%d", i+1), d.LabPath, d.Owner,
 				d.LabName, d.Name, d.ContainerID, d.Image, d.Kind, d.State, d.IPv4Address, d.IPv6Address,
 			})
 			continue
@@ -163,6 +163,7 @@ func printContainerInspect(containers []runtime.GenericContainer, format string)
 			State:       cont.State,
 			IPv4Address: cont.GetContainerIPv4(),
 			IPv6Address: cont.GetContainerIPv6(),
+			Owner:       cont.Labels[labels.Owner],
 		}
 		cdet.ContainerID = cont.ShortID
 
@@ -176,6 +177,10 @@ func printContainerInspect(containers []runtime.GenericContainer, format string)
 
 		if kind, ok := cont.Labels[labels.NodeKind]; ok {
 			cdet.Kind = kind
+		}
+
+		if owner, ok := cont.Labels[labels.Owner]; ok {
+			cdet.Owner = owner
 		}
 
 		contDetails = append(contDetails, *cdet)
@@ -213,7 +218,7 @@ func printContainerInspect(containers []runtime.GenericContainer, format string)
 			"IPv6 Address",
 		}
 		if all {
-			table.SetHeader(append([]string{"#", "Topo Path"}, header...))
+			table.SetHeader(append([]string{"#", "Topo Path", "Owner"}, header...))
 		} else {
 			table.SetHeader(append([]string{"#"}, header[1:]...))
 		}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/olekukonko/tablewriter"
@@ -44,7 +45,7 @@ func init() {
 	inspectCmd.Flags().BoolVarP(&details, "details", "", false, "print all details of lab containers")
 	inspectCmd.Flags().StringVarP(&inspectFormat, "format", "f", "table", "output format. One of [table, json]")
 	inspectCmd.Flags().BoolVarP(&all, "all", "a", false, "show all deployed containerlab labs")
-	inspectCmd.Flags().BoolVarP(&wide, "wide", "w", false, "also show the owner of a lab")
+	inspectCmd.Flags().BoolVarP(&wide, "wide", "w", false, "also more details about a lab and its nodes")
 }
 
 func inspectFn(_ *cobra.Command, _ []string) error {
@@ -169,7 +170,6 @@ func printContainerInspect(containers []runtime.GenericContainer, format string)
 			State:       cont.State,
 			IPv4Address: cont.GetContainerIPv4(),
 			IPv6Address: cont.GetContainerIPv6(),
-			Owner:       cont.Labels[labels.Owner],
 		}
 		cdet.ContainerID = cont.ShortID
 
@@ -225,7 +225,7 @@ func printContainerInspect(containers []runtime.GenericContainer, format string)
 		}
 
 		if wide {
-			header = append(header[:1], append([]string{"Owner"}, header[1:]...)...)
+			header = slices.Insert(header, 1, "Owner")
 		}
 
 		if all {

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -36,6 +36,9 @@ The `inspect` command produces a brief summary about the running lab components.
 
 With this flag inspect command will output every bit of information about the running containers. This is what `docker inspect` command provides.
 
+#### wide
+The local `--wide` flag adds an "Owner" column to the `inspect` output table.
+
 ### Examples
 
 #### List all running labs on the host
@@ -77,6 +80,18 @@ INFO[0000] Parsing & checking topology file: srl02.clab.yml
 | 1 | clab-srl02-srl1 | 7a7c101be7d8 | ghcr.io/nokia/srlinux | srl  | running | 172.20.20.4/24 | 2001:172:20:20::4/64 |
 | 2 | clab-srl02-srl2 | 5e3737621753 | ghcr.io/nokia/srlinux | srl  | running | 172.20.20.5/24 | 2001:172:20:20::5/64 |
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
+```
+
+#### Provide owner information of running labs
+```bash
+clab inspect --all --wide
++---+-----------------------------------+----------+-------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
+| # |             Topo Path             | Lab Name | Owner |      Name       | Container ID |         Image         |     Kind      |  State  |  IPv4 Address  |     IPv6 Address     |
++---+-----------------------------------+----------+-------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
+| 1 | lab-examples/srl01/srl01.clab.yml | srl01    | user1 | clab-srl01-srl  | ea86f40b412a | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.2/24 | 2001:172:20:20::2/64 |
+| 2 | lab-examples/srl02/srl02.clab.yml | srl02    | user2 | clab-srl02-srl1 | ba7e807235b6 | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.4/24 | 2001:172:20:20::4/64 |
+| 3 |                                   |          |       | clab-srl02-srl2 | 71006155b70a | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.3/24 | 2001:172:20:20::3/64 |
++---+-----------------------------------+----------+-------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
 ```
 
 #### Provide information about a specific running lab in json format

--- a/docs/cmd/inspect.md
+++ b/docs/cmd/inspect.md
@@ -11,6 +11,7 @@ The `inspect` command provides the information about the deployed labs.
 ### Flags
 
 #### all
+
 With the local `--all` flag it's possible to list all deployed labs in a single table. The output will also show the relative path to the topology file that was used to spawn this lab.
 
 The lab name and path values will be set for the first node of such lab, to reduce the clutter. Refer to the [examples](#examples) section for more details.
@@ -32,12 +33,14 @@ The local `--format` flag enables different output stylings. By default the tabl
 Currently, the only other format option is `json` that will produce the output in the JSON format.
 
 #### details
+
 The `inspect` command produces a brief summary about the running lab components. It is also possible to get a full view on the running containers by adding `--details` flag.
 
 With this flag inspect command will output every bit of information about the running containers. This is what `docker inspect` command provides.
 
 #### wide
-The local `--wide` flag adds an "Owner" column to the `inspect` output table.
+
+The local `-w | --wide` flag adds all available columns to the `inspect` output table.
 
 ### Examples
 
@@ -83,6 +86,9 @@ INFO[0000] Parsing & checking topology file: srl02.clab.yml
 ```
 
 #### Provide owner information of running labs
+
+An owner is a linux user that started the lab. When `sudo` is used, the original user is displayed as the owner.
+
 ```bash
 clab inspect --all --wide
 +---+-----------------------------------+----------+-------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
@@ -121,4 +127,3 @@ clab inspect --all --wide
   }
 ]
 ```
-

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -197,10 +197,10 @@ Ensure "inspect all" outputs IP addresses
     @{data} =    Split String    ${line}    |
     Log    ${data}
     # verify ipv4 address
-    ${ipv4} =    String.Strip String    ${data}[9]
+    ${ipv4} =    String.Strip String    ${data}[10]
     Should Match Regexp    ${ipv4}    ^[\\d\\.]+/\\d{1,2}$
     # verify ipv6 address
-    Run Keyword    Match IPv6 Address    ${data}[10]
+    Run Keyword    Match IPv6 Address    ${data}[11]
 
 Verify bind mount in l1 node
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -197,10 +197,10 @@ Ensure "inspect all" outputs IP addresses
     @{data} =    Split String    ${line}    |
     Log    ${data}
     # verify ipv4 address
-    ${ipv4} =    String.Strip String    ${data}[10]
+    ${ipv4} =    String.Strip String    ${data}[9]
     Should Match Regexp    ${ipv4}    ^[\\d\\.]+/\\d{1,2}$
     # verify ipv6 address
-    Run Keyword    Match IPv6 Address    ${data}[11]
+    Run Keyword    Match IPv6 Address    ${data}[10]
 
 Verify bind mount in l1 node
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/types/types.go
+++ b/types/types.go
@@ -282,6 +282,7 @@ type ContainerDetails struct {
 	IPv4Address string                `json:"ipv4_address,omitempty"`
 	IPv6Address string                `json:"ipv6_address,omitempty"`
 	Ports       []*GenericPortBinding `json:"ports,omitempty"`
+	Owner       string                `json:"owner,omitempty"`
 }
 
 // GenericPortBinding represents a port binding.


### PR DESCRIPTION
In addition to #2157

This adds a column to the ```containerlab inspect --all``` showing the owner of the lab.
``` bash
containerlab inspect -a
+---+-----------------------------------+---------+----------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
| # |             Topo Path             |  Owner  | Lab Name |      Name       | Container ID |         Image         |     Kind      |  State  |  IPv4 Address  |     IPv6 Address     |
+---+-----------------------------------+---------+----------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
| 1 | lab-examples/srl01/srl01.clab.yml | toweber | srl01    | clab-srl01-srl  | 793dddc6704b | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.2/24 | 2001:172:20:20::2/64 |
| 2 | lab-examples/srl02/srl02.clab.yml |         | srl02    | clab-srl02-srl1 | be1878cbf83b | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.3/24 | 2001:172:20:20::3/64 |
| 3 |                                   |         | srl02    | clab-srl02-srl2 | 0b5e6c9059fb | ghcr.io/nokia/srlinux | nokia_srlinux | running | 172.20.20.4/24 | 2001:172:20:20::4/64 |
+---+-----------------------------------+--------+----------+-----------------+--------------+-----------------------+---------------+---------+----------------+----------------------+
```

``` json
containerlab inspect -a -f json
{
  "containers": [
    {
      "lab_name": "srl01",
      "labPath": "lab-examples/srl01/srl01.clab.yml",
      "name": "clab-srl01-srl",
      "container_id": "793dddc6704b",
      "image": "ghcr.io/nokia/srlinux",
      "kind": "nokia_srlinux",
      "state": "running",
      "ipv4_address": "172.20.20.2/24",
      "ipv6_address": "2001:172:20:20::2/64",
      "owner": "toweber"
    },
    {
      "lab_name": "srl02",
      "labPath": "lab-examples/srl02/srl02.clab.yml",
      "name": "clab-srl02-srl1",
      "container_id": "be1878cbf83b",
      "image": "ghcr.io/nokia/srlinux",
      "kind": "nokia_srlinux",
      "state": "running",
      "ipv4_address": "172.20.20.3/24",
      "ipv6_address": "2001:172:20:20::3/64",
      "owner": "toweber"
    },
    {
      "lab_name": "srl02",
      "labPath": "lab-examples/srl02/srl02.clab.yml",
      "name": "clab-srl02-srl2",
      "container_id": "0b5e6c9059fb",
      "image": "ghcr.io/nokia/srlinux",
      "kind": "nokia_srlinux",
      "state": "running",
      "ipv4_address": "172.20.20.4/24",
      "ipv6_address": "2001:172:20:20::4/64",
      "owner": "toweber"
    }
  ]
}
```
