### PR TITLE
Don't crash if a Docker password contains a colon

### DIFF
--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -94,7 +94,7 @@ func GetDockerAuth(dockerConfig *DockerConfig, imageName string) (string, error)
 		return "", err
 	}
 
-	decodedAuthSplit := strings.Split(string(decodedAuth), authStringSep)
+	decodedAuthSplit := strings.SplitN(string(decodedAuth), authStringSep, authStringLength)
 
 	if len(decodedAuthSplit) != authStringLength {
 		return "", errors.New("unexpected auth string")


### PR DESCRIPTION
One of my passwords saved in `~/.docker/config.json` contains a colon. Because of this, every attempt to use `containerlab deploy` would fail with:

```
INFO[0000] Containerlab v0.56.0 started                 
INFO[0000] Parsing & checking topology file: sonic01.clab.yml 
Error: unexpected auth string
```