### PR TITLE
Allow overriding data installation prefix

### DIFF
--- a/clab/config/template.go
+++ b/clab/config/template.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -58,7 +59,11 @@ func RenderAll(allnodes map[string]*NodeConfig) error {
 
 	for i, v := range TemplatePaths {
 		if v == "@" {
-			TemplatePaths[i] = "/etc/containerlab/templates/"
+			prefix := os.Getenv("CLAB_PREFIX")
+			if prefix == "" {
+				prefix = "/etc/containerlab"
+			}
+			TemplatePaths[i] = filepath.Join(prefix, "templates/")
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -16,11 +17,6 @@ import (
 	"github.com/srl-labs/containerlab/clab"
 	"github.com/srl-labs/containerlab/clab/dependency_manager"
 	"github.com/srl-labs/containerlab/runtime"
-)
-
-const (
-	// file name of a topology export data.
-	defaultExportTemplateFPath = "/etc/containerlab/templates/export/auto.tmpl"
 )
 
 // name of the container management network.
@@ -62,6 +58,13 @@ var deployCmd = &cobra.Command{
 }
 
 func init() {
+	prefix := os.Getenv("CLAB_PREFIX")
+	if prefix == "" {
+		prefix = "/etc/containerlab"
+	}
+
+	defaultExportTemplateFPath := filepath.Join(prefix, "templates/export/auto.tmpl")
+
 	rootCmd.AddCommand(deployCmd)
 	deployCmd.Flags().BoolVarP(&graph, "graph", "g", false, "generate topology graph")
 	deployCmd.Flags().StringVarP(&mgmtNetName, "network", "", "", "management network name")

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -9,6 +9,8 @@ import (
 	_ "embed"
 	"encoding/json"
 	"html/template"
+	"os"
+	"path/filepath"
 	"sort"
 
 	log "github.com/sirupsen/logrus"
@@ -17,11 +19,6 @@ import (
 	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
-)
-
-const (
-	defaultGraphTemplatePath = "/etc/containerlab/templates/graph/nextui/nextui.html"
-	defaultStaticPath        = "/etc/containerlab/templates/graph/nextui/static"
 )
 
 var (
@@ -146,6 +143,14 @@ func graphFn(_ *cobra.Command, _ []string) error {
 }
 
 func init() {
+	prefix := os.Getenv("CLAB_PREFIX")
+	if prefix == "" {
+		prefix = "/etc/containerlab"
+	}
+
+	defaultGraphTemplatePath := filepath.Join(prefix, "templates/graph/nextui/nextui.html")
+	defaultStaticPath := filepath.Join(prefix, "templates/graph/nextui/static")
+
 	rootCmd.AddCommand(graphCmd)
 	graphCmd.Flags().StringVarP(&srv, "srv", "s", "0.0.0.0:50080",
 		"HTTP server address serving the topology view")


### PR DESCRIPTION
Allow changing the default installation directory where containerlab expects to find templates, using $CLAB_PREFIX.

Alternatively there could be a $CLAB_TEMPLATES_DIR or similar.