### PR TITLE
Don't crash if encoded Docker password contains +

### DIFF
--- a/runtime/docker/auth.go
+++ b/runtime/docker/auth.go
@@ -89,7 +89,7 @@ func GetDockerAuth(dockerConfig *DockerConfig, imageName string) (string, error)
 		return "", nil
 	}
 
-	decodedAuth, err := base64.URLEncoding.DecodeString(auth)
+	decodedAuth, err := base64.StdEncoding.DecodeString(auth)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is a different bug from #2167. The decoding is done using URL encoding (`A-Za-z-_`) instead of standard encoding (`A-Za-z+/`).

This would cause a crash if a Docker password happened to encoding to a string with a `+` or `/`, as was my case with my quay.io account:

```
$ containerlab deploy
INFO[0000] Containerlab v0.57.0 started                 
INFO[0000] Parsing & checking topology file: frr.clab.yml 
Error: illegal base64 data at input byte 15
```