### PR TITLE
removing whitespaces and linefeed from NodeType parameter.

### DIFF
--- a/types/topology.go
+++ b/types/topology.go
@@ -1,10 +1,11 @@
 package types
 
 import (
+	"strings"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/utils"
-	"strings"
 )
 
 // Topology represents a lab topology.

--- a/types/topology.go
+++ b/types/topology.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/utils"
+	"strings"
 )
 
 // Topology represents a lab topology.
@@ -294,10 +295,10 @@ func (t *Topology) GetNodeGroup(name string) string {
 func (t *Topology) GetNodeType(name string) string {
 	if ndef, ok := t.Nodes[name]; ok {
 		if v := ndef.GetType(); v != "" {
-			return v
+			return strings.TrimSpace(v)
 		}
 		if v := t.GetKind(t.GetNodeKind(name)).GetType(); v != "" {
-			return v
+			return strings.TrimSpace(v)
 		}
 	}
 	return t.GetDefaults().GetType()


### PR DESCRIPTION
When using custom-sros-variant in clab topology definition, the trailing \n is added as parameter to vrnetlab. Since https://github.com/srl-labs/containerlab/pull/2012 the parameter is escaped with %q which result in "n" is added as NodeType parameter to vrnetlab. vrnetlab also passes the same to vsim instannce which always fails to boot with incorrect type.

Not sure if this is best way to fix this issue. As a workaround, I added white space at the end of my type definition in topology yaml.
