### PR TITLE
Minor documentation fix for XRd and Cat9kv

### DIFF
--- a/docs/manual/kinds/vr-cat9kv.md
+++ b/docs/manual/kinds/vr-cat9kv.md
@@ -35,7 +35,7 @@ Users can adjust the CPU and memory resources by setting adding appropriate envi
 You can manage the [[[ kind_display_name ]]] with containerlab via the following interfaces:
 
 /// tab | bash
-to connect to a `bash` shell of a running Cisco CSR1000v container:
+to connect to a `bash` shell of a running [[[ kind_display_name ]]] container:
 
 ```bash
 docker exec -it <container-name/id> bash
@@ -43,7 +43,7 @@ docker exec -it <container-name/id> bash
 
 ///
 /// tab | CLI
-to connect to the Catalyst 9000v CLI
+to connect to the [[[ kind_display_name ]]]  CLI
 
 ```bash
 ssh admin@<container-name/id>

--- a/docs/manual/kinds/xrd.md
+++ b/docs/manual/kinds/xrd.md
@@ -22,11 +22,23 @@ XRd image is available for download only for users who have an active service ac
 
 ## Host server requirements
 
-You should increase the value of `user.max_inotify_instances`:
+Cisco [xrdocs](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-setting-up-host-environment-to-run-xrd/#making-suggested-corrections-to-the-host-machine) reccomends to increase `inotify.max_user_instances` and `inotify.max_user_watches`.
+
+You can do this by executing the following:
 
 ```bash
-sysctl -w user.max_inotify_instances=64000
+sysctl -w fs.inotify.max_user_instances=64000
+sysctl -w fs.inotify.max_user_watches=64000
 ```
+
+To make the settings persist reboots append `fs.inotify.max_user_instances=64000` and `fs.inotify.max_user_watches=64000` to `/etc/sysctl.conf`. You can use the following one-liner:
+
+```
+echo -e "fs.inotify.max_user_instances=64000\nfs.inotify.max_user_watches=64000" | sudo tee -a /etc/sysctl.conf
+```
+
+!!!tip
+    If using 10+ XRd nodes, you may need to increase the `fs.inotify.max_user_instances` and/or `fs.inotify.max_user_watches` even higher.
 
 ## Managing XRd nodes
 


### PR DESCRIPTION
The Cat9kv had an erroneous reference to csr1000v under the instructions on connecting to the bash shell. I've fixed this and use the `[[[ kind_display_name ]]]` instead.

I've also added some more information on host tuning to make XRd run properly, as well as tuning for larger-scale XRd topologies. Hopefully it's easier and more informative for users.