### PR TITLE
Dedup TopoFileLoading

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -184,11 +184,6 @@ func listContainers(ctx context.Context, topo string) ([]runtime.GenericContaine
 		clab.WithTimeout(timeout),
 	}
 
-	c, err := clab.NewContainerLab(opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	// filter to list all containerlab containers
 	// it is overwritten if topo file is provided
 	filter := []*types.GenericFilter{{
@@ -199,11 +194,15 @@ func listContainers(ctx context.Context, topo string) ([]runtime.GenericContaine
 
 	// when topo file is provided, filter containers by lab name
 	if topo != "" {
-		err := c.LoadTopologyFromFile(topo, varsFile)
-		if err != nil {
-			return nil, err
-		}
+		opts = append(opts, clab.WithTopoPath(topo, varsFile))
+	}
 
+	c, err := clab.NewContainerLab(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if topo != "" {
 		filter = []*types.GenericFilter{{
 			FilterType: "label",
 			Field:      labels.Containerlab,

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -200,29 +199,16 @@ func listContainers(ctx context.Context, topo string) ([]runtime.GenericContaine
 
 	// when topo file is provided, filter containers by lab name
 	if topo != "" {
-		topo, err = c.ProcessTopoPath(topo)
+		err := c.LoadTopologyFromFile(topo, varsFile)
 		if err != nil {
 			return nil, err
-		}
-
-		// read topo yaml file to get the lab name
-		topo, err := os.ReadFile(topo)
-		if err != nil {
-			return nil, err
-		}
-
-		config := &clab.Config{}
-
-		err = yaml.Unmarshal(topo, config)
-		if err != nil {
-			return nil, fmt.Errorf("%w, failed to parse topology file", err)
 		}
 
 		filter = []*types.GenericFilter{{
 			FilterType: "label",
 			Field:      labels.Containerlab,
 			Operator:   "=",
-			Match:      config.Name,
+			Match:      c.Config.Name,
 		}}
 	}
 


### PR DESCRIPTION
Related to #2225 this dedups the code for loading topologies, where we've had a seperate implementation for the Destroy action.