### PR TITLE
Change management interface on IOL Layer 2 images from Vlan0

### DIFF
--- a/nodes/iol/iol.cfg.tmpl
+++ b/nodes/iol/iol.cfg.tmpl
@@ -13,29 +13,22 @@ no ip domain lookup
 username admin privilege 15 secret admin
 !
 vrf definition clab-mgmt
+ description clab-mgmt
  address-family ipv4
  !
  address-family ipv6
  !
 !
+interface Ethernet0/0
 {{ if .IsL2Node }}
-interface Vlan1
+ no switchport
+{{ end }}
  vrf forwarding clab-mgmt
+ description clab-mgmt
  ip address {{ .MgmtIPv4Addr }} {{ .MgmtIPv4SubnetMask }}
  ipv6 address {{ .MgmtIPv6Addr }}/{{ .MgmtIPv6PrefixLen }}
-!
-{{ end }}
-interface Ethernet0/0
  no shutdown
  mac-address {{ .MgmtIntfMacAddr }}
-{{ if .IsL2Node }}
- switchport mode access
- switchport access vlan 1
-{{ else }}
- vrf forwarding clab-mgmt
- ip address {{ .MgmtIPv4Addr }} {{ .MgmtIPv4SubnetMask }}
- ipv6 address {{ .MgmtIPv6Addr }}/{{ .MgmtIPv6PrefixLen }}
-{{ end }}
 !{{ range $index, $item := .DataIFaces }}
 interface Ethernet{{ .Slot }}/{{ .Port }}
  no shutdown
@@ -43,8 +36,8 @@ interface Ethernet{{ .Slot }}/{{ .Port }}
 !{{ end }}
 ip forward-protocol nd
 !
-ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {{ if .IsL2Node }}Vlan1{{ else }}Ethernet0/0{{ end }} {{ .MgmtIPv4GW }}
-ipv6 route vrf clab-mgmt ::/0 {{ if .IsL2Node }}Vlan1{{ else }}Ethernet0/0{{ end }} {{ .MgmtIPv6GW }}
+ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {Ethernet0/0} {{ .MgmtIPv4GW }}
+ipv6 route vrf clab-mgmt ::/0 {Ethernet0/0} {{ .MgmtIPv6GW }}
 !
 ip ssh version 2
 crypto key generate rsa modulus 2048

--- a/nodes/iol/iol.cfg.tmpl
+++ b/nodes/iol/iol.cfg.tmpl
@@ -36,8 +36,8 @@ interface Ethernet{{ .Slot }}/{{ .Port }}
 !{{ end }}
 ip forward-protocol nd
 !
-ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 {Ethernet0/0} {{ .MgmtIPv4GW }}
-ipv6 route vrf clab-mgmt ::/0 {Ethernet0/0} {{ .MgmtIPv6GW }}
+ip route vrf clab-mgmt 0.0.0.0 0.0.0.0 Ethernet0/0 {{ .MgmtIPv4GW }}
+ipv6 route vrf clab-mgmt ::/0 Ethernet0/0 {{ .MgmtIPv6GW }}
 !
 ip ssh version 2
 crypto key generate rsa modulus 2048

--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -33,7 +33,7 @@ Verify links in node router1
 
 Verify links in node switch
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-switch sh ip int br | head -9 | tail -1
+    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-switch sh ip int br | head -5 | tail -1
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    172.20.20.


### PR DESCRIPTION
Change management interface on IOL Layer 2 images from Vlan0 to Ethernet 0/0. While at it, get rid of any specific SVI configuration. Please note that the order of configurations statements is important.

When testing, please allocate enough time before trying to ssh into the layer 2 iol devices. Its initialization time is significantly higher then that of layer 3 iol devices.

The modification where tested both with containerlab and with the work in progress to support iol image in networklab through it's containerlab backed.  