### PR TITLE
Adding HostExec for stages and RestartPolicy

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -197,6 +197,7 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		Memory:          c.Config.Topology.GetNodeMemory(nodeName),
 		StartupDelay:    c.Config.Topology.GetNodeStartupDelay(nodeName),
 		AutoRemove:      c.Config.Topology.GetNodeAutoRemove(nodeName),
+		RestartPolicy:   c.Config.Topology.GetRestartPolicy(nodeName),
 		Extras:          c.Config.Topology.GetNodeExtras(nodeName),
 		DNS:             c.Config.Topology.GetNodeDns(nodeName),
 		Certificate:     c.Config.Topology.GetCertificateConfig(nodeName),

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -102,7 +102,7 @@ func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {
 
 func (d *DependencyNode) runExecs(ctx context.Context, ct types.CommandType, p types.WaitForStage) {
 
-	for _, target := range []types.CommandTarget{types.CommandTargetContainer, types.CommandTargetHost} {
+	for _, target := range []types.CommandTarget{types.CommandTargetHost, types.CommandTargetContainer} {
 
 		execs, err := d.getExecs(p, ct, target)
 		if err != nil {

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -91,11 +91,6 @@ func (d *DependencyNode) getExecs(p types.WaitForStage, t types.CommandType, tar
 	return e.GetExecCommands(t)
 }
 
-const (
-	execsConst     = "execs"
-	hostExecsConst = "host-execs"
-)
-
 // EnterStage is called by a node that is meant to enter the specified stage.
 // The call will be blocked until all dependencies for the node to enter the stage are met.
 func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/clab/exec"
 	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/nodes/host"
 	"github.com/srl-labs/containerlab/types"
 )
 
@@ -61,21 +62,39 @@ func (d *DependencyNode) getStageWG(n types.WaitForStage) *sync.WaitGroup {
 	return d.stageWG[n]
 }
 
-func (d *DependencyNode) getExecs(p types.WaitForStage, t types.CommandType) ([]*exec.ExecCmd, error) {
+func (d *DependencyNode) getExecs(p types.WaitForStage, t types.CommandType, target types.CommandTarget) ([]*exec.ExecCmd, error) {
+
+	var sb types.StageBase
 	switch p {
 	case types.WaitForCreate:
-		return d.Config().Stages.Create.GetExecCommands(t)
+		sb = d.Config().Stages.Create.StageBase
 	case types.WaitForCreateLinks:
-		return d.Config().Stages.CreateLinks.GetExecCommands(t)
+		sb = d.Config().Stages.CreateLinks.StageBase
 	case types.WaitForConfigure:
-		return d.Config().Stages.Configure.GetExecCommands(t)
+		sb = d.Config().Stages.Configure.StageBase
 	case types.WaitForHealthy:
-		return d.Config().Stages.Healthy.GetExecCommands(t)
+		sb = d.Config().Stages.Healthy.StageBase
 	case types.WaitForExit:
-		return d.Config().Stages.Exit.GetExecCommands(t)
+		sb = d.Config().Stages.Exit.StageBase
+	default:
+		return nil, fmt.Errorf("stage %s unknown", p)
 	}
-	return nil, fmt.Errorf("stage %s unknown", p)
+
+	var e types.Execs
+	switch target {
+	case types.CommandTargetContainer:
+		e = sb.Execs
+	case types.CommandTargetHost:
+		e = sb.HostExecs
+	}
+
+	return e.GetExecCommands(t)
 }
+
+const (
+	execsConst     = "execs"
+	hostExecsConst = "host-execs"
+)
 
 // EnterStage is called by a node that is meant to enter the specified stage.
 // The call will be blocked until all dependencies for the node to enter the stage are met.
@@ -87,26 +106,35 @@ func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {
 }
 
 func (d *DependencyNode) runExecs(ctx context.Context, ct types.CommandType, p types.WaitForStage) {
-	execs, err := d.getExecs(p, ct)
-	if err != nil {
-		log.Errorf("error getting exec commands defined for %s: %v", d.GetShortName(), err)
-	}
 
-	if len(execs) == 0 {
-		return
-	}
+	for _, target := range []types.CommandTarget{types.CommandTargetContainer, types.CommandTargetHost} {
 
-	// exec the commands
-	execResultCollection := exec.NewExecCollection()
-
-	for _, exec := range execs {
-		execResult, err := d.RunExec(ctx, exec)
+		execs, err := d.getExecs(p, ct, target)
 		if err != nil {
-			log.Errorf("error on exec in node %s for stage %s: %v", d.GetShortName(), p, err)
+			log.Errorf("error getting exec commands defined for %s: %v", d.GetShortName(), err)
 		}
-		execResultCollection.Add(d.GetShortName(), execResult)
+
+		if len(execs) == 0 {
+			continue
+		}
+
+		// exec the commands
+		execResultCollection := exec.NewExecCollection()
+		var execResult *exec.ExecResult
+		for _, exec := range execs {
+			if target == types.CommandTargetContainer {
+				execResult, err = d.RunExec(ctx, exec)
+			} else {
+				execResult, err = host.RunExec(ctx, exec)
+			}
+			if err != nil {
+				log.Errorf("error on exec in node %s for stage %s: %v", d.GetShortName(), p, err)
+			}
+			execResultCollection.Add(d.GetShortName(), execResult)
+		}
+		execResultCollection.Log()
 	}
-	execResultCollection.Log()
+
 }
 
 // Done is called by a node that has finished all tasks for the provided stage.

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -88,6 +88,32 @@ topology:
       image-pull-policy: Always
 ```
 
+### restart-policy
+
+With `restart-policy` a user defines the restart policy of a container as per [docker docs](https://docs.docker.com/engine/containers/start-containers-automatically/).
+
+Valid values are:
+
+- `no` - Don't automatically restart the container.
+- `on-failure` - Restart the container if it exits due to an error, which manifests as a non-zero exit code. The on-failure policy only prompts a restart if the container exits with a failure. It doesn't restart the container if the daemon restarts.
+- `always` - Always restart the container if it stops. If it's manually stopped, it's restarted only when Docker daemon restarts or the container itself is manually restarted.
+- `unless-stopped` Similar to always, except that when the container is stopped (manually or otherwise), it isn't restarted even after Docker daemon restarts.
+
+`no` is the default restart policy value for all kinds, but `linux`. Linux kind defaults to `always`.
+
+```yaml
+topology:
+  nodes:
+    srl:
+      image: ghcr.io/nokia/srlinux
+      kind: nokia_srlinux
+      restart-policy: always
+    alpine:
+      kind: linux
+      image: alpine
+      restart-policy: "no"
+```
+
 ### license
 
 Some containerized NOSes require a license to operate or can leverage a license to lift-off limitations of an unlicensed version. With `license` property a user sets a path to a license file that a node will use. The license file will then be mounted to the container by the path that is defined by the `kind/type` of the node.
@@ -757,6 +783,24 @@ In the example above, the `ls /sys/class/net/` command will be executed when `no
 Per-stage command execution gives you additional flexibility in terms of when the commands are executed, and what commands are executed at each stage.
 
 <!-- --8<-- [end:per-stage-1] -->
+
+##### Host exec
+
+The stage's `exec` property runs the commands in the container namespace and therefore targets the container node itself. This is super useful in itself, but sometimes you need to run a command on the host as a reaction to a stage enter/exit event.
+
+This is what `host-exec` is designed for. It runs the command in the host namespace and therefore targets the host itself.
+
+```yaml
+nodes:
+  node1:
+    stages:
+      create-links:
+        host-exec:
+          on-enter:
+            - touch /tmp/hello
+```
+
+In the example above, containerlab will run `touch /tmp/hello` command when the `node1` is about to enter the `create-links` stage. You can use `host-exec` in every stage.
 
 ### certificate
 

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -109,6 +109,10 @@ func (*host) GetContainers(_ context.Context) ([]runtime.GenericContainer, error
 
 // RunExec runs commands on the container host.
 func (*host) RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
+	return RunExec(ctx, e)
+}
+
+func RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
 	// retireve the command with its arguments
 	command := e.GetCmd()
 

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -38,6 +38,10 @@ func (n *linux) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	n.DefaultNode = *nodes.NewDefaultNode(n)
 	n.Cfg = cfg
 
+	// linux kind uses `always` as a default restart policy
+	// since often they run auxiliary services that might fail because
+	// of the wrong configuration or other reasons.
+	// Usually we want those services to automatically restart.
 	if n.Cfg.RestartPolicy == "" {
 		n.Cfg.RestartPolicy = "always"
 	}

--- a/nodes/linux/linux.go
+++ b/nodes/linux/linux.go
@@ -37,6 +37,11 @@ func (n *linux) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 	// Init DefaultNode
 	n.DefaultNode = *nodes.NewDefaultNode(n)
 	n.Cfg = cfg
+
+	if n.Cfg.RestartPolicy == "" {
+		n.Cfg.RestartPolicy = "always"
+	}
+
 	for _, o := range opts {
 		o(n)
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -502,8 +502,19 @@ func (d *DockerRuntime) CreateContainer(ctx context.Context, node *types.NodeCon
 
 	// regular linux containers may benefit from automatic restart on failure
 	// note, that veth pairs added to this container (outside of eth0) will be lost on restart
-	if node.Kind == "linux" && !node.AutoRemove {
-		containerHostConfig.RestartPolicy.Name = "on-failure"
+	if !node.AutoRemove && node.RestartPolicy != "" {
+		var rp container.RestartPolicyMode
+		switch node.RestartPolicy {
+		case "no":
+			rp = container.RestartPolicyDisabled
+		case "always":
+			rp = container.RestartPolicyAlways
+		case "on-failure":
+			rp = container.RestartPolicyOnFailure
+		case "unless-stopped":
+			rp = container.RestartPolicyUnlessStopped
+		}
+		containerHostConfig.RestartPolicy.Name = rp
 	}
 
 	cont, err := d.Client.ContainerCreate(

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -15,7 +15,7 @@
                 },
                 "image-pull-policy": {
                     "type": "string",
-                    "description": "policy for pulling the referenced cotnainer image",
+                    "description": "policy for pulling the referenced container image",
                     "markdownDescription": "container [image-pull-policy](https://containerlab.dev/manual/nodes/#image-pull-policy) to use for this node",
                     "enum": [
                         "always",
@@ -24,6 +24,21 @@
                         "Never",
                         "ifnotpresent",
                         "IfNotPresent"
+                    ]
+                },
+                "restart-policy": {
+                    "type": "string",
+                    "description": "restart policy for the referenced container image",
+                    "markdownDescription": "container [restart-policy](https://containerlab.dev/manual/nodes/#restart-policy) to use for this node",
+                    "enum": [
+                        "no",
+                        "No",
+                        "on-failure",
+                        "On-failure",
+                        "Always",
+                        "always",
+                        "unless-stopped",
+                        "Unless-stopped"
                     ]
                 },
                 "kind": {

--- a/tests/01-smoke/18-stages.robot
+++ b/tests/01-smoke/18-stages.robot
@@ -92,6 +92,10 @@ Ensure node1 executed on-enter commands for its create-links stage and this outp
 
     Log    ${match}
 
+Ensure host-exec file is created with the right content
+    ${content} =    Get File    /tmp/host-exec-test
+    Should Contain    ${content}    foo    msg=File does not contain the expected string
+
 Deploy ${lab-name} lab with a single worker
     Run Keyword    Teardown
 

--- a/tests/01-smoke/stages.clab.yml
+++ b/tests/01-smoke/stages.clab.yml
@@ -17,6 +17,9 @@ topology:
             - node: node2
               stage: create
         create-links:
+          host-exec:
+            on-enter:
+              - bash -c 'echo foo > /tmp/host-exec-test'
           exec:
             on-enter:
               - ls /sys/class/net/

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -22,6 +22,7 @@ type NodeDefinition struct {
 	EnforceStartupConfig  *bool             `yaml:"enforce-startup-config,omitempty"`
 	SuppressStartupConfig *bool             `yaml:"suppress-startup-config,omitempty"`
 	AutoRemove            *bool             `yaml:"auto-remove,omitempty"`
+	RestartPolicy         string            `yaml:"restart-policy,omitempty"`
 	Config                *ConfigDispatcher `yaml:"config,omitempty"`
 	Image                 string            `yaml:"image,omitempty"`
 	ImagePullPolicy       string            `yaml:"image-pull-policy,omitempty"`
@@ -167,6 +168,13 @@ func (n *NodeDefinition) GetAutoRemove() *bool {
 		return nil
 	}
 	return n.AutoRemove
+}
+
+func (n *NodeDefinition) GetRestartPolicy() string {
+	if n == nil {
+		return ""
+	}
+	return n.RestartPolicy
 }
 
 func (n *NodeDefinition) GetConfigDispatcher() *ConfigDispatcher {

--- a/types/topology.go
+++ b/types/topology.go
@@ -245,6 +245,18 @@ func (t *Topology) GetNodeAutoRemove(name string) bool {
 	return false
 }
 
+func (t *Topology) GetRestartPolicy(name string) string {
+	if ndef, ok := t.Nodes[name]; ok {
+		if l := ndef.GetRestartPolicy(); l != "" {
+			return l
+		}
+		if l := t.GetKind(t.GetNodeKind(name)).GetRestartPolicy(); l != "" {
+			return l
+		}
+	}
+	return t.GetDefaults().GetRestartPolicy()
+}
+
 func (t *Topology) GetNodeLicense(name string) string {
 	if ndef, ok := t.Nodes[name]; ok {
 		if l := ndef.GetLicense(); l != "" {

--- a/types/types.go
+++ b/types/types.go
@@ -114,7 +114,8 @@ type NodeConfig struct {
 	// when set to true will prevent creation of a startup-config, for auto-provisioning testing (ZTP)
 	SuppressStartupConfig bool `json:"suppress-startup-config,omitempty"`
 	// when set to true will auto-remove a stopped/failed container
-	AutoRemove bool `json:"auto-remove,omitempty"`
+	AutoRemove    bool   `json:"auto-remove,omitempty"`
+	RestartPolicy string `json:"restart-policy,omitempty"`
 	// path to config file that is actually mounted to the container and is a result of templation
 	ResStartupConfig string            `json:"startup-config-abs-path,omitempty"`
 	Config           *ConfigDispatcher `json:"config,omitempty"`


### PR DESCRIPTION
Adding the RestartPolicy as a knob, also cleaning up the docker runtime from referencing specific node kinds.
Further implements host-exec per stage, which executes commands in the host namespace as part of the stages of a specific node.
Tackling the two topics that surfaced in #2233 

```
name: linuxfrr

topology:
  kinds:
    linux:
      image: alpine
  nodes:
    frr1:
      kind: linux
      stages:
        configure:
          host-exec:
            on-enter:
              - docker update --restart=no clab-linuxfrr-frr1
    frr2:
      kind: linux
    frr3:
      kind: linux
      restart-policy: no
```

The json schema update is missing so far, as well as docs update.