### PR TITLE
Reorg the stage exec struct

### DIFF
--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -63,7 +63,6 @@ func (d *DependencyNode) getStageWG(n types.WaitForStage) *sync.WaitGroup {
 }
 
 func (d *DependencyNode) getExecs(stage types.WaitForStage, execPhase types.ExecPhase) ([]*types.Exec, error) {
-
 	var sb types.StageBase
 	switch stage {
 	case types.WaitForCreate:
@@ -100,9 +99,8 @@ func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {
 	d.runExecs(ctx, types.CommandExecutionPhaseEnter, p)
 }
 
-func (d *DependencyNode) runExecs(ctx context.Context, ct types.ExecPhase, p types.WaitForStage) {
-
-	execs, err := d.getExecs(p, ct)
+func (d *DependencyNode) runExecs(ctx context.Context, execPhase types.ExecPhase, stage types.WaitForStage) {
+	execs, err := d.getExecs(stage, execPhase)
 	if err != nil {
 		log.Errorf("error getting exec commands defined for %s: %v", d.GetShortName(), err)
 	}
@@ -119,7 +117,7 @@ func (d *DependencyNode) runExecs(ctx context.Context, ct types.ExecPhase, p typ
 
 		execCmd, err := exec.GetExecCmd()
 		if err != nil {
-			log.Errorf("%s stage %s error parsing command: %s", d.GetShortName(), p, exec.String())
+			log.Errorf("%s stage %s error parsing command: %s", d.GetShortName(), stage, exec.String())
 		}
 
 		switch *exec.Target {
@@ -133,7 +131,7 @@ func (d *DependencyNode) runExecs(ctx context.Context, ct types.ExecPhase, p typ
 			continue
 		}
 		if err != nil {
-			log.Errorf("error on exec in node %s for stage %s: %v", d.GetShortName(), p, err)
+			log.Errorf("error on exec in node %s for stage %s: %v", d.GetShortName(), stage, err)
 		}
 		execResultCollection.Add(hostname, execResult)
 	}

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -62,10 +62,10 @@ func (d *DependencyNode) getStageWG(n types.WaitForStage) *sync.WaitGroup {
 	return d.stageWG[n]
 }
 
-func (d *DependencyNode) getExecs(p types.WaitForStage, t types.CommandExecutionPhase) ([]*types.CommandAndTarget, error) {
+func (d *DependencyNode) getExecs(stage types.WaitForStage, execPhase types.ExecPhase) ([]*types.Exec, error) {
 
 	var sb types.StageBase
-	switch p {
+	switch stage {
 	case types.WaitForCreate:
 		sb = d.Config().Stages.Create.StageBase
 	case types.WaitForCreateLinks:
@@ -77,13 +77,13 @@ func (d *DependencyNode) getExecs(p types.WaitForStage, t types.CommandExecution
 	case types.WaitForExit:
 		sb = d.Config().Stages.Exit.StageBase
 	default:
-		return nil, fmt.Errorf("stage %s unknown", p)
+		return nil, fmt.Errorf("stage %s unknown", stage)
 	}
 
-	var result = []*types.CommandAndTarget{}
+	var result = []*types.Exec{}
 	for _, x := range sb.Execs {
 		// filter the list of commands for the given phase (on-enter / on-exit)
-		if *x.Phase == t {
+		if *x.Phase == execPhase {
 			result = append(result, x)
 		}
 	}
@@ -100,7 +100,7 @@ func (d *DependencyNode) EnterStage(ctx context.Context, p types.WaitForStage) {
 	d.runExecs(ctx, types.CommandExecutionPhaseEnter, p)
 }
 
-func (d *DependencyNode) runExecs(ctx context.Context, ct types.CommandExecutionPhase, p types.WaitForStage) {
+func (d *DependencyNode) runExecs(ctx context.Context, ct types.ExecPhase, p types.WaitForStage) {
 
 	execs, err := d.getExecs(p, ct)
 	if err != nil {

--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -82,7 +82,7 @@ func (d *DependencyNode) getExecs(stage types.WaitForStage, execPhase types.Exec
 	var result = []*types.Exec{}
 	for _, x := range sb.Execs {
 		// filter the list of commands for the given phase (on-enter / on-exit)
-		if *x.Phase == execPhase {
+		if x.Phase == execPhase {
 			result = append(result, x)
 		}
 	}
@@ -120,7 +120,7 @@ func (d *DependencyNode) runExecs(ctx context.Context, execPhase types.ExecPhase
 			log.Errorf("%s stage %s error parsing command: %s", d.GetShortName(), stage, exec.String())
 		}
 
-		switch *exec.Target {
+		switch exec.Target {
 		case types.CommandTargetContainer:
 			execResult, err = d.RunExec(ctx, execCmd)
 			hostname = d.GetShortName()

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -693,7 +693,7 @@ topology:
 
 ### stages
 
-Containerlab v0.51.0 introduces a new concept of **stages**. Stages are a way to define stages a node goes through during its lifecycle and the interdependencies between the different stages of different nodes in the lab.
+Stages are a way to define stages a node goes through during its lifecycle and the interdependencies between the different stages of different nodes in the lab.
 
 The stages are currently mainly used to host the `wait-for` knob, which is used to define the startup dependencies between nodes.
 
@@ -765,8 +765,7 @@ The existing [`exec`](#exec) node configuration parameter is used to run command
 
 These more advanced command execution scenarios are enabled in the per-stage command execution feature.
 
-<!-- --8<-- [start:per-stage-1] -->
-With per-stage command execution the user can define `exec` block under each stage; moreover, it is possible to specify when the commands should be run `on-enter` or `on-exit` of the stage.
+With per-stage command execution the user can define `exec` block under each stage; moreover, it is possible to specify when the commands should be run `on-enter` or `on-exit` of the stage. And if that is not enough, you can also specify where the command should be executed, on the host or in the container.
 
 ```yaml
 nodes:
@@ -774,33 +773,36 @@ nodes:
     stages:
       create-links:
         exec:
-          on-enter:
-            - ls /sys/class/net/
+          - command: ls /sys/class/net/
+            target: container #(1)!
+            phase: on-enter #(2)!
 ```
+
+1. `target` defaults to "container" and can be omitted. Possible values `container` or `host`
+2. `phase` defaults to "on-enter" and can be omitted. Possible values `on-enter` or `on-exit`
 
 In the example above, the `ls /sys/class/net/` command will be executed when `node1` is about to enter the `create-links` stage. As expected, the command will list only interfaces provisioned by docker (eth0 and lo), but none of the containerlab-provisioned interfaces, since the create-links stage has not been finished yet.
 
 Per-stage command execution gives you additional flexibility in terms of when the commands are executed, and what commands are executed at each stage.
 
-<!-- --8<-- [end:per-stage-1] -->
-
 ##### Host exec
 
 The stage's `exec` property runs the commands in the container namespace and therefore targets the container node itself. This is super useful in itself, but sometimes you need to run a command on the host as a reaction to a stage enter/exit event.
 
-This is what `host-exec` is designed for. It runs the command in the host namespace and therefore targets the host itself.
+This is what `target` property of the stage's `exec` is designed for. It runs the command in the host namespace and therefore targets the host itself.
 
 ```yaml
 nodes:
   node1:
     stages:
       create-links:
-        host-exec:
-          on-enter:
-            - touch /tmp/hello
+        exec:
+          - command: touch /tmp/hello
+            target: host
+            phase: on-enter
 ```
 
-In the example above, containerlab will run `touch /tmp/hello` command when the `node1` is about to enter the `create-links` stage. You can use `host-exec` in every stage.
+In the example above, containerlab will run `touch /tmp/hello` command when the `node1` is about to enter the `create-links` stage.
 
 ### certificate
 

--- a/docs/rn/0.52.md
+++ b/docs/rn/0.52.md
@@ -39,7 +39,21 @@ With links asynchronous creation, you can now define the stages for your nodes a
 
 With [Stages](../manual/nodes.md#stages) introduction in the previous release, we opened new possibilities for the nodes lifecycle management. Now, @steiler expanded it even further by adding the [per-stage exec](../manual/nodes.md#per-stage-command-execution) option to the stages.
 
---8<-- "docs/manual/nodes.md:per-stage-1"
+With per-stage command execution the user can define `exec` block under each stage; moreover, it is possible to specify when the commands should be run `on-enter` or `on-exit` of the stage.
+
+```yaml
+nodes:
+  node1:
+    stages:
+      create-links:
+        exec:
+          on-enter:
+            - ls /sys/class/net/
+```
+
+In the example above, the `ls /sys/class/net/` command will be executed when `node1` is about to enter the `create-links` stage. As expected, the command will list only interfaces provisioned by docker (eth0 and lo), but none of the containerlab-provisioned interfaces, since the create-links stage has not been finished yet.
+
+Per-stage command execution gives you additional flexibility in terms of when the commands are executed, and what commands are executed at each stage.
 
 ## k8s-kind extra options
 

--- a/tests/01-smoke/stages.clab.yml
+++ b/tests/01-smoke/stages.clab.yml
@@ -17,12 +17,11 @@ topology:
             - node: node2
               stage: create
         create-links:
-          host-exec:
-            on-enter:
-              - bash -c 'echo foo > /tmp/host-exec-test'
           exec:
-            on-enter:
-              - ls /sys/class/net/
+            - command: bash -c 'echo foo > /tmp/host-exec-test'
+              phase: on-enter
+              target: host
+            - command: ls /sys/class/net/
 
     node2:
       cmd: sh -c "date +%s%N > /tmp/time & sh"
@@ -40,8 +39,8 @@ topology:
             - node: node4
               stage: healthy
           exec:
-            on-exit:
-              - ls /sys/class/net/
+            - command: ls /sys/class/net/
+              phase: on-exit
 
     node4:
       cmd: sh -c "date +%s%N > /tmp/time & sh"
@@ -54,12 +53,12 @@ topology:
       stages:
         create-links:
           exec:
-            on-exit:
-              - ls /sys/class/net/
+            - command: ls /sys/class/net/
+              phase: on-exit
         healthy:
           exec:
-            on-exit:
-              - echo 'hey I am existing healthy stage'
+            - command: echo 'hey I am existing healthy stage'
+              phase: on-exit
 
   links:
     - endpoints: ["node1:eth1", "node2:eth1"]

--- a/types/stages.go
+++ b/types/stages.go
@@ -21,8 +21,8 @@ const (
 
 var (
 	// the defauts we need as pointers, so assign them to vars, such that we can acquire the pointer
-	defaultCommandExecutionPhaseVar = CommandExecutionPhaseEnter
-	defaultCommandTargetVar         = CommandTargetContainer
+	defaultCommandExecutionPhase = CommandExecutionPhaseEnter
+	defaultCommandTarget         = CommandTargetContainer
 )
 
 // Stages represents a configuration of a given node deployment stage.
@@ -128,8 +128,10 @@ func (s *Stages) Merge(other *Stages) error {
 	return err
 }
 
+// Execs represents a list of Exec configurations.
 type Execs []*Exec
 
+// HasCommands returns true if the Execs contains at least one command.
 func (c Execs) HasCommands() bool {
 	return len(c) > 0
 }
@@ -153,11 +155,11 @@ type Exec struct {
 func (c *Exec) NilToDefault() {
 	// default the phase to on-enter
 	if c.Phase == nil {
-		c.Phase = &defaultCommandExecutionPhaseVar
+		c.Phase = &defaultCommandExecutionPhase
 	}
 	// default target to container
 	if c.Target == nil {
-		c.Target = &defaultCommandTargetVar
+		c.Target = &defaultCommandTarget
 	}
 }
 
@@ -280,12 +282,12 @@ func (wfl WaitForList) contains(wf *WaitFor) bool {
 
 // Merge merges base stage from sc into s.
 // Merging for WaitFor and Exec commands is done by appending from sc to s without duplicates.
-func (s *StageBase) Merge(sc *StageBase) error {
-	if sc == nil {
+func (s *StageBase) Merge(sb *StageBase) error {
+	if sb == nil {
 		return nil
 	}
 
-	for _, wf := range sc.WaitFor {
+	for _, wf := range sb.WaitFor {
 		// prevent adding the same dependency twice
 		if s.WaitFor.contains(wf) {
 			continue
@@ -293,7 +295,7 @@ func (s *StageBase) Merge(sc *StageBase) error {
 		s.WaitFor = append(s.WaitFor, wf)
 	}
 
-	s.Execs = append(s.Execs, sc.Execs...)
+	s.Execs = append(s.Execs, sb.Execs...)
 
 	return nil
 }

--- a/types/stages.go
+++ b/types/stages.go
@@ -65,14 +65,13 @@ func NewStages() *Stages {
 	}
 }
 
-// NilToDefault containing structs consist of pointer values, that need to be set to default if
-// they are not set to a concrete value via the topo file. This func is doing that initialization.
-func (s *Stages) NilToDefault() {
-	s.Configure.Execs.NilToDefault()
-	s.Create.Execs.NilToDefault()
-	s.CreateLinks.Execs.NilToDefault()
-	s.Healthy.Execs.NilToDefault()
-	s.Exit.Execs.NilToDefault()
+// InitDefaults set defaults for the stages.
+func (s *Stages) InitDefaults() {
+	s.Configure.Execs.InitDefaults()
+	s.Create.Execs.InitDefaults()
+	s.CreateLinks.Execs.InitDefaults()
+	s.Healthy.Execs.InitDefaults()
+	s.Exit.Execs.InitDefaults()
 }
 
 // GetWaitFor returns lists of nodes that need to be waited for in a map
@@ -136,30 +135,28 @@ func (c Execs) HasCommands() bool {
 	return len(c) > 0
 }
 
-// NilToDefault containing structs consist of pointer values, that need to be set to default if
-// they are not set to a concrete value via the topo file. This func is doing that initialization.
-func (c Execs) NilToDefault() {
-	for _, x := range c {
-		x.NilToDefault()
+// InitDefaults sets default values for Execs.
+func (execs Execs) InitDefaults() {
+	for _, e := range execs {
+		e.InitDefaults()
 	}
 }
 
 type Exec struct {
-	Command string      `yaml:"command,omitempty"`
-	Target  *ExecTarget `yaml:"target,omitempty"`
-	Phase   *ExecPhase  `yaml:"phase,omitempty"`
+	Command string     `yaml:"command,omitempty"`
+	Target  ExecTarget `yaml:"target,omitempty"`
+	Phase   ExecPhase  `yaml:"phase,omitempty"`
 }
 
-// NilToDefault containing structs consist of pointer values, that need to be set to default if
-// they are not set to a concrete value via the topo file. This func is doing that initialization.
-func (c *Exec) NilToDefault() {
+// InitDefaults sets default values for Exec.
+func (c *Exec) InitDefaults() {
 	// default the phase to on-enter
-	if c.Phase == nil {
-		c.Phase = &defaultCommandExecutionPhase
+	if c.Phase == "" {
+		c.Phase = defaultCommandExecutionPhase
 	}
 	// default target to container
-	if c.Target == nil {
-		c.Target = &defaultCommandTarget
+	if c.Target == "" {
+		c.Target = defaultCommandTarget
 	}
 }
 
@@ -168,7 +165,7 @@ func (c *Exec) GetExecCmd() (*exec.ExecCmd, error) {
 }
 
 func (c *Exec) String() string {
-	return fmt.Sprintf("phase: %s, command: %s, target: %s", *c.Phase, c.Command, *c.Target)
+	return fmt.Sprintf("phase: %s, command: %s, target: %s", c.Phase, c.Command, c.Target)
 }
 
 type ExecPhase string

--- a/types/stages.go
+++ b/types/stages.go
@@ -39,27 +39,27 @@ func NewStages() *Stages {
 	return &Stages{
 		Create: &StageCreate{
 			StageBase: StageBase{
-				Execs: CommandAndTargetList{},
+				Execs: Execs{},
 			},
 		},
 		CreateLinks: &StageCreateLinks{
 			StageBase: StageBase{
-				Execs: CommandAndTargetList{},
+				Execs: Execs{},
 			},
 		},
 		Configure: &StageConfigure{
 			StageBase: StageBase{
-				Execs: CommandAndTargetList{},
+				Execs: Execs{},
 			},
 		},
 		Healthy: &StageHealthy{
 			StageBase: StageBase{
-				Execs: CommandAndTargetList{},
+				Execs: Execs{},
 			},
 		},
 		Exit: &StageExit{
 			StageBase: StageBase{
-				Execs: CommandAndTargetList{},
+				Execs: Execs{},
 			},
 		},
 	}
@@ -128,29 +128,29 @@ func (s *Stages) Merge(other *Stages) error {
 	return err
 }
 
-type CommandAndTargetList []*CommandAndTarget
+type Execs []*Exec
 
-func (c CommandAndTargetList) HasCommands() bool {
+func (c Execs) HasCommands() bool {
 	return len(c) > 0
 }
 
 // NilToDefault containing structs consist of pointer values, that need to be set to default if
 // they are not set to a concrete value via the topo file. This func is doing that initialization.
-func (c CommandAndTargetList) NilToDefault() {
+func (c Execs) NilToDefault() {
 	for _, x := range c {
 		x.NilToDefault()
 	}
 }
 
-type CommandAndTarget struct {
-	Command string                 `yaml:"command,omitempty"`
-	Target  *CommandTarget         `yaml:"target,omitempty"`
-	Phase   *CommandExecutionPhase `yaml:"phase,omitempty"`
+type Exec struct {
+	Command string      `yaml:"command,omitempty"`
+	Target  *ExecTarget `yaml:"target,omitempty"`
+	Phase   *ExecPhase  `yaml:"phase,omitempty"`
 }
 
 // NilToDefault containing structs consist of pointer values, that need to be set to default if
 // they are not set to a concrete value via the topo file. This func is doing that initialization.
-func (c *CommandAndTarget) NilToDefault() {
+func (c *Exec) NilToDefault() {
 	// default the phase to on-enter
 	if c.Phase == nil {
 		c.Phase = &defaultCommandExecutionPhaseVar
@@ -161,30 +161,30 @@ func (c *CommandAndTarget) NilToDefault() {
 	}
 }
 
-func (c *CommandAndTarget) GetExecCmd() (*exec.ExecCmd, error) {
+func (c *Exec) GetExecCmd() (*exec.ExecCmd, error) {
 	return exec.NewExecCmdFromString(c.Command)
 }
 
-func (c *CommandAndTarget) String() string {
+func (c *Exec) String() string {
 	return fmt.Sprintf("phase: %s, command: %s, target: %s", *c.Phase, c.Command, *c.Target)
 }
 
-type CommandExecutionPhase string
+type ExecPhase string
 
 const (
 	// CommandExecutionPhaseEnter represents a command to be executed when the node enters the stage.
-	CommandExecutionPhaseEnter CommandExecutionPhase = "on-enter"
+	CommandExecutionPhaseEnter ExecPhase = "on-enter"
 	// CommandExecutionPhaseExit represents a command to be executed when the node exits the stage.
-	CommandExecutionPhaseExit CommandExecutionPhase = "on-exit"
+	CommandExecutionPhaseExit ExecPhase = "on-exit"
 )
 
-type CommandTarget string
+type ExecTarget string
 
 const (
 	// CommandTargetContainer determines that the commands are meant to be executed within the container
-	CommandTargetContainer CommandTarget = "container"
+	CommandTargetContainer ExecTarget = "container"
 	// CommandTargetHost determines that the commands are meant to be executed on the host system
-	CommandTargetHost CommandTarget = "host"
+	CommandTargetHost ExecTarget = "host"
 )
 
 // StageCreate represents a creation stage of a given node.
@@ -260,8 +260,8 @@ func (s *StageExit) Merge(other *StageExit) error {
 // StageBase represents a common configuration stage.
 // Other stages embed this type to inherit its configuration options.
 type StageBase struct {
-	WaitFor WaitForList          `yaml:"wait-for,omitempty"`
-	Execs   CommandAndTargetList `yaml:"exec,omitempty"`
+	WaitFor WaitForList `yaml:"wait-for,omitempty"`
+	Execs   Execs       `yaml:"exec,omitempty"`
 }
 
 // WaitForList is a list of WaitFor configurations.

--- a/types/topology.go
+++ b/types/topology.go
@@ -510,7 +510,7 @@ func (t *Topology) GetStages(name string) (*Stages, error) {
 		s.Merge(nodeStages)
 	}
 	// set nil values to their respective defaults
-	s.NilToDefault()
+	s.InitDefaults()
 	return s, nil
 }
 

--- a/types/topology.go
+++ b/types/topology.go
@@ -509,7 +509,8 @@ func (t *Topology) GetStages(name string) (*Stages, error) {
 	if nodeStages != nil {
 		s.Merge(nodeStages)
 	}
-
+	// set nil values to their respective defaults
+	s.NilToDefault()
 	return s, nil
 }
 


### PR DESCRIPTION
This is a slight reorg to #2238.

The structure is now as follows:
```
nodes:
    frr1:
      kind: linux
      stages:
        configure:
          exec:
              - command: <command>
                target: <host / container>                optional, with a default of container
                phase: <on-enter / on-exit>            optional, with a default of on-enter
```