### PR TITLE
Add network aliases to node

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -202,6 +202,7 @@ func (c *CLab) createNodeCfg(nodeName string, nodeDef *types.NodeDefinition, idx
 		DNS:             c.Config.Topology.GetNodeDns(nodeName),
 		Certificate:     c.Config.Topology.GetCertificateConfig(nodeName),
 		Healthcheck:     c.Config.Topology.GetHealthCheckConfig(nodeName),
+		Aliases:         c.Config.Topology.GetNodeAliases(nodeName),
 	}
 	var err error
 

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -890,3 +890,17 @@ When the node is configured with a healthcheck the health status is visible in t
 
 [^1]: [docker runtime resources constraints](https://docs.docker.com/config/containers/resource_constraints/).
 [^2]: this deployment model makes two containers to use a shared network namespace, similar to a Kubernetes pod construct.
+
+### aliases
+
+To define additional hostnames for the node use the `aliases` configuration option. Other containers on the same network can use these aliases to communicate with the node.
+
+```yaml
+topology:
+  nodes:
+    r1:
+      kind: nokia_srlinux
+      image: ghcr.io/nokia/srlinux
+      aliases:
+        - r1.example.com
+```

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -999,6 +999,7 @@ func (d *DockerRuntime) processNetworkMode(
 					IPv4Address: node.MgmtIPv4Address,
 					IPv6Address: node.MgmtIPv6Address,
 				},
+				Aliases: node.Aliases,
 			},
 		}
 	}

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -214,7 +214,7 @@ func (r *PodmanRuntime) createContainerSpec(ctx context.Context, cfg *types.Node
 		// Static IPs & Macs are properties of a network attachment
 		nets := map[string]netTypes.PerNetworkOptions{netName: {
 			StaticIPs:     staticIPs,
-			Aliases:       nil,
+			Aliases:       cfg.Aliases,
 			StaticMAC:     hwAddr,
 			InterfaceName: "",
 		}}

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -333,6 +333,15 @@
                 "healthcheck": {
                     "type": "object",
                     "$ref": "#/definitions/healthcheck-config"
+                },
+                "aliases": {
+                    "type": "array",
+                    "description": "list of additional network aliases for the node",
+                    "markdownDescription": "list of [aliases](https://containerlab.dev/manual/nodes/#aliases) for the node",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
                 }
             },
             "allOf": [

--- a/tests/01-smoke/01-linux-nodes.clab.yml
+++ b/tests/01-smoke/01-linux-nodes.clab.yml
@@ -38,6 +38,8 @@ topology:
         - 56180:80
       mgmt-ipv4: 172.20.20.100
       mgmt-ipv6: 3fff:172:20:20::100
+      aliases:
+        - l2.mydomain.com
       dns:
         servers:
           - 8.8.8.8

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -75,6 +75,8 @@ type NodeDefinition struct {
 	Certificate *CertificateConfig `yaml:"certificate,omitempty"`
 	// Healthcheck configuration
 	HealthCheck *HealthcheckConfig `yaml:"healthcheck,omitempty"`
+	// Network aliases
+	Aliases []string `yaml:"aliases,omitempty"`
 }
 
 // Interface compliance.
@@ -386,6 +388,13 @@ func (n *NodeDefinition) GetHealthcheckConfig() *HealthcheckConfig {
 		return nil
 	}
 	return n.HealthCheck
+}
+
+func (n *NodeDefinition) GetAliases() []string {
+	if n == nil {
+		return nil
+	}
+	return n.Aliases
 }
 
 // ImportEnvs imports all environment variales defined in the shell

--- a/types/topology.go
+++ b/types/topology.go
@@ -581,3 +581,10 @@ func (t *Topology) GetHealthCheckConfig(name string) *HealthcheckConfig {
 
 	return nil
 }
+
+func (t *Topology) GetNodeAliases(name string) []string {
+	if ndef, ok := t.Nodes[name]; ok {
+		return ndef.GetAliases()
+	}
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -163,6 +163,8 @@ type NodeConfig struct {
 	Certificate *CertificateConfig
 	// Healthcheck configuration parameters
 	Healthcheck *HealthcheckConfig
+	// Network aliases
+	Aliases []string `json:"aliases,omitempty"`
 	// NSPath      string `json:"nspath,omitempty"` // network namespace path for this node
 	// list of ports to publish with mysocketctl
 	Publish []string `json:"publish,omitempty"`


### PR DESCRIPTION
A node may have additional network aliases defined in the topology file, like so:

```yaml
topology:
  nodes:
    srl1:
      kind: srl
      aliases:
        - srl1-alias1
```

This is directly influenced by docker-compose
aliases (https://docs.docker.com/reference/compose-file/services/#aliases). The difference is that containerlab aliases are defined on a per-node basis, not per-network.