### PR TITLE
Remove IOL MAC generation

### DIFF
--- a/nodes/iol/iol.cfg.tmpl
+++ b/nodes/iol/iol.cfg.tmpl
@@ -28,11 +28,9 @@ interface Ethernet0/0
  ip address {{ .MgmtIPv4Addr }} {{ .MgmtIPv4SubnetMask }}
  ipv6 address {{ .MgmtIPv6Addr }}/{{ .MgmtIPv6PrefixLen }}
  no shutdown
- mac-address {{ .MgmtIntfMacAddr }}
 !{{ range $index, $item := .DataIFaces }}
 interface Ethernet{{ .Slot }}/{{ .Port }}
  no shutdown
- mac-address {{ .MacAddr }}
 !{{ end }}
 ip forward-protocol nd
 !


### PR DESCRIPTION
IOL generates it's own hardware MAC addresses for its interfaces. It turns out we can use these instead of generating our own MAC addresses.

This PR removes:

- The MAC address generation in containerlab.
- references in the template config to any generated MACs.
- Any other variables/structs vars which store the generated MAC addresses.