### PR TITLE
Add secondary IOL NVRAM bind.

### DIFF
--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -28,6 +28,10 @@ import (
 const (
 	typeIOL = "iol"
 	typeL2  = "l2"
+
+	iol_workdir = "/iol"
+	nvram_file1 = "nvram_00001"
+	nvram_file2 = "nvram_00003"
 )
 
 var (
@@ -95,8 +99,8 @@ func (n *iol) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	n.Cfg.Binds = append(n.Cfg.Binds,
 		// mount nvram so that config persists
-		fmt.Sprint(path.Join(n.Cfg.LabDir, "nvram_00001"), ":/iol/nvram_00001"),
-		fmt.Sprint(path.Join(n.Cfg.LabDir, "nvram_00003"), ":/iol/nvram_00003"),
+		fmt.Sprint(path.Join(n.Cfg.LabDir, nvram_file1), ":", path.Join(iol_workdir, nvram_file1)),
+		fmt.Sprint(path.Join(n.Cfg.LabDir, nvram_file2), ":", path.Join(iol_workdir, nvram_file2)),
 
 		// mount launch config
 		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "startup.cfg"), ":/iol/config.txt"),
@@ -133,14 +137,14 @@ func (n *iol) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) er
 func (n *iol) CreateIOLFiles(ctx context.Context) error {
 	// If NVRAM already exists, don't need to create
 	// otherwise saved configs in NVRAM are overwritten.
-	if !utils.FileExists(path.Join(n.Cfg.LabDir, "nvram_00001")) {
+	if !utils.FileExists(path.Join(n.Cfg.LabDir, nvram_file1)) {
 		// create nvram file
-		utils.CreateFile(path.Join(n.Cfg.LabDir, "nvram_00001"), "")
+		utils.CreateFile(path.Join(n.Cfg.LabDir, nvram_file1), "")
 	}
 
-	if !utils.FileExists(path.Join(n.Cfg.LabDir, "nvram_00003")) {
+	if !utils.FileExists(path.Join(n.Cfg.LabDir, nvram_file2)) {
 		// create nvram file
-		utils.CreateFile(path.Join(n.Cfg.LabDir, "nvram_00003"), "")
+		utils.CreateFile(path.Join(n.Cfg.LabDir, nvram_file2), "")
 	}
 
 	// create these files so the bind monut doesn't automatically

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -95,7 +95,8 @@ func (n *iol) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 
 	n.Cfg.Binds = append(n.Cfg.Binds,
 		// mount nvram so that config persists
-		fmt.Sprint(path.Join(n.Cfg.LabDir, "nvram"), ":/iol/nvram_00001"),
+		fmt.Sprint(path.Join(n.Cfg.LabDir, "nvram_00001"), ":/iol/nvram_00001"),
+		fmt.Sprint(path.Join(n.Cfg.LabDir, "nvram_00003"), ":/iol/nvram_00003"),
 
 		// mount launch config
 		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "startup.cfg"), ":/iol/config.txt"),
@@ -132,9 +133,14 @@ func (n *iol) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) er
 func (n *iol) CreateIOLFiles(ctx context.Context) error {
 	// If NVRAM already exists, don't need to create
 	// otherwise saved configs in NVRAM are overwritten.
-	if !utils.FileExists(path.Join(n.Cfg.LabDir, "nvram")) {
+	if !utils.FileExists(path.Join(n.Cfg.LabDir, "nvram_00001")) {
 		// create nvram file
-		utils.CreateFile(path.Join(n.Cfg.LabDir, "nvram"), "")
+		utils.CreateFile(path.Join(n.Cfg.LabDir, "nvram_00001"), "")
+	}
+
+	if !utils.FileExists(path.Join(n.Cfg.LabDir, "nvram_00003")) {
+		// create nvram file
+		utils.CreateFile(path.Join(n.Cfg.LabDir, "nvram_00003"), "")
 	}
 
 	// create these files so the bind monut doesn't automatically


### PR DESCRIPTION
IOL actually has two locations where it stores the NVRAM (essentially the saved configuration files). 

Previously only one of the locations was bound from the container to the lab directory.

This PR adds the second NVRAM location as a bind to the container (as well as the logic check if we have to create the file so that we don't overwrite it).