### PR TITLE
Fix yum and add dnf instructions for non-scripted installs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -116,13 +116,37 @@ sudo apt update && sudo apt install containerlab
 ```
 
 ///
+
 /// tab | YUM
 
 ```
-yum-config-manager --add-repo=https://netdevops.fury.site/yum/ && \
-echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/yum.fury.io_netdevops_.repo
+sudo yum-config-manager --add-repo=https://netdevops.fury.site/yum/ && \
+echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo
 
 sudo yum install containerlab
+```
+
+///
+
+/// tab | DNF4
+
+```
+sudo dnf config-manager -y --add-repo "https://netdevops.fury.site/yum/" && \
+echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo
+
+sudo dnf install containerlab
+```
+
+///
+
+
+/// tab | DNF5
+
+```
+sudo dnf config-manager addrepo --set=baseurl="https://netdevops.fury.site/yum/" && \
+echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo
+
+sudo dnf install containerlab
 ```
 
 ///


### PR DESCRIPTION
Yum instructions had inconsistent use of sudo and pointed to an older path for the repo file which caused the gpgcheck=0 property to be written to a different file than which was created in the first step.

The install script supports using dnf on Fedora, so it makes sense to also give the non-automated install commands. Fedora 41 now ships with DNF5 which uses a slightly different syntax so both DNF 4 (Fedora versions <= 40) and DNF 5 (versions >= 41) are included.

Instructions tested in container images almalinux:9, fedora:40 and fedora:41 respectively, installing sudo and necessary yum/dnf plugins which would normally be present on a full system where necessary.

Yum:
```
[root@f8885285f917 /]# sudo yum-config-manager --add-repo=https://netdevops.fury.site/yum/ && \
echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo

sudo yum install containerlab
Adding repo from: https://netdevops.fury.site/yum/
gpgcheck=0
created by dnf config-manager from https://netdevops.fury.site/y  91 kB/s | 216 kB     00:02
Dependencies resolved.
=================================================================================================
 Package               Architecture    Version           Repository                         Size
=================================================================================================
Installing:
 containerlab          x86_64          0.59.0-1          netdevops.fury.site_yum_           26 M

Transaction Summary
=================================================================================================
Install  1 Package

Total download size: 26 M
Installed size: 82 M
Is this ok [y/N]:
```

DNF 4:
```
[root@01826f2c9102 /]# sudo dnf config-manager -y --add-repo "https://netdevops.fury.site/yum/" && \
echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo

sudo dnf install containerlab
Adding repo from: https://netdevops.fury.site/yum/
gpgcheck=0
created by dnf config-manager from https://netdevops.fury.site/y  76 kB/s | 176 kB     00:02
Dependencies resolved.
=================================================================================================
 Package               Architecture    Version           Repository                         Size
=================================================================================================
Installing:
 containerlab          x86_64          0.59.0-1          netdevops.fury.site_yum_           26 M

Transaction Summary
=================================================================================================
Install  1 Package

Total download size: 26 M
Installed size: 82 M
Is this ok [y/N]:
```

DNF 5:
```
[root@eabe3606f2cb /]# sudo dnf config-manager addrepo --set=baseurl="https://netdevops.fury.site/yum/" && \
echo "gpgcheck=0" | sudo tee -a /etc/yum.repos.d/netdevops.fury.site_yum_.repo

sudo dnf install containerlab
gpgcheck=0
Updating and loading repositories:
 Fedora 41 - x86_64                                      100% |  11.5 MiB/s |  35.4 MiB |  00m03s
 Fedora 41 - x86_64 - Updates                            100% |   3.6 MiB/s |   3.3 MiB |  00m01s
 Fedora 41 openh264 (From Cisco) - x86_64                100% |   6.2 KiB/s |   6.0 KiB |  00m01s
 netdevops.fury.site_yum_ - Created by dnf5 config-manag 100% |   1.4 MiB/s |   1.7 MiB |  00m01s
Repositories loaded.
Package                      Arch   Version                      Repository                  Size
Installing:
 containerlab                x86_64 0.59.0-1                     netdevops.fury.site_yu  81.6 MiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 26 MiB. Need to download 26 MiB.
After this operation, 82 MiB extra will be used (install 82 MiB, remove 0 B).
Is this ok [y/N]:
```