### PR TITLE
invoke key update, closes #2278

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,11 +5,30 @@ ARG CLAB_VERSION
 RUN echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
     tee -a /etc/apt/sources.list.d/netdevops.list
 
-# setup keyring for github cli
-RUN sudo mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+# Create the update-github-cli-key.sh script
+RUN echo '#!/bin/bash\n'\
+'set -e\n'\
+'echo "Updating GitHub CLI GPG key..."\n'\
+'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \\\n'\
+'sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg\n'\
+'sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg\n' | \
+sudo tee /usr/local/bin/update-github-cli-key.sh > /dev/null
+
+# Make the script executable
+RUN sudo chmod +x /usr/local/bin/update-github-cli-key.sh
+
+# Create an apt configuration file to run the script before updates
+RUN echo 'APT::Update::Pre-Invoke {"/usr/local/bin/update-github-cli-key.sh";};' | \
+sudo tee /etc/apt/apt.conf.d/99updategithubclikey > /dev/null
+
+# Fetch and install the GPG key for GitHub CLI (initial setup)
+RUN /usr/local/bin/update-github-cli-key.sh
+
+# Add the GitHub CLI repository
+RUN echo "deb [arch=$(dpkg --print-architecture) \
+    signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+    https://cli.github.com/packages stable main" | \
+    sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
 # install containerlab and tools
 RUN apt update && apt install -y --no-install-recommends containerlab${CLAB_VERSION:+=$CLAB_VERSION} \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,79 +2,68 @@ FROM mcr.microsoft.com/devcontainers/python:3.11-bookworm
 
 ARG CLAB_VERSION
 
+# Add the netdevops repository
 RUN echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" | \
     tee -a /etc/apt/sources.list.d/netdevops.list
 
-# Create the update-github-cli-key.sh script
-RUN echo '#!/bin/bash\n'\
-'set -e\n'\
-'echo "Updating GitHub CLI GPG key..."\n'\
-'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \\\n'\
-'sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg\n'\
-'sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg\n' | \
-sudo tee /usr/local/bin/update-github-cli-key.sh > /dev/null
-
-# Make the script executable
-RUN sudo chmod +x /usr/local/bin/update-github-cli-key.sh
-
-# Create an apt configuration file to run the script before updates
-RUN echo 'APT::Update::Pre-Invoke {"/usr/local/bin/update-github-cli-key.sh";};' | \
-sudo tee /etc/apt/apt.conf.d/99updategithubclikey > /dev/null
-
-# Fetch and install the GPG key for GitHub CLI (initial setup)
-RUN /usr/local/bin/update-github-cli-key.sh
-
-# Add the GitHub CLI repository
-RUN echo "deb [arch=$(dpkg --print-architecture) \
-    signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-    https://cli.github.com/packages stable main" | \
-    sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
-# install containerlab and tools
-RUN apt update && apt install -y --no-install-recommends containerlab${CLAB_VERSION:+=$CLAB_VERSION} \
+# Install necessary packages, including curl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    containerlab${CLAB_VERSION:+=$CLAB_VERSION} \
     direnv \
     btop \
-    gh \
     iputils-ping \
     tcpdump \
     iproute2 \
     qemu-kvm \
     dnsutils \
-    telnet
+    telnet \
+    curl
 
-# install gNMIc and gNOIc
-RUN bash -c "$(curl -sL https://get-gnmic.openconfig.net)" && bash -c "$(curl -sL https://get-gnoic.kmrd.dev)"
+# Install GitHub CLI directly from the latest release
+RUN bash -c 'VERSION=$(curl -s https://api.github.com/repos/cli/cli/releases/latest | \
+    grep -oP "\"tag_name\": \"\K[^\"]+") && \
+    CLEAN_VERSION=${VERSION#v} && \
+    DOWNLOAD_URL="https://github.com/cli/cli/releases/download/${VERSION}/gh_${CLEAN_VERSION}_linux_amd64.tar.gz" && \
+    curl -L "$DOWNLOAD_URL" | tar xz -C /tmp && \
+    mv /tmp/gh_${CLEAN_VERSION}_linux_amd64/bin/gh /usr/local/bin/ && \
+    chmod +x /usr/local/bin/gh && \
+    rm -rf /tmp/gh_${CLEAN_VERSION}_linux_amd64'
 
-# add empty docker config files to avoid clab warnings for root user
+# Install gNMIc and gNOIc
+RUN bash -c "$(curl -sL https://get-gnmic.openconfig.net)" && \
+    bash -c "$(curl -sL https://get-gnoic.kmrd.dev)"
+
+# Add empty docker config files to avoid clab warnings for root user
 RUN mkdir -p /root/.docker && echo "{}" > /root/.docker/config.json
 
-# maintain SSH_AUTH_SOCK env var when using sudo
+# Maintain SSH_AUTH_SOCK env var when using sudo
 RUN mkdir -p /etc/sudoers.d && echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/ssh_auth_sock
 
-# vscode user is created in the MS devcontainer image
+# Switch to the vscode user provided by the base image
 USER vscode
 
-# copy dclab script that is used to run the local containerlab build
-# after `make build` is executed
+# Copy dclab script used to run the local containerlab build after `make build`
 COPY ./.devcontainer/dclab /usr/local/bin/dclab
 
-# create ssh key for vscode user to enable passwordless ssh to devices
+# Create SSH key for vscode user to enable passwordless SSH to devices
 RUN ssh-keygen -t ecdsa -b 256 -N "" -f ~/.ssh/id_ecdsa
 
-# install pyenv
+# Install pyenv
 RUN bash -c "$(curl https://pyenv.run)"
 
-# add empty docker config files to avoid clab warnings for vscode user
+# Add empty docker config files to avoid clab warnings for vscode user
 RUN mkdir -p /home/vscode/.docker && echo "{}" > /home/vscode/.docker/config.json
 
-# setup zsh
+# Setup Zsh and plugins
 COPY ./.devcontainer/zsh/.zshrc /home/vscode/.zshrc
 COPY ./.devcontainer/zsh/.p10k.zsh /home/vscode/.p10k.zsh
 COPY ./.devcontainer/zsh/install-zsh-plugins.sh /tmp/install-zsh-plugins.sh
 RUN bash -c "/tmp/install-zsh-plugins.sh"
 
-# setup pyenv venv for clab tests
+# Setup pyenv virtual environment for clab tests
 COPY ./tests/requirements.txt /tmp/requirements.txt
-ENV PYENV_ROOT /home/vscode/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-RUN pyenv virtualenv system clab-rf && pyenv global clab-rf && pip install -r /tmp/requirements.txt
+ENV PYENV_ROOT="/home/vscode/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv virtualenv system clab-rf \
+    && pyenv global clab-rf \
+    && pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Closes #2278 

I have not found a better solution to keep the gpg keys updated/rotated automatically.
The gpg keys from the current release are valid until 2026, but with PR it ensures older Docker images of the clab-devcontainer can still function correctly even if the GPG key for the GitHub CLI repository has expired. The goal is to make the container update the GPG key as needed without requiring users to rebuild the image or manually intervene, allowing apt update to succeed seamlessly.

By configuring apt to run /usr/local/bin/update-github-cli-key.sh before any update operation, its ensure that the GPG key is refreshed every time apt update is invoked. This happens automatically and does not require any manual intervention from the user.
If the key installed in the image is expired, the script will fetch the latest key from the GitHub servers, updating the keyring so that apt can verify the repository signatures correctly.