### PR TITLE
Use default vCPU and RAM settings from vrnetlab

### DIFF
--- a/nodes/vr_xrv9k/vr-xrv9k.go
+++ b/nodes/vr_xrv9k/vr-xrv9k.go
@@ -59,7 +59,7 @@ func (n *vrXRV9K) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 		"USERNAME":           defaultCredentials.GetUsername(),
 		"PASSWORD":           defaultCredentials.GetPassword(),
 		"CONNECTION_MODE":    nodes.VrDefConnMode,
-		"VCPU":               "2",
+		"VCPU":               "4",
 		"RAM":                "16384",
 		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,


### PR DESCRIPTION
2vCPU is frankly not enough for this node. Cisco docs say 4vCPU is the minimum required, with 4 vCPU I am seeing greatly improved boot times (still absurdly long though 😁).

https://www.cisco.com/c/en/us/td/docs/routers/virtual-routers/configuration/guide/b-xrv9k-cg/b-xrv9k-cg_chapter_011.html

