### PR TITLE
Add script which prevents XRd from having multiple IPv6 addresses on mgmt interface

### DIFF
--- a/nodes/xrd/mgmt_intf_v6_addr.sh.tmpl
+++ b/nodes/xrd/mgmt_intf_v6_addr.sh.tmpl
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /pkg/bin/ztp_helper.sh
+
+xrapply_string "interface MgmtEth0/RP0/CPU0/0\n no ipv6 address\n{{- if .MgmtIPv6Addr }}ipv6 address {{ .MgmtIPv6Addr }}/{{ .MgmtIPv6PrefixLen }}\n{{- end}}"

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -5,6 +5,7 @@
 package xrd
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -12,7 +13,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 
+	"github.com/hairyhenderson/gomplate/v3"
+	"github.com/hairyhenderson/gomplate/v3/data"
 	log "github.com/sirupsen/logrus"
 	"github.com/srl-labs/containerlab/netconf"
 	"github.com/srl-labs/containerlab/nodes"
@@ -26,7 +30,14 @@ var (
 	xrdEnv             = map[string]string{
 		"XR_FIRST_BOOT_CONFIG": "/etc/xrd/first-boot.cfg",
 		"XR_MGMT_INTERFACES":   "linux:eth0,xr_name=Mg0/RP0/CPU0/0,chksum,snoop_v4,snoop_v6",
+		"XR_EVERY_BOOT_SCRIPT": "/etc/xrd/mgmt_intf_v6_addr.sh",
 	}
+
+	//go:embed mgmt_intf_v6_addr.sh.tmpl
+	scriptTemplate string
+
+	xrdMgmtScriptTpl, _ = template.New("clab-xrd-mgmt-ipv6-script").Funcs(
+		gomplate.CreateFuncs(context.Background(), new(data.Data))).Parse(scriptTemplate)
 
 	//go:embed xrd.cfg
 	cfgTemplate string
@@ -61,6 +72,8 @@ func (n *xrd) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
 		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "first-boot.cfg"), ":/etc/xrd/first-boot.cfg"),
 		// persist data by mounting /xr-storage
 		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "xr-storage"), ":/xr-storage"),
+		// management IPv6 address script
+		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"), ":/etc/xrd/mgmt_intf_v6_addr.sh"),
 	)
 
 	return nil
@@ -77,6 +90,27 @@ func (n *xrd) PreDeploy(ctx context.Context, params *nodes.PreDeployParams) erro
 	}
 
 	return n.createXRDFiles(ctx)
+}
+
+func (n *xrd) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
+	log.Infof("Running postdeploy actions for Cisco XRd '%s' node", n.Cfg.ShortName)
+
+	// create interface script template
+	tpl := xrdScriptTmpl{
+		MgmtIPv6Addr:      n.Cfg.MgmtIPv6Address,
+		MgmtIPv6PrefixLen: n.Cfg.MgmtIPv6PrefixLength,
+	}
+
+	// create script from template
+	buf := new(bytes.Buffer)
+	err := xrdMgmtScriptTpl.Execute(buf, tpl)
+	if err != nil {
+		return err
+	}
+	// write it to disk
+	utils.CreateFile(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"), buf.String())
+
+	return err
 }
 
 func (n *xrd) SaveConfig(_ context.Context) error {
@@ -100,6 +134,12 @@ func (n *xrd) createXRDFiles(_ context.Context) error {
 	// generate first-boot config
 	cfg := filepath.Join(n.Cfg.LabDir, "first-boot.cfg")
 	nodeCfg.ResStartupConfig = cfg
+
+	// generate script file
+	if !utils.FileExists(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh")) {
+		utils.CreateFile(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"), "")
+		utils.AdjustFileACLs(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"))
+	}
 
 	// set mgmt IPv4/IPv6 gateway as it is already known by now
 	// since the container network has been created before we launch nodes
@@ -151,4 +191,9 @@ func (n *xrd) CheckInterfaceName() error {
 	}
 
 	return nil
+}
+
+type xrdScriptTmpl struct {
+	MgmtIPv6Addr      string
+	MgmtIPv6PrefixLen int
 }

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -92,7 +92,7 @@ func (n *xrd) PreDeploy(ctx context.Context, params *nodes.PreDeployParams) erro
 	return n.createXRDFiles(ctx)
 }
 
-func (n *xrd) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
+func (n *xrd) PostDeploy(_ context.Context, _ *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Cisco XRd '%s' node", n.Cfg.ShortName)
 
 	// create interface script template


### PR DESCRIPTION
Closes #2277.

This PR adds a basic script which removes all IPv6 address from the management interface (MgmtEth0/RP0/CPU0/0), and then assigns the correct management IPv6 address according to clab.

This fixes a problem that users have reported having of 'incorrect device mapping to ip address'. No work is required for IPv4 as the management interface is only allowed a single IPv4 address and XRd automatically overwrites the old one.

- Environment variable `XR_EVERY_BOOT_SCRIPT` points to the path to the script on the containers filesystem. When this env var is populated XRd runs the script at that path on well.. every boot 😀.
- An empty file for the script is created in the `createXRDFiles()` function, so that docker doesn't automatically create a folder for the bind mount. ACLs are also edited on the file since XR needs the file to be executable.
- Script populates IPv6 address via gomplate. This has to be done in PostDeploy since we don't know the container IPv6 address in PreDeploy (I think?).
- XRd executes the script AFTER first boot or startup configuration has been applied.

I've tested and ensured the script is working as it should and confirmed that *without* the script i'm getting the duplicate address behaviour.