### PR TITLE
Change quickstart doc piece installation script to use the 'quick start' script.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -30,14 +30,14 @@ The script officially supports the following OSes:
 * Rocky Linux 9.3, 8.8 (should work on any 9.x and 8.x release)
 
 To install all components at once, run the following command on any of the supported OSes:
-
+<!-- --8<-- [start:quick-setup-script-cmd] -->
 ```bash
 curl -sL https://containerlab.dev/setup | sudo -E bash -s "all"
 ```
-
-/// note
+/// tip
 To complete installation please execute `newgrp docker` or logout and log back in.
 ///
+<!-- --8<-- [end:quick-setup-script-cmd] -->
 
 To install an individual component, specify the function name as an argument to the script. For example, to install only `docker`:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,9 +34,9 @@ To install all components at once, run the following command on any of the suppo
 ```bash
 curl -sL https://containerlab.dev/setup | sudo -E bash -s "all"
 ```
-/// tip
-To complete installation please execute `newgrp docker` or logout and log back in.
-///
+
+Complete installation and enable sudo-less `docker` command execution please run `newgrp docker` or logout and log back in.
+
 <!-- --8<-- [end:quick-setup-script-cmd] -->
 
 To install an individual component, specify the function name as an argument to the script. For example, to install only `docker`:
@@ -138,7 +138,6 @@ sudo dnf install containerlab
 ```
 
 ////
-
 
 //// tab | DNF5
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,9 +6,9 @@ hide:
 
 ## Installation
 
-Getting containerlab is as easy as it gets. Thanks to the trivial [installation](install.md) procedure it can be set up in a matter of a few seconds on any RHEL or Debian based OS[^1].
+Getting containerlab is as easy as it gets. Thanks to the [quick setup script](install.md#quick-setup) you can get up and running in a matter of seconds on any RHEL or Debian based OS[^1].
 
---8<-- "docs/install.md:install-script-cmd"
+--8<-- "docs/install.md:quick-setup-script-cmd"
 
 ## Topology definition file
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -124,7 +124,7 @@ sudo containerlab deploy # (1)!
   If you have several files and want to pick a specific one, use `--topo <path>` flag.
 
 In no time you will see the summary table with the deployed lab nodes.  
-The table will show the node name (which equals to container name), node kind, image name and a bunch of other usefule information. You can always list the nodes of the lab with [`containerlab inspect`](cmd/inspect.md) command.
+The table will show the node name (which equals to container name), node kind, image name and a bunch of other useful information. You can always list the nodes of the lab with [`containerlab inspect`](cmd/inspect.md) command.
 
 ```
 +---+---------------------+--------------+-----------------------+---------------+---------+-----------------+----------------------+


### PR DESCRIPTION
Previously the [Quickstart](https://containerlab.dev/quickstart/) page had the one-liner script that only installed containerlab only and not any of the dependencies.

I think the quicksetup script makes more sense instead of the clab-only install script. This PR does the following:

- Admonition on the install page under the quicksetup script is now of the 'tip' type (was 'info' before).
- Quickstart doc page was updated to use the proper quicksetup script (via snippets).
- Changed the text/explainer slightly to more accurately reflect the quicksetup script. The hyperlink now links to the quicksetup heading as well.

Let me know if you think the admonition should be changed back to info, or something that catches attention more like 'warning'. In fairness the content is important as if the user doesn't follow those instructions their docker install will not be working properly.