### PR TITLE
Update mgmt ipv6 interface script to be globally executable

### DIFF
--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -135,10 +135,12 @@ func (n *xrd) createXRDFiles(_ context.Context) error {
 	cfg := filepath.Join(n.Cfg.LabDir, "first-boot.cfg")
 	nodeCfg.ResStartupConfig = cfg
 
+	mgmt_script_path := filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh")
+
 	// generate script file
-	if !utils.FileExists(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh")) {
-		utils.CreateFile(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"), "")
-		utils.AdjustFileACLs(filepath.Join(n.Cfg.LabDir, "mgmt_intf_v6_addr.sh"))
+	if !utils.FileExists(mgmt_script_path) {
+		utils.CreateFile(mgmt_script_path, "")
+		os.Chmod(mgmt_script_path, 0775) // rwxrwxr-x
 	}
 
 	// set mgmt IPv4/IPv6 gateway as it is already known by now

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -140,7 +140,7 @@ func (n *xrd) createXRDFiles(_ context.Context) error {
 	// generate script file
 	if !utils.FileExists(mgmt_script_path) {
 		utils.CreateFile(mgmt_script_path, "")
-		os.Chmod(mgmt_script_path, 0775) // rwxrwxr-x
+		os.Chmod(mgmt_script_path, 0775) // skipcq: GSC-G302
 	}
 
 	// set mgmt IPv4/IPv6 gateway as it is already known by now


### PR DESCRIPTION
Fixes #2324 

Effectively does a `chmod 775` which is `rwxrwxr-x`

![image](https://github.com/user-attachments/assets/edfe65b4-d863-4788-bef1-cf0f53783412)
