### PR TITLE
[#2344] Fix documented default password

### DIFF
--- a/docs/manual/kinds/generic_vm.md
+++ b/docs/manual/kinds/generic_vm.md
@@ -34,7 +34,7 @@ docker exec -it <container-name/id> bash
 
 ///
 /// tab | CLI via SSH
-to connect to the Linux shell (password `sysadmin`)
+Connect to the VM Guest via SSH. Default password see below the [Credentials](#credentials).
 
 ```bash
 ssh clab@<container-name>


### PR DESCRIPTION
The default password is not `sysadmin` anymore, it's `clab@123` as stated lower in the document, too. This just cleans the last reference.

Fixes #2344 