### PR TITLE
Polish IOL test

### DIFF
--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -61,13 +61,13 @@ Write configuration to NVRAM on router1
     Should Contain    ${output}    [OK]
 
 Log IP addresses for router1
-    ${rc}   ${ipv4_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv4-address"'
-    Log    ${ipv4_addr}
+    ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv4-address"'
+    Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
     Should Be Equal As Integers    ${rc}    0
-    ${rc}   ${ipv6_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv6-address"'
-    Log    ${ipv6_addr}
+    ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv6-address"'
+    Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
 Write configuration to NVRAM on switch
     ${rc}    ${output} =    Run And Return Rc And Output
@@ -77,38 +77,42 @@ Write configuration to NVRAM on switch
     Should Contain    ${output}    [OK]
 
 Log IP addresses for switch
-    ${rc}   ${ipv4_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv4-address"'
-    Log    ${ipv4_addr}
+    ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv4-address"'
+    Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
     Should Be Equal As Integers    ${rc}    0
-    ${rc}   ${ipv6_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv6-address"'
-    Log    ${ipv6_addr}
+    ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv6-address"'
+    Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
 Destroy ${lab-name} lab
-    Log     ${CURDIR}
-    ${rc}   ${output} =    Run And Return Rc And Output
-    ...     sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name}
-    Log     ${output}
+    Log    ${CURDIR}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name}
+    Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Re-deploy ${lab-name} lab
-    Log     ${CURDIR}
-    ${rc}   ${output} =    Run And Return Rc And Output
-    ...     sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
-    Log     ${output}
+    Log    ${CURDIR}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Wait 60s for nodes to boot
     Sleep    60s
 
 Verify connectivity via new management addresses on router1
-    ${rc}   ${ipv4_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv4-address"'
+    ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv4-address"'
     Should Be Equal As Integers    ${rc}    0
-    ${rc}   ${ipv6_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv6-address"'
+    Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
+
+    ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv6-address"'
     Should Be Equal As Integers    ${rc}    0
+    Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-router1 "sh run interface Ethernet0/0"
     Log    ${output}
@@ -117,18 +121,23 @@ Verify connectivity via new management addresses on router1
     Should Contain    ${output}    ${ipv6_addr.upper()}
 
 Verify connectivity via new management addresses on switch
-    ${rc}   ${ipv4_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv4-address"'
+    ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv4-address"'
     Should Be Equal As Integers    ${rc}    0
-    ${rc}   ${ipv6_addr} =    Run And Return Rc And Output
-    ...     cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv6-address"'
+    Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
+
+    ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
+    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv6-address"'
     Should Be Equal As Integers    ${rc}    0
+    Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
+
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-switch "sh run interface Ethernet0/0"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    ${ipv4_addr.upper()}
     Should Contain    ${output}    ${ipv6_addr.upper()}
+
 
 *** Keywords ***
 Cleanup


### PR DESCRIPTION

Change the labdir file path and added console logging

Test log:
```
❯ CLAB_BIN=$(pwd)/bin/containerlab ./tests/rf-run.sh docker tests/10-basic-cisco_iol/01-iol.robot
Running tests with containerlab binary at /home/romandodin/srl-labs/containerlab/bin/containerlab path and selected runtime: docker
==============================================================================
01-Iol                                                                        
==============================================================================
Deploy iol lab                                                        | PASS |
------------------------------------------------------------------------------
Wait 45s for nodes to boot                                            | PASS |
------------------------------------------------------------------------------
Verify links in node router1                                          Warning: Permanently added 'clab-iol-router1' (RSA) to the list of known hosts.
Connection to clab-iol-router1 closed by remote host.
Verify links in node router1                                          | PASS |
------------------------------------------------------------------------------
Verify links in node switch                                           Warning: Permanently added 'clab-iol-switch' (RSA) to the list of known hosts.
Connection to clab-iol-switch closed by remote host.
Verify links in node switch                                           | PASS |
------------------------------------------------------------------------------
Verify parital startup configuration on router2                       | PASS |
------------------------------------------------------------------------------
Verify full startup configuration on router3                          | PASS |
------------------------------------------------------------------------------
Write configuration to NVRAM on router1                               | PASS |
------------------------------------------------------------------------------
Log IP addresses for router1                                          .
--> LOG: IPv4 addr - "172.20.20.4"
...
--> LOG: IPv6 addr - "3fff:172:20:20::4"
Log IP addresses for router1                                          | PASS |
------------------------------------------------------------------------------
Write configuration to NVRAM on switch                                | PASS |
------------------------------------------------------------------------------
Log IP addresses for switch                                           .
--> LOG: IPv4 addr - "172.20.20.5"
...
--> LOG: IPv6 addr - "3fff:172:20:20::5"
Log IP addresses for switch                                           | PASS |
------------------------------------------------------------------------------
Destroy iol lab                                                       | PASS |
------------------------------------------------------------------------------
Re-deploy iol lab                                                     | PASS |
------------------------------------------------------------------------------
Wait 60s for nodes to boot                                            | PASS |
------------------------------------------------------------------------------
Verify connectivity via new management addresses on router1           ..
--> LOG: IPv4 addr - 172.20.20.2
...
--> LOG: IPv6 addr - 3fff:172:20:20::2
Verify connectivity via new management addresses on router1           | PASS |
------------------------------------------------------------------------------
Verify connectivity via new management addresses on switch            ..
--> LOG: IPv4 addr - 172.20.20.3
...
--> LOG: IPv6 addr - 3fff:172:20:20::3
Verify connectivity via new management addresses on switch            | PASS |
------------------------------------------------------------------------------
01-Iol                                                                | PASS |
15 tests, 15 passed, 0 failed
==============================================================================
```