### PR TITLE
fix: regression for docker bridge gw check on darwin dind

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -320,7 +320,13 @@ func getMgmtBridgeIPs(bridgeName string, netResource networkapi.Inspect) (string
 			}
 		}
 	}
-	return v4, v6, err
+
+	// didnt find any gateways, fallthrough to returning the error
+	if v4 == "" && v6 == "" {
+		return "", "", err
+	}
+
+	return v4, v6, nil
 }
 
 // postCreateNetActions performs additional actions after the network has been created.


### PR DESCRIPTION
little regression after #1482 -- pretty much same issue where clab cant find gw for the bridge (via netlink) and stops even though we have that data from docker inspection.