### PR TITLE
Fix for OcNOS 6.5.2-101

### DIFF
--- a/docs/manual/kinds/ipinfusion-ocnos.md
+++ b/docs/manual/kinds/ipinfusion-ocnos.md
@@ -4,7 +4,7 @@ search:
 ---
 # IPInfusion OcNOS
 
-IPInfusion OcNOS virtualized router is identified with `ipinfusion_ocnos` kind in the [topology file](../topo-def-file.md). It is built using either [boxen](https://github.com/carlmontanari/boxen) project or [hellt/vrnetlab](https://github.com/hellt/vrnetlab/tree/master/ocnos) and essentially is a Qemu VM packaged in a docker container format.
+IPInfusion OcNOS virtualized router is identified with `ipinfusion_ocnos` kind in the [topology file](../topo-def-file.md). It is built using [hellt/vrnetlab](https://github.com/hellt/vrnetlab/tree/master/ocnos) and essentially is a Qemu VM packaged in a docker container format.
 
 ipinfusion_ocnos nodes launched with containerlab come up pre-provisioned with SSH, and NETCONF services enabled.
 

--- a/docs/manual/kinds/ipinfusion-ocnos.md
+++ b/docs/manual/kinds/ipinfusion-ocnos.md
@@ -36,7 +36,7 @@ IPInfusion OcNOS node launched with containerlab can be managed via the followin
     ```
 
 !!!info
-    Default user credentials: `ocnos:ocnos`
+    Default user credentials: `admin:admin@123`
 
 ## Interfaces mapping
 

--- a/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
+++ b/nodes/ipinfusion_ocnos/ipinfusion_ocnos.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	kindnames          = []string{"ipinfusion_ocnos"}
-	defaultCredentials = nodes.NewCredentials("admin", "admin")
+	defaultCredentials = nodes.NewCredentials("admin", "admin@123")
 )
 
 const (


### PR DESCRIPTION
Modified the default password to `admin@123` to comply with the password length requirements of OcNOS 6.5.2.

```
OcNOS(config)#username admin role network-admin password admin
% Invalid input for password (Allowed length 8 - 32): admin

OcNOS(config)#username admin role network-admin password admin@123
OcNOS(config)#commit
```

Tested with `OcNOS-SP-PLUS-x86-6.5.2-101-GA.qcow2`.