### PR TITLE
Remove "spin up" from docs for `clab destroy`

### DIFF
--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -14,7 +14,7 @@ The `destroy` command destroys a lab referenced by its [topology definition file
 
 #### topology
 
-With the global `--topo | -t` flag a user sets the path to the topology definition file that will be used to spin up a lab.
+With the global `--topo | -t` flag a user sets the path to the topology definition file that will be used to identify the lab to destroy.
 
 When the topology path refers to a directory, containerlab will look for a file with `.clab.yml` extension in that directory and use it as a topology definition file.
 


### PR DESCRIPTION
Just a minor fix regarding wording in the docs for the `destroy` subcommand. It currently says:

 ```With the global --topo | -t flag a user sets the path to the topology definition file that will be used to spin up a lab.```

That confused me a bit since I did not know if I were reading the docs for `deploy` or for `destroy`. This PR changes the docs for destroy so that the part with "spin up a lab" is removed. 