### PR TITLE
redeploy command without parameters

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,7 @@ func preRunFn(cmd *cobra.Command, _ []string) error {
 // Errors if more than one file is found by the glob path.
 func getTopoFilePath(cmd *cobra.Command) error {
 	// set commands which may use topo file find functionality, the rest don't need it
-	if !(cmd.Name() == "deploy" || cmd.Name() == "destroy" || cmd.Name() == "inspect" ||
+	if !(cmd.Name() == "deploy" || cmd.Name() == "destroy" || cmd.Name() == "redeploy" || cmd.Name() == "inspect" ||
 		cmd.Name() == "save" || cmd.Name() == "graph") {
 		return nil
 	}


### PR DESCRIPTION
Fix for #2378.
Now it is possible to redeploy the lab with `*.clab.yml|*.clab.yaml` file in a folder without parameters:


```
anatoly@orb:~/containerlab/bin$ ls
containerlab  pr.clab.yaml
anatoly@orb:~/containerlab/bin$ sudo ./containerlab deploy
INFO[0000] Containerlab v0.0.0 started
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Creating lab directory: /home/anatoly/containerlab/bin/clab-srl01
INFO[0000] Creating container: "srl"
INFO[0000] Running postdeploy actions for Nokia SR Linux 'srl' node
INFO[0005] Adding containerlab host entries to /etc/hosts file
INFO[0005] Adding ssh config for containerlab nodes
INFO[0005] 🎉 New containerlab version 0.61.0 is available! Release notes: https://containerlab.dev/rn/0.61/
Run 'containerlab version upgrade' to upgrade or go check other installation options at https://containerlab.dev/install/
╭────────────────┬───────────────────────┬─────────┬───────────────────╮
│      Name      │       Kind/Image      │  State  │   IPv4/6 Address  │
├────────────────┼───────────────────────┼─────────┼───────────────────┤
│ clab-srl01-srl │ nokia_srlinux         │ running │ 172.20.20.4       │
│                │ ghcr.io/nokia/srlinux │         │ 3fff:172:20:20::4 │
╰────────────────┴───────────────────────┴─────────┴───────────────────╯
anatoly@orb:~/containerlab/bin$ sudo ./containerlab redeploy
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Destroying lab: srl01
INFO[0000] Removed container: clab-srl01-srl
INFO[0000] Removing containerlab host entries from /etc/hosts file
INFO[0000] Removing ssh config for containerlab nodes
INFO[0000] Containerlab v0.0.0 started
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Creating lab directory: /home/anatoly/containerlab/bin/clab-srl01
INFO[0000] Creating container: "srl"
INFO[0000] Running postdeploy actions for Nokia SR Linux 'srl' node
INFO[0003] Adding containerlab host entries to /etc/hosts file
INFO[0003] Adding ssh config for containerlab nodes
INFO[0003] 🎉 New containerlab version 0.61.0 is available! Release notes: https://containerlab.dev/rn/0.61/
Run 'containerlab version upgrade' to upgrade or go check other installation options at https://containerlab.dev/install/
╭────────────────┬───────────────────────┬─────────┬───────────────────╮
│      Name      │       Kind/Image      │  State  │   IPv4/6 Address  │
├────────────────┼───────────────────────┼─────────┼───────────────────┤
│ clab-srl01-srl │ nokia_srlinux         │ running │ 172.20.20.4       │
│                │ ghcr.io/nokia/srlinux │         │ 3fff:172:20:20::4 │
╰────────────────┴───────────────────────┴─────────┴───────────────────╯
anatoly@orb:~/containerlab/bin$ sudo ./containerlab destroy
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Parsing & checking topology file: pr.clab.yaml
INFO[0000] Destroying lab: srl01
INFO[0000] Removed container: clab-srl01-srl
INFO[0000] Removing containerlab host entries from /etc/hosts file
INFO[0000] Removing ssh config for containerlab nodes
anatoly@orb:~/containerlab/bin$```