### PR TITLE
nokia_sros: handle CRLF and tabs in partialCfg

### DIFF
--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -262,8 +262,10 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 		return err
 	}
 
+	configContentStr := string(configContent)
+
 	// check file contains content, otherwise exit early
-	if strings.TrimSpace(string(configContent)) == "" {
+	if strings.TrimSpace(configContentStr) == "" {
 		return nil
 	}
 
@@ -315,8 +317,14 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 			}
 		}
 	}
+
+	// Replace CRLF with LF
+	configContentStr = strings.ReplaceAll(configContentStr, "\r\n", "\n")
+	// Replace tabs with 4 spaces
+	configContentStr = strings.ReplaceAll(configContentStr, "\t", "    ")
+
 	// converting byte slice to newline delimited string slice
-	cfgs := strings.Split(string(configContent), "\n")
+	cfgs := strings.Split(configContentStr, "\n")
 
 	// config snippets should not have commit command, so we need to commit manually
 	// and quit from the config mode

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -318,12 +318,14 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 		}
 	}
 
-	// Replace CRLF with LF
-	configContentStr = strings.ReplaceAll(configContentStr, "\r\n", "\n")
-	// Replace tabs with 4 spaces
-	configContentStr = strings.ReplaceAll(configContentStr, "\t", "    ")
+	// Normalize character sequences to avoid interaction issues with CLI
+	replacer := strings.NewReplacer(
+		"\r\n", "\n", // replace EOL CRLF with LF
+		"\t", "    ", // replace tabs with 4 spaces
+	)
+	configContentStr = replacer.Replace(configContentStr)
 
-	// converting byte slice to newline delimited string slice
+	// converting string to newline delimited string slice
 	cfgs := strings.Split(configContentStr, "\n")
 
 	// config snippets should not have commit command, so we need to commit manually


### PR DESCRIPTION
SROS partial configs with CRLF (\r\n) or tabs (\t) can fail to apply. This patch adds automatic conversion to avoid the issue:
- Replace CRLF with LF.
- Replace tabs with 4 spaces.
