### PR TITLE
quick-setup: allow disabling setup-sshd from environment var

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,6 +38,14 @@ To install all components at once, run the following command on any of the suppo
 curl -sL https://containerlab.dev/setup | sudo -E bash -s "all"
 ```
 
+By default, this will also configure sshd on the system to increase max auth tries so unknown keys don't lock ssh attempts.
+This behaviour can be turned off by setting the environment variable "SETUP_SSHD" to "false" **before** running the command shown above.
+The environment variable can be set and exported with the command shown below.
+
+```bash
+export SETUP_SSHD="false"
+```
+
 To complete installation and enable sudo-less `docker` command execution, please run `newgrp docker` or logout and log back in.
 
 <!-- --8<-- [end:quick-setup-script-cmd] -->

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -1,5 +1,5 @@
 DISTRO_TYPE=""
-SETUP_SSHD="true"
+SETUP_SSHD="${SETUP_SSHD:-true}"
 
 # Docker version that will be installed by this install script.
 DOCKER_VERSION="26.1.4"


### PR DESCRIPTION
* by default, the quick-setup.sh script also configures sshd to prevent locking when using unknown keys in the auth process
* this patch documents the function itself as well as adds and documents the new option to disable it via an environment variable