### PR TITLE
Fix ipv6 forwarding for datapath bridges

### DIFF
--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/containerlab/runtime/docker/firewall"
 )
 
 type EndpointBridge struct {
@@ -44,6 +47,19 @@ func (e *EndpointBridge) Verify(ctx context.Context, p *VerifyLinkParams) error 
 }
 
 func (e *EndpointBridge) Deploy(ctx context.Context) error {
+
+	log.Debugf("endpoint_bridge Deploy(%q)", e.GetNode().GetShortName())
+
+	f, err := firewall.NewFirewallClient(e.GetNode().GetShortName())
+	if err != nil {
+		return err
+	}
+	log.Debugf("using %s as the firewall interface", f.Name())
+
+	err = f.InstallForwardingRules()
+	if err != nil {
+		return err
+	}
 	return e.GetLink().Deploy(ctx, e)
 }
 


### PR DESCRIPTION
Fixes https://github.com/srl-labs/containerlab/issues/2389

On many platforms and following security best practices, the default policy for IP forwarding is "drop". This PR modifies the existing firewall logic to dynamically create forwarding rules for both ipv4 and ipv6, on all bridges used in the topology.

This results in new rules in the ```DOCKER-USER``` chain for table ip (v4) and ip6, enabling IPv6 forwarding across bridges

Implementation notes:
* The ```endpoint_bridge Deploy``` function gets called many times, once per endpoint. The rules only need to be created once - the remaining calls go ignored. Feel free to move this logic to a more suitable place if needed
* The debug print of IP versions could be made nicer; in Python I would do ```'IPv4' if v==xyz else 'IPv6'``` but I don't know the Go equivalent

