### PR TITLE
Added centralized magic var replacer and support replacer for execs

### DIFF
--- a/clab/config_test.go
+++ b/clab/config_test.go
@@ -78,7 +78,7 @@ func TestBindsInit(t *testing.T) {
 			want: []string{
 				"node1.lic:/dst1",
 				"kind.lic:/dst2",
-				"${PWD}/test_data/clab-topo2/node1/somefile:/somefile",
+				"${PWD}/test_data/clab-topo2/node1/node1:/somefile",
 			},
 		},
 		"kind_and_node_binds": {
@@ -734,6 +734,39 @@ func TestStartupConfigInit(t *testing.T) {
 			if c.Nodes[tc.node].Config().StartupConfig != filepath.Join(cwd, tc.want) {
 				t.Errorf("want startup-config %q got startup-config %q",
 					filepath.Join(cwd, tc.want), c.Nodes[tc.node].Config().StartupConfig)
+			}
+		})
+	}
+}
+
+func TestExecInit(t *testing.T) {
+	tests := map[string]struct {
+		got  string
+		node string
+		want []string
+	}{
+		"node_exec": {
+			got:  "test_data/topo14.yml",
+			node: "node1",
+			want: []string{
+				"echo \"Hello world\"",
+				"echo \"Hello node node1\"",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := []ClabOption{
+				WithTopoPath(tc.got, ""),
+			}
+			c, err := NewContainerLab(opts...)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if d := cmp.Diff(c.Nodes[tc.node].Config().Exec, tc.want); d != "" {
+				t.Errorf("execs do not match %s", d)
 			}
 		})
 	}

--- a/clab/test_data/topo14.yml
+++ b/clab/test_data/topo14.yml
@@ -4,3 +4,6 @@ topology:
     node1:
       kind: nokia_srlinux
       startup-config: ./configs/fabric/__clabNodeName__.cfg
+      exec:
+        - echo "Hello world"
+        - echo "Hello node __clabNodeName__"

--- a/clab/test_data/topo2.yml
+++ b/clab/test_data/topo2.yml
@@ -15,7 +15,7 @@ topology:
       binds:
         - node1.lic:/dst1
         - kind.lic:/dst2
-        - __clabNodeDir__/somefile:/somefile
+        - __clabNodeDir__/__clabNodeName__:/somefile
     node2:
       kind: nokia_srlinux
       type: ixr10


### PR DESCRIPTION
fix #2393

it is immediately clear if doing a global replacement is possible due to the requirement to support nodeName variable that needs to have node name parsed first.

Instead, the node vars are being applied to the most wanted sections:

- binds
- execs
- startup-config