### PR TITLE
Implement `clab save` for IOL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ site:
 # when PUBLIC=yes is not set, the mkdocs-material insiders image is used with all the dependencies included.
 .PHONY: serve-docs-full
 serve-docs-full:
-ifeq ($(PUBLIC),yes)
+ifdef PUBLIC
 	@{ 	\
 		sed -i 's/^  - typeset/#- typeset/g' mkdocs.yml; \
 	}

--- a/docs/cmd/save.md
+++ b/docs/cmd/save.md
@@ -11,6 +11,7 @@ The exact command that performs configuration save depends on a given kind. The 
 | **Nokia SR Linux** | `sr_cli -d tools system configuration save` |                                                         |
 | **Nokia SR OS**    |                                             | delivered via netconf RPC `copy-config running startup` |
 | **Arista cEOS**    | `Cli -p 15 -c wr`                           |                                                         |
+| **Cisco IOL**      | `write memory`                              |                                                         |
 
 ### Usage
 

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -49,11 +49,11 @@ var (
 	// IntfRegexp with named capture groups for extracting slot and port.
 	CapturingIntfRegexp = regexp.MustCompile(`(?:e|Ethernet)\s?(?P<slot>\d+)/(?P<port>\d+)$`)
 	// ethX naming is the "raw" or "default" interface naming.
-	DefaultIntfRegexp = regexp.MustCompile(`eth[1-9][0-9]*$`)
+	DefaultIntfRegexp = regexp.MustCompile(`eth[1-9]\d*$`)
 	// Match on the management interface.
 	MgmtIntfRegexp = regexp.MustCompile(`(eth0|e0/0|Ethernet0/0)$`)
 	// Matches on any allowed/legal interface name.
-	AllowedIntfRegexp = regexp.MustCompile("(e|Ethernet)((0/[1-3])|([1-9]/[0-3]))$|eth[1-9][0-9]*$")
+	AllowedIntfRegexp = regexp.MustCompile(`(e|Ethernet)((0/[123])|([1-9]/[0-3]))$|eth[1-9]\d*$`)
 	IntfHelpMsg       = "Interfaces should follow Ethernet<slot>/<port> or e<slot>/<port> naming convention, where <slot> is a number from 0-9 and <port> is a number from 0-3. You can also use ethX-based interface naming."
 
 	validTypes = []string{typeIOL, typeL2}
@@ -181,7 +181,7 @@ func (n *iol) GenInterfaceConfig(_ context.Context) error {
 	slot, port := 0, 0
 
 	// Regexp to pull number out of linux'ethX' interface naming
-	IntfRegExpr := regexp.MustCompile("[0-9]+")
+	IntfRegExpr := regexp.MustCompile(`\d+`)
 
 	for _, intf := range n.Endpoints {
 

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -140,7 +140,7 @@ func (n *iol) PreDeploy(ctx context.Context, params *nodes.PreDeployParams) erro
 	return n.CreateIOLFiles(ctx)
 }
 
-func (n *iol) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
+func (n *iol) PostDeploy(ctx context.Context, _ *nodes.PostDeployParams) error {
 	log.Infof("Running postdeploy actions for Cisco IOL '%s' node", n.Cfg.ShortName)
 
 	n.GenBootConfig(ctx)
@@ -274,7 +274,7 @@ type IOLTemplateData struct {
 	PartialCfg         string
 }
 
-// IOLinterface struct stores mapping info between
+// IOLInterface struct stores mapping info between
 // IOL interface name and linux container interface.
 type IOLInterface struct {
 	IfaceName string
@@ -283,7 +283,7 @@ type IOLInterface struct {
 	Port      int
 }
 
-func (n *iol) GetMappedInterfaceName(ifName string) (string, error) {
+func (*iol) GetMappedInterfaceName(ifName string) (string, error) {
 	captureGroups, err := utils.GetRegexpCaptureGroups(CapturingIntfRegexp, ifName)
 	if err != nil {
 		return "", err

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -51,7 +51,7 @@ var (
 	// Match on the management interface.
 	MgmtIntfRegexp = regexp.MustCompile(`(eth0|e0/0|Ethernet0/0)$`)
 	// Matches on any allowed/legal interface name.
-	AllowedIntfRegexp = regexp.MustCompile("Ethernet((0/[1-3])|([1-9]/[0-3]))$|e((0/[1-3])|([1-9]/[0-9]))$|eth[1-9][0-9]*$")
+	AllowedIntfRegexp = regexp.MustCompile("(e|Ethernet)((0/[1-3])|([1-9]/[0-3]))$|eth[1-9][0-9]*$")
 	IntfHelpMsg       = "Interfaces should follow Ethernet<slot>/<port> or e<slot>/<port> naming convention, where <slot> is a number from 0-9 and <port> is a number from 0-3. You can also use ethX-based interface naming."
 
 	validTypes = []string{typeIOL, typeL2}

--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -53,12 +53,25 @@ Verify full startup configuration on router3
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    FULL_STARTUP_CFG-router3
 
-Write configuration to NVRAM on router1
+Save running-config to startup-config to NVRAM with clab save
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-iol-router1 "write memory"
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    [OK]
+
+Verify startup-config is saved to NVRAM on router1
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-iol-router1 "sh startup-configuration | inc hostname"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    router1
+
+Verify startup-config is saved to NVRAM on switch
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-iol-switch "sh startup-configuration | inc hostname"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    switch
 
 Log IP addresses for router1
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
@@ -68,13 +81,6 @@ Log IP addresses for router1
     ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
     ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv6-address"'
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
-
-Write configuration to NVRAM on switch
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-iol-switch "write memory"
-    Log    ${output}
-    Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    [OK]
 
 Log IP addresses for switch
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output

--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -75,20 +75,20 @@ Verify startup-config is saved to NVRAM on switch
 
 Log IP addresses for router1
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv4-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv4-address"'
     Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
     Should Be Equal As Integers    ${rc}    0
     ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv6-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.router1."mgmt-ipv6-address"'
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
 Log IP addresses for switch
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv4-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv4-address"'
     Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
     Should Be Equal As Integers    ${rc}    0
     ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv6-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq '.nodes.switch."mgmt-ipv6-address"'
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
 Destroy ${lab-name} lab
@@ -110,12 +110,12 @@ Wait 60s for nodes to boot
 
 Verify connectivity via new management addresses on router1
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv4-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv4-address"'
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
 
     ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv6-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.router1."mgmt-ipv6-address"'
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
@@ -128,12 +128,12 @@ Verify connectivity via new management addresses on router1
 
 Verify connectivity via new management addresses on switch
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv4-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv4-address"'
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv4 addr - ${ipv4_addr}    console=True
 
     ${rc}    ${ipv6_addr} =    Run And Return Rc And Output
-    ...    cat clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv6-address"'
+    ...    cat ${CURDIR}/clab-${lab-name}/topology-data.json | jq -r '.nodes.switch."mgmt-ipv6-address"'
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 


### PR DESCRIPTION
As per the title this PR:

- Adds `clab save` for IOL
- Minor regex cleanup in `AllowedIntfRegexp`

I've pretty much stolen the sample in the scrapligo README and modified it to exec `write memory` which does the same as `copy run start`, the difference being with `write memory` there is no pesky prompt that shows up to confirm you want to copy the config.

I'll add some tests, but let me know if you like it this way or would prefer something else.

FYI: "programmability" is not supported on IOL (this includes NETCONF).