### PR TITLE
iptables rules for mgmt net and bridges in both directions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ build:
 
 build-linux-arm64:
 	mkdir -p $(BIN_DIR)
-	GOARCH=arm64 go build -o $(BINARY) -ldflags="$(LDFLAGS)" main.go
+	GOOS=linux GOARCH=arm64 go build -o $(BINARY) -ldflags="$(LDFLAGS)" main.go
+
+build-linux-amd64:
+	mkdir -p $(BIN_DIR)
+	GOOS=linux GOARCH=amd64 go build -o $(BINARY) -ldflags="$(LDFLAGS)" main.go
 
 build-with-cover:
 	mkdir -p $(BIN_DIR)

--- a/docs/manual/dev/debug.md
+++ b/docs/manual/dev/debug.md
@@ -17,9 +17,13 @@ We will document the workflow for the latter (non-root user) case, as this is th
 
 The debug configuration defined in the `launch.json` file will contain the important fields such as `asRoot` and `console`, both needed for the debugging as a root user.
 
-Here is an example of a configuration file that launches `containerlab tools vxlan create` command in the debug mode:
+Here is an example of a configuration file that has debug configurations to run the following debug configurations:
 
-```json
+1. run `containerlab tools vxlan create` command
+2. run `containerlab deploy` command for a given topology
+3. run `containerlab destroy` for a given topology
+
+```{.json .code-scroll-lg}
 {
     "version": "0.2.0",
     "configurations": [
@@ -41,6 +45,36 @@ Here is an example of a configuration file that launches `containerlab tools vxl
                 "ens3"
             ],
             "preLaunchTask": "delete vx-ens3 interface",
+        },
+        {
+            "name": "deploy linux lab",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "console": "integratedTerminal",
+            "asRoot": true,
+            "program": "${workspaceFolder}/bin/containerlab",
+            "args": [
+                "dep",
+                "-t",
+                "private/linux.clab.yml"
+            ],
+            "preLaunchTask": "delete linux lab",
+        },
+        {
+            "name": "destroy linux lab",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "console": "integratedTerminal",
+            "asRoot": true,
+            "program": "${workspaceFolder}/bin/containerlab",
+            "args": [
+                "des",
+                "-t",
+                "private/linux.clab.yml"
+            ],
+            "preLaunchTask": "make build-dlv-debug",
         }
     ]
 }
@@ -58,7 +92,7 @@ Here is a simple task file that contains two tasks - one is building the binary 
 
 The dependencies between the tasks are defined in the `dependsOn` field, and this is how you can first build the binary and then run the preparation step.
 
-```json
+```{.json .code-scroll-lg}
 {
     "version": "2.0.0",
     "tasks": [
@@ -66,6 +100,17 @@ The dependencies between the tasks are defined in the `dependsOn` field, and thi
             "label": "delete vx-ens3 interface",
             "type": "shell",
             "command": "sudo ip link delete vx-ens3",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "dependsOn": "make build-dlv-debug",
+            "problemMatcher": []
+        },
+        {
+            "label": "delete linux lab",
+            "type": "shell",
+            "command": "sudo clab des -c -t private/linux.clab.yml",
             "presentation": {
                 "reveal": "always",
                 "panel": "new"

--- a/docs/manual/kinds/bridge.md
+++ b/docs/manual/kinds/bridge.md
@@ -75,6 +75,17 @@ iptables -I FORWARD -i br-clab -j ACCEPT
 iptables -I FORWARD -o br-clab -j ACCEPT
 ```
 
-This will ensure that traffic is forwarded when passing this particular bridge. Note, that once you destroy the lab, the rule will stay, if you wish to remove it, you will have to do it manually.
+This will ensure that traffic is forwarded when passing this particular bridge.
+
+/// warning
+Once you destroy the lab, the rules in the FORWARD chain will stay, if you wish to remove it, you will have to do it manually. For example the with the following script (for v4 family):
+
+```
+sudo iptables -vL FORWARD --line-numbers -n | \
+grep "set by containerlab" | awk '{print $1}' \
+| sort -r | xargs -I {} sudo iptables -D FORWARD {}
+```
+
+///
 
 Check out ["External bridge"](../../lab-examples/ext-bridge.md) lab for a ready-made example on how to use bridges.

--- a/docs/manual/kinds/bridge.md
+++ b/docs/manual/kinds/bridge.md
@@ -68,10 +68,11 @@ br-clab         8000.6281eb7133d2       no              eth1
                                                         eth3
 ```
 
-Containerlab automatically adds iptables rules for the referenced bridges (v4 and v6) to allow traffic ingressing to the bridges. Namely, for a given bridge named `br-clab` containerlab will attempt to create the allowing rule in the filter table, FORWARD chain like this:
+Containerlab automatically adds iptables rules for the referenced bridges (v4 and v6) to allow traffic ingressing/egressing to/from the bridges. Namely, for a given bridge named `br-clab` containerlab will attempt to create the allowing rule in the filter table, FORWARD chain like this:
 
 ```
 iptables -I FORWARD -i br-clab -j ACCEPT
+iptables -I FORWARD -o br-clab -j ACCEPT
 ```
 
 This will ensure that traffic is forwarded when passing this particular bridge. Note, that once you destroy the lab, the rule will stay, if you wish to remove it, you will have to do it manually.

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -259,12 +259,13 @@ sudo iptables -vnL DOCKER-USER
 ```{.no-copy .no-select}
 Chain DOCKER-USER (1 references)
  pkts bytes target     prot opt in     out     source               destination
-    0     0 ACCEPT     all  --  *      br-a8b9fc8b33a2  0.0.0.0/0            0.0.0.0/0            /* set by containerlab */
-12719   79M RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0
+    0     0 ACCEPT     0    --  br-1351328e1855 *       0.0.0.0/0            0.0.0.0/0            /* set by containerlab */
+    0     0 ACCEPT     0    --  *      br-1351328e1855  0.0.0.0/0            0.0.0.0/0            /* set by containerlab */
+    0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0
 ```
 </div>
 
-1. The `br-a8b9fc8b33a2` bridge interface is the interface that backs up the containerlab's management network (`clab` docker network).
+1. The `br-1351328e1855` bridge interface is the interface that backs up the containerlab's management network (`clab` docker network).
 
 The rule will be removed together with the management network.
 

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -129,7 +129,7 @@ func (b *bridge) GetLinkEndpointType() links.LinkEndpointType {
 	return links.LinkEndpointTypeBridge
 }
 
-// installIPTablesBridgeFwdRule installs `allow` rule for the traffic routed to ingress the bridge
+// installIPTablesBridgeFwdRule installs `allow` rule for the traffic routed in and out of the bridge
 // otherwise, communication over the bridge is not permitted on most systems.
 func (b *bridge) installIPTablesBridgeFwdRule() (err error) {
 	f, err := firewall.NewFirewallClient()

--- a/nodes/bridge/bridge.go
+++ b/nodes/bridge/bridge.go
@@ -138,5 +138,27 @@ func (b *bridge) installIPTablesBridgeFwdRule() (err error) {
 	}
 	log.Debugf("setting up bridge firewall rules using %s as the firewall interface", f.Name())
 
-	return f.InstallForwardingRules(b.Cfg.ShortName, "", definitions.ForwardChain)
+	r := definitions.FirewallRule{
+		Interface: b.Cfg.ShortName,
+		Direction: definitions.InDirection,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+		Table:     definitions.FilterTable,
+		Chain:     definitions.ForwardChain,
+	}
+	err = f.InstallForwardingRules(r)
+	if err != nil {
+		return err
+	}
+
+	r = definitions.FirewallRule{
+		Interface: b.Cfg.ShortName,
+		Direction: definitions.OutDirection,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+		Table:     definitions.FilterTable,
+		Chain:     definitions.ForwardChain,
+	}
+
+	return f.InstallForwardingRules(r)
 }

--- a/runtime/docker/firewall.go
+++ b/runtime/docker/firewall.go
@@ -18,7 +18,39 @@ func (d *DockerRuntime) deleteMgmtNetworkFwdRule() (err error) {
 		return err
 	}
 
-	return f.DeleteForwardingRules("", d.mgmt.Bridge, definitions.DockerUserChain)
+	// delete the rules with the management bridge listed as the outgoing interface with the allow action
+	// in the DOCKER-USER chain
+	r := definitions.FirewallRule{
+		Interface: d.mgmt.Bridge,
+		Direction: definitions.OutDirection,
+		Chain:     definitions.DockerUserChain,
+		Table:     definitions.FilterTable,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+	}
+
+	err = f.DeleteForwardingRules(r)
+	if err != nil {
+		return err
+	}
+
+	// install the rules with the management bridge listed as the incoming interface with the allow action
+	// in the DOCKER-USER chain
+	r = definitions.FirewallRule{
+		Interface: d.mgmt.Bridge,
+		Direction: definitions.OutDirection,
+		Chain:     definitions.DockerUserChain,
+		Table:     definitions.FilterTable,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+	}
+
+	err = f.DeleteForwardingRules(r)
+	if err != nil {
+		return err
+	}
+
+	return err
 }
 
 // installMgmtNetworkFwdRule installs the `allow` rule for traffic destined to the nodes
@@ -43,14 +75,32 @@ func (d *DockerRuntime) installMgmtNetworkFwdRule() (err error) {
 
 	// install the rules with the management bridge listed as the outgoing interface with the allow action
 	// in the DOCKER-USER chain
-	err = f.InstallForwardingRules("", d.mgmt.Bridge, definitions.DockerUserChain)
+	r := definitions.FirewallRule{
+		Interface: d.mgmt.Bridge,
+		Direction: definitions.OutDirection,
+		Chain:     definitions.DockerUserChain,
+		Table:     definitions.FilterTable,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+	}
+
+	err = f.InstallForwardingRules(r)
 	if err != nil {
 		return err
 	}
 
 	// install the rules with the management bridge listed as the incoming interface with the allow action
 	// in the DOCKER-USER chain
-	err = f.InstallForwardingRules(d.mgmt.Bridge, "", definitions.DockerUserChain)
+	r = definitions.FirewallRule{
+		Interface: d.mgmt.Bridge,
+		Direction: definitions.OutDirection,
+		Chain:     definitions.DockerUserChain,
+		Table:     definitions.FilterTable,
+		Action:    definitions.AcceptAction,
+		Comment:   definitions.ContainerlabComment,
+	}
+
+	err = f.InstallForwardingRules(r)
 	if err != nil {
 		return err
 	}

--- a/runtime/docker/firewall.go
+++ b/runtime/docker/firewall.go
@@ -93,7 +93,7 @@ func (d *DockerRuntime) installMgmtNetworkFwdRule() (err error) {
 	// in the DOCKER-USER chain
 	r = definitions.FirewallRule{
 		Interface: d.mgmt.Bridge,
-		Direction: definitions.OutDirection,
+		Direction: definitions.InDirection,
 		Chain:     definitions.DockerUserChain,
 		Table:     definitions.FilterTable,
 		Action:    definitions.AcceptAction,

--- a/runtime/docker/firewall.go
+++ b/runtime/docker/firewall.go
@@ -43,5 +43,17 @@ func (d *DockerRuntime) installMgmtNetworkFwdRule() (err error) {
 
 	// install the rules with the management bridge listed as the outgoing interface with the allow action
 	// in the DOCKER-USER chain
-	return f.InstallForwardingRules("", d.mgmt.Bridge, definitions.DockerUserChain)
+	err = f.InstallForwardingRules("", d.mgmt.Bridge, definitions.DockerUserChain)
+	if err != nil {
+		return err
+	}
+
+	// install the rules with the management bridge listed as the incoming interface with the allow action
+	// in the DOCKER-USER chain
+	err = f.InstallForwardingRules(d.mgmt.Bridge, "", definitions.DockerUserChain)
+	if err != nil {
+		return err
+	}
+
+	return err
 }

--- a/runtime/docker/firewall/definitions/definitions.go
+++ b/runtime/docker/firewall/definitions/definitions.go
@@ -1,6 +1,8 @@
 package definitions
 
-import "errors"
+import (
+	"errors"
+)
 
 var ErrNotAvailable = errors.New("not available")
 
@@ -8,15 +10,27 @@ const (
 	DockerUserChain = "DOCKER-USER"
 	ForwardChain    = "FORWARD"
 	FilterTable     = "filter"
+	AcceptAction    = "ACCEPT"
+	InDirection     = "in"
+	OutDirection    = "out"
 
-	IPTablesRuleComment = "set by containerlab"
+	ContainerlabComment = "set by containerlab"
 
 	IPTablesCommentMaxSize = 256
 )
 
 // ClabFirewall is the interface that all firewall clients must implement.
 type ClabFirewall interface {
-	DeleteForwardingRules(inInterface, outInterface, chain string) error
-	InstallForwardingRules(inInterface, outInterface, chain string) error
+	DeleteForwardingRules(rule FirewallRule) error
+	InstallForwardingRules(rule FirewallRule) error
 	Name() string
+}
+
+type FirewallRule struct {
+	Chain     string
+	Table     string
+	Interface string
+	Direction string
+	Action    string
+	Comment   string
 }

--- a/runtime/docker/firewall/iptables/client.go
+++ b/runtime/docker/firewall/iptables/client.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	iptCheckArgs = "-vL DOCKER-USER -w 5"
-	iptAllowArgs = "-I DOCKER-USER %s %s -j ACCEPT -w 5 -m comment --comment \"" + definitions.IPTablesRuleComment + "\""
-	iptDelArgs   = "-D DOCKER-USER %s %s -j ACCEPT -w 5 -m comment --comment \"" + definitions.IPTablesRuleComment + "\""
+	iptAllowArgs = "-I DOCKER-USER -%s %s -j ACCEPT -w 5 -m comment --comment \"" + definitions.IPTablesRuleComment + "\""
+	iptDelArgs   = "-D DOCKER-USER -%s %s -j ACCEPT -w 5 -m comment --comment \"" + definitions.IPTablesRuleComment + "\""
 	ipTables     = "ip_tables"
 
 	v4AF         = "v4"

--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -20,6 +20,11 @@ var directionMap = map[string]expr.MetaKey{
 	definitions.OutDirection: expr.MetaKeyOIFNAME,
 }
 
+var afMap = map[nftables.TableFamily]string{
+	nftables.TableFamilyIPv4: "ipv4",
+	nftables.TableFamilyIPv6: "ipv6",
+}
+
 // NftablesClient is a client for nftables.
 type NftablesClient struct {
 	nftConn *nftables.Conn
@@ -146,7 +151,7 @@ func (c *NftablesClient) InstallForwardingRulesForAF(af nftables.TableFamily, ru
 		return nil
 	}
 
-	log.Debugf("Installing iptables rules for bridge %q", iface)
+	log.Debugf("Installing iptables rules for interface %q, direction %s, family %s", iface, rule.Direction, afMap[af])
 
 	// create a new rule
 	r, err := c.newClabNftablesRule(rule.Chain, rule.Table, af, 0)

--- a/runtime/docker/firewall/nftables/rule.go
+++ b/runtime/docker/firewall/nftables/rule.go
@@ -14,14 +14,14 @@ type clabNftablesRule struct {
 }
 
 // AddInterfaceFilter adds an interface filter to the rule.
-func (cnr *clabNftablesRule) AddInterfaceFilter(ifName string, isOutput bool) {
+func (cnr *clabNftablesRule) AddInterfaceFilter(rule definitions.FirewallRule) {
 	// define the metadata to evaluate
 	metaKey := expr.MetaKeyIIFNAME
-	if isOutput {
+	if rule.Direction == definitions.OutDirection {
 		metaKey = expr.MetaKeyOIFNAME
 	}
 
-	metaIfName := &expr.Meta{
+	meta := &expr.Meta{
 		Key:            metaKey,
 		SourceRegister: false,
 		Register:       1,
@@ -31,11 +31,11 @@ func (cnr *clabNftablesRule) AddInterfaceFilter(ifName string, isOutput bool) {
 	comp := &expr.Cmp{
 		Op:       expr.CmpOpEq,
 		Register: 1,
-		Data:     []byte(ifName + "\x00"),
+		Data:     []byte(rule.Interface + "\x00"),
 	}
 
 	// add expr to rule
-	cnr.rule.Exprs = append(cnr.rule.Exprs, metaIfName, comp)
+	cnr.rule.Exprs = append(cnr.rule.Exprs, meta, comp)
 }
 
 func (cnr *clabNftablesRule) AddCounter() error {
@@ -64,7 +64,7 @@ func (cnr *clabNftablesRule) AddVerdictDrop() error {
 func (cnr *clabNftablesRule) AddComment(comment string) error {
 	// convert comment to byte
 	actualCommentByte := []byte(comment)
-	// check comment length not exceded
+	// check comment length
 	if len(actualCommentByte) > definitions.IPTablesCommentMaxSize {
 		return fmt.Errorf("comment max length is %d you've provided %d bytes",
 			definitions.IPTablesCommentMaxSize, len(actualCommentByte))

--- a/runtime/docker/firewall/nftables/rule.go
+++ b/runtime/docker/firewall/nftables/rule.go
@@ -16,10 +16,7 @@ type clabNftablesRule struct {
 // AddInterfaceFilter adds an interface filter to the rule.
 func (cnr *clabNftablesRule) AddInterfaceFilter(rule definitions.FirewallRule) {
 	// define the metadata to evaluate
-	metaKey := expr.MetaKeyIIFNAME
-	if rule.Direction == definitions.OutDirection {
-		metaKey = expr.MetaKeyOIFNAME
-	}
+	metaKey := directionMap[rule.Direction]
 
 	meta := &expr.Meta{
 		Key:            metaKey,

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -311,9 +311,17 @@ Verify iptables allow rule is set
     ...    sudo iptables -vnL DOCKER-USER
     Log    ${ipt}
     # debian 12 uses `0` for protocol, while previous versions use `all`
+    # this matches the rule in the in direction
     Should Contain Any    ${ipt}
     ...    ACCEPT all -- * ${MgmtBr}
     ...    ACCEPT 0 -- * ${MgmtBr}
+    ...    ignore_case=True
+    ...    collapse_spaces=True
+
+    # this matches the rule in the out direction
+    Should Contain Any    ${ipt}
+    ...    ACCEPT all -- ${MgmtBr} *
+    ...    ACCEPT 0 -- ${MgmtBr} *
     ...    ignore_case=True
     ...    collapse_spaces=True
 
@@ -332,6 +340,7 @@ Verify ip6tables allow rule is set
     ...    sudo nft list chain ip6 filter DOCKER-USER
     Log    ${ipt}
     Should Match Regexp    ${ipt}    oifname.*${MgmtBr}.*accept
+    Should Match Regexp    ${ipt}    iifname.*${MgmtBr}.*accept
 
 
 Verify DNS-Server Config

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -71,7 +71,7 @@ Verify iptables allow rule is set
     Skip If    '${runtime}' != 'docker'
 
     ${ipt} =    Run
-    ...    sudo iptables -vnL DOCKER-USER
+    ...    sudo iptables -vnL FORWARD
     Log    ${ipt}
     # debian 12 uses `0` for protocol, while previous versions use `all`
     # this matches the rule in the in direction
@@ -100,7 +100,7 @@ Verify ip6tables allow rule is set
     Skip If    'ip6 filter' not in '''${output}'''    ip6 filter chain not found
 
     ${ipt} =    Run
-    ...    sudo nft list chain ip6 filter DOCKER-USER
+    ...    sudo nft list chain ip6 filter FORWARD
     Log    ${ipt}
     Should Match Regexp    ${ipt}    oifname.*${bridge-name}.*accept
     Should Match Regexp    ${ipt}    iifname.*${bridge-name}.*accept
@@ -115,7 +115,7 @@ Verify iptables allow rule are gone
     [Documentation]    Checking if iptables allow rule is removed once the lab is destroyed
     Skip If    '${runtime}' != 'docker'
     ${ipt} =    Run
-    ...    sudo iptables -vnL DOCKER-USER
+    ...    sudo iptables -vnL FORWARD
     Log    ${ipt}
     Should Not Contain    ${ipt}    ${bridge-name}
 
@@ -131,7 +131,7 @@ Verify ip6tables allow rule are gone
     Skip If    'ip6 filter' not in '''${output}'''    ip6 filter chain not found
 
     ${ipt} =    Run
-    ...    sudo nft list chain ip6 filter DOCKER-USER
+    ...    sudo nft list chain ip6 filter FORWARD
     Log    ${ipt}
     Should Not Contain    ${ipt}    ${bridge-name}
 

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -105,36 +105,6 @@ Verify ip6tables allow rule is set
     Should Match Regexp    ${ipt}    oifname.*${bridge-name}.*accept
     Should Match Regexp    ${ipt}    iifname.*${bridge-name}.*accept
 
-Destroy ${lab-name} lab
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
-    Log    ${output}
-    Should Be Equal As Integers    ${rc}    0
-
-Verify iptables allow rule are gone
-    [Documentation]    Checking if iptables allow rule is removed once the lab is destroyed
-    Skip If    '${runtime}' != 'docker'
-    ${ipt} =    Run
-    ...    sudo iptables -vnL FORWARD
-    Log    ${ipt}
-    Should Not Contain    ${ipt}    ${bridge-name}
-
-Verify ip6tables allow rule are gone
-    [Documentation]    Checking if ip6tables allow rule is removed once the lab is destroyed
-    Skip If    '${runtime}' != 'docker'
-
-    # Add check for ip6tables availability
-    ${rc}    ${output} =    Run And Return Rc And Output    which nft
-    Skip If    ${rc} != 0    nft command not found
-
-    ${rc}    ${output} =    Run And Return Rc And Output    sudo nft list tables
-    Skip If    'ip6 filter' not in '''${output}'''    ip6 filter chain not found
-
-    ${ipt} =    Run
-    ...    sudo nft list chain ip6 filter FORWARD
-    Log    ${ipt}
-    Should Not Contain    ${ipt}    ${bridge-name}
-
 *** Keywords ***
 Setup
     # ensure the bridge we about to create is deleted first
@@ -144,5 +114,11 @@ Setup
     Run    sudo ctr -n clab image rm docker.io/library/alpine:3
 
 Cleanup
+    Destroy ${lab-name} lab
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    
     Run    sudo ip l del ${bridge-name}
     Run    sudo ip l del ${host-link-name}

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -66,6 +66,74 @@ Verify management network is using user-specified bridge
     Log    ${res}
     Should Contain    ${res}    master ${mgmt-br-name} state UP
 
+Verify iptables allow rule is set
+    [Documentation]    Checking if iptables allow rule is set so that external traffic can reach containerlab management network
+    Skip If    '${runtime}' != 'docker'
+
+    ${ipt} =    Run
+    ...    sudo iptables -vnL DOCKER-USER
+    Log    ${ipt}
+    # debian 12 uses `0` for protocol, while previous versions use `all`
+    # this matches the rule in the in direction
+    Should Contain Any    ${ipt}
+    ...    ACCEPT all -- * ${bridge-name}
+    ...    ACCEPT 0 -- * ${bridge-name}
+    ...    ignore_case=True
+    ...    collapse_spaces=True
+
+    # this matches the rule in the out direction
+    Should Contain Any    ${ipt}
+    ...    ACCEPT all -- ${bridge-name} *
+    ...    ACCEPT 0 -- ${bridge-name} *
+    ...    ignore_case=True
+    ...    collapse_spaces=True
+
+Verify ip6tables allow rule is set
+    [Documentation]    Checking if ip6tables allow rule is set so that external traffic can reach containerlab management network
+    Skip If    '${runtime}' != 'docker'
+
+    # Add check for ip6tables availability
+    ${rc}    ${output} =    Run And Return Rc And Output    which nft
+    Skip If    ${rc} != 0    nft command not found
+
+    ${rc}    ${output} =    Run And Return Rc And Output    sudo nft list tables
+    Skip If    'ip6 filter' not in '''${output}'''    ip6 filter chain not found
+
+    ${ipt} =    Run
+    ...    sudo nft list chain ip6 filter DOCKER-USER
+    Log    ${ipt}
+    Should Match Regexp    ${ipt}    oifname.*${bridge-name}.*accept
+    Should Match Regexp    ${ipt}    iifname.*${bridge-name}.*accept
+
+Destroy ${lab-name} lab
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Verify iptables allow rule are gone
+    [Documentation]    Checking if iptables allow rule is removed once the lab is destroyed
+    Skip If    '${runtime}' != 'docker'
+    ${ipt} =    Run
+    ...    sudo iptables -vnL DOCKER-USER
+    Log    ${ipt}
+    Should Not Contain    ${ipt}    ${bridge-name}
+
+Verify ip6tables allow rule are gone
+    [Documentation]    Checking if ip6tables allow rule is removed once the lab is destroyed
+    Skip If    '${runtime}' != 'docker'
+
+    # Add check for ip6tables availability
+    ${rc}    ${output} =    Run And Return Rc And Output    which nft
+    Skip If    ${rc} != 0    nft command not found
+
+    ${rc}    ${output} =    Run And Return Rc And Output    sudo nft list tables
+    Skip If    'ip6 filter' not in '''${output}'''    ip6 filter chain not found
+
+    ${ipt} =    Run
+    ...    sudo nft list chain ip6 filter DOCKER-USER
+    Log    ${ipt}
+    Should Not Contain    ${ipt}    ${bridge-name}
 
 *** Keywords ***
 Setup
@@ -76,8 +144,5 @@ Setup
     Run    sudo ctr -n clab image rm docker.io/library/alpine:3
 
 Cleanup
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
-    Log    ${output}
     Run    sudo ip l del ${bridge-name}
     Run    sudo ip l del ${host-link-name}

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -114,11 +114,10 @@ Setup
     Run    sudo ctr -n clab image rm docker.io/library/alpine:3
 
 Cleanup
-    Destroy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
-    
+
     Run    sudo ip l del ${bridge-name}
     Run    sudo ip l del ${host-link-name}


### PR DESCRIPTION
setting up the rules in one of the directions (in/out) was not enough for all use cases. This fix sets the rules in both in and out directions for mgmt network and bridges used in the topology 