### PR TITLE
Sudo-less operation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           name: containerlab
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PY_VER }}
@@ -226,7 +226,7 @@ jobs:
         with:
           name: containerlab
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PY_VER }}
@@ -289,7 +289,7 @@ jobs:
         with:
           name: containerlab
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PY_VER }}

--- a/.github/workflows/cisco_iol-tests.yml
+++ b/.github/workflows/cisco_iol-tests.yml
@@ -27,7 +27,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/fortigate-tests.yml
+++ b/.github/workflows/fortigate-tests.yml
@@ -27,7 +27,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/kind-tests.yml
+++ b/.github/workflows/kind-tests.yml
@@ -27,7 +27,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -51,7 +51,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - name: Setup Podman
         if: matrix.runtime == 'podman'

--- a/.github/workflows/srlinux-tests.yml
+++ b/.github/workflows/srlinux-tests.yml
@@ -31,7 +31,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - name: Setup Podman
         if: matrix.runtime == 'podman'

--- a/.github/workflows/sros-tests.yml
+++ b/.github/workflows/sros-tests.yml
@@ -28,7 +28,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/vxlan-tests.yml
+++ b/.github/workflows/vxlan-tests.yml
@@ -29,7 +29,7 @@ jobs:
           name: containerlab
 
       - name: Move containerlab to usr/bin
-        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chmod a+x /usr/bin/containerlab
+        run: sudo mv ./containerlab /usr/bin/containerlab && sudo chown root:root /usr/bin/containerlab && sudo chmod 4755 /usr/bin/containerlab
 
       - uses: actions/setup-python@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,10 @@ nfpms:
       postinstall: ./utils/postinstall.sh
     bindir: /usr/bin
     contents:
+      - src: ./containerlab
+        dst: /usr/bin/containerlab
+        file_info:
+          mode: 4755 # SUID bit set
       - src: ./lab-examples
         dst: /etc/containerlab/lab-examples
       - src: /usr/bin/containerlab

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ ifndef suite
 override suite = .
 endif
 robot-test: build-with-podman-debug
+	sudo chown root:root $(BINARY) && sudo chmod 4755 $(BINARY)
 	CLAB_BIN=$(BINARY) $$PWD/tests/rf-run.sh $(runtime) $$PWD/tests/$(suite)
 
 MOCKDIR = ./mocks

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -1297,3 +1297,15 @@ func (c *CLab) Exec(ctx context.Context, cmds []string, options *ExecOptions) (*
 
 	return resultCollection, nil
 }
+
+// CheckConnectivity checks the connectivity to all container runtimes, returns an error if it encounters any, otherwise nil.
+func (c *CLab) CheckConnectivity(ctx context.Context) error {
+	for _, r := range c.Runtimes {
+		err := r.CheckConnection(ctx)
+		if err != nil {
+			return fmt.Errorf("could not connect to container runtime: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/common/sudo.go
+++ b/cmd/common/sudo.go
@@ -1,16 +1,96 @@
 package common
 
 import (
-	"errors"
+	"fmt"
 	"os"
+	"os/user"
+	"slices"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func SudoCheck(_ *cobra.Command, _ []string) error {
-	id := os.Geteuid()
-	if id != 0 {
-		return errors.New("containerlab requires sudo privileges to run")
+const CLAB_AUTHORISED_GROUP = "clab_admins"
+
+func CheckAndGetRootPrivs(_ *cobra.Command, _ []string) error {
+	_, euid, suid := unix.Getresuid()
+	if euid != 0 && suid != 0 {
+		return fmt.Errorf("this containerlab command requires root privileges or root via SUID to run, effective UID: %v SUID: %v", euid, suid)
 	}
+
+	if euid != 0 && suid == 0 {
+		clabGroupExists := true
+		clabGroup, err := user.LookupGroup(CLAB_AUTHORISED_GROUP)
+		if err != nil {
+			if _, ok := err.(user.UnknownGroupError); ok {
+				log.Debug("Containerlab admin group does not exist, skipping group membership check")
+				clabGroupExists = false
+			} else {
+				return fmt.Errorf("failed to lookup containerlab admin group: %v", err)
+			}
+		}
+
+		if clabGroupExists {
+			currentEffUser, err := user.Current()
+			if err != nil {
+				return err
+			}
+
+			effUserGroupIDs, err := currentEffUser.GroupIds()
+			if err != nil {
+				return err
+			}
+
+			if !slices.Contains(effUserGroupIDs, clabGroup.Gid) {
+				return fmt.Errorf("user '%v' is not part of containerlab admin group 'clab_admins' (GID %v), which is required to execute this command.\nTo add yourself to this group, run the following command:\n\t$ sudo gpasswd -a %v clab_admins",
+					currentEffUser.Username, clabGroup.Gid, currentEffUser.Username)
+			}
+
+			log.Debug("Group membership check passed")
+		}
+
+		err = obtainRootPrivs()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func obtainRootPrivs() error {
+	// Escalate to root privileges, changing saved UIDs to root/current group to be able to retain privilege escalation
+	err := changePrivileges(0, os.Getgid(), 0, os.Getgid())
+	if err != nil {
+		return err
+	}
+
+	log.Debug("Obtained root privileges")
+
+	return nil
+}
+
+func DropRootPrivs() error {
+	// Drop privileges to the running user, retaining current saved IDs
+	err := changePrivileges(os.Getuid(), os.Getgid(), -1, -1)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("Dropped root privileges")
+
+	return nil
+}
+
+func changePrivileges(new_uid, new_gid, saved_uid, saved_gid int) error {
+	if err := unix.Setresuid(-1, new_uid, saved_uid); err != nil {
+		return fmt.Errorf("failed to set UID: %v", err)
+	}
+	if err := unix.Setresgid(-1, new_gid, saved_gid); err != nil {
+		return fmt.Errorf("failed to set GID: %v", err)
+	}
+	log.Debugf("Changed running UIDs to UID: %d GID: %d", new_uid, new_gid)
 	return nil
 }

--- a/cmd/common/sudo.go
+++ b/cmd/common/sudo.go
@@ -12,7 +12,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const CLAB_AUTHORISED_GROUP = "clab_admins"
+const (
+	CLAB_AUTHORISED_GROUP = "clab_admins"
+	ROOT_UID              = 0
+	NOMODIFY              = -1
+)
 
 func CheckAndGetRootPrivs(_ *cobra.Command, _ []string) error {
 	_, euid, suid := unix.Getresuid()

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -56,7 +56,7 @@ var deployCmd = &cobra.Command{
 	Long:         "deploy a lab based defined by means of the topology definition file\nreference: https://containerlab.dev/cmd/deploy/",
 	Aliases:      []string{"dep"},
 	SilenceUsage: true,
-	PreRunE:      common.SudoCheck,
+	PreRunE:      common.CheckAndGetRootPrivs,
 	RunE:         deployFn,
 }
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -32,7 +32,7 @@ var destroyCmd = &cobra.Command{
 	Short:   "destroy a lab",
 	Long:    "destroy a lab based defined by means of the topology definition file\nreference: https://containerlab.dev/cmd/destroy/",
 	Aliases: []string{"des"},
-	PreRunE: common.SudoCheck,
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE:    destroyFn,
 }
 

--- a/cmd/disableTxOffload.go
+++ b/cmd/disableTxOffload.go
@@ -21,6 +21,7 @@ var disableTxOffloadCmd = &cobra.Command{
 	Use:   "disable-tx-offload",
 	Short: "disables tx checksum offload on eth0 interface of a container",
 
+	PreRunE: checkAndGetRootPrivs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/cmd/disableTxOffload.go
+++ b/cmd/disableTxOffload.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -21,7 +22,7 @@ var disableTxOffloadCmd = &cobra.Command{
 	Use:   "disable-tx-offload",
 	Short: "disables tx checksum offload on eth0 interface of a container",
 
-	PreRunE: checkAndGetRootPrivs,
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -28,7 +28,7 @@ var (
 var execCmd = &cobra.Command{
 	Use:     "exec",
 	Short:   "execute a command on one or multiple containers",
-	PreRunE: common.SudoCheck,
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE:    execFn,
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
 	"github.com/srl-labs/containerlab/clab/exec"
-	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
@@ -26,10 +25,9 @@ var (
 
 // execCmd represents the exec command.
 var execCmd = &cobra.Command{
-	Use:     "exec",
-	Short:   "execute a command on one or multiple containers",
-	PreRunE: common.CheckAndGetRootPrivs,
-	RunE:    execFn,
+	Use:   "exec",
+	Short: "execute a command on one or multiple containers",
+	RunE:  execFn,
 }
 
 func execFn(_ *cobra.Command, _ []string) error {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -73,6 +73,11 @@ func execFn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	err = c.CheckConnectivity(ctx)
+	if err != nil {
+		return err
+	}
+
 	var filters []*types.GenericFilter
 
 	if len(labelsFilter) != 0 {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/types"
@@ -89,6 +90,10 @@ var generateCmd = &cobra.Command{
 			}
 		}
 		if deploy {
+			err = common.CheckAndGetRootPrivs(nil, nil)
+			if err != nil {
+				return err
+			}
 			reconfigure = true
 			if file == "" {
 				file = fmt.Sprintf("%s.clab.yml", name)

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -19,7 +19,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
-	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/labels"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
@@ -38,7 +37,6 @@ var inspectCmd = &cobra.Command{
 	Short:   "inspect lab details",
 	Long:    "show details about a particular lab or all running labs\nreference: https://containerlab.dev/cmd/inspect/",
 	Aliases: []string{"ins", "i"},
-	PreRunE: common.SudoCheck,
 	RunE:    inspectFn,
 }
 

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -83,6 +83,11 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not parse the topology file: %v", err)
 	}
 
+	err = c.CheckConnectivity(ctx)
+	if err != nil {
+		return err
+	}
+
 	var containers []runtime.GenericContainer
 	var glabels []*types.GenericFilter
 

--- a/cmd/redeploy.go
+++ b/cmd/redeploy.go
@@ -13,7 +13,7 @@ var redeployCmd = &cobra.Command{
 	Short:        "destroy and redeploy a lab",
 	Long:         "destroy a lab and deploy it again based on the topology definition file\nreference: https://containerlab.dev/cmd/redeploy/",
 	Aliases:      []string{"rdep"},
-	PreRunE:      common.SudoCheck,
+	PreRunE:      common.CheckAndGetRootPrivs,
 	SilenceUsage: true,
 	RunE:         redeployFn,
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,9 +90,12 @@ func preRunFn(cmd *cobra.Command, _ []string) error {
 	// setting output to stderr, so that json outputs can be parsed
 	log.SetOutput(os.Stderr)
 
-	err := common.DropRootPrivs()
-	if err != nil {
-		return err
+	// Rootless operations only supported for Docker runtime
+	if rt == "" || rt == "docker" {
+		err := common.DropRootPrivs()
+		if err != nil {
+			return err
+		}
 	}
 
 	return getTopoFilePath(cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,15 +20,6 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
-<<<<<<< HEAD
-=======
-const (
-	CLAB_AUTHORISED_GROUP = "clab_admins"
-	ROOT_UID              = 0
-	NOMODIFY              = -1
-)
-
->>>>>>> b1098918 (containerlab: Add shorthands for root UID and no-modify flags for readability)
 var (
 	debugCount int
 	debug      bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,9 +90,13 @@ func preRunFn(cmd *cobra.Command, _ []string) error {
 	// setting output to stderr, so that json outputs can be parsed
 	log.SetOutput(os.Stderr)
 
+	err := common.DropRootPrivs()
+	if err != nil {
+		return err
+	}
 	// Rootless operations only supported for Docker runtime
-	if rt == "" || rt == "docker" {
-		err := common.DropRootPrivs()
+	if rt != "" && rt != "docker" {
+		err := common.CheckAndGetRootPrivs(cmd, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,15 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
+<<<<<<< HEAD
+=======
+const (
+	CLAB_AUTHORISED_GROUP = "clab_admins"
+	ROOT_UID              = 0
+	NOMODIFY              = -1
+)
+
+>>>>>>> b1098918 (containerlab: Add shorthands for root UID and no-modify flags for readability)
 var (
 	debugCount int
 	debug      bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/cmd/version"
 	"github.com/srl-labs/containerlab/git"
 	"github.com/srl-labs/containerlab/utils"
@@ -88,6 +89,11 @@ func preRunFn(cmd *cobra.Command, _ []string) error {
 
 	// setting output to stderr, so that json outputs can be parsed
 	log.SetOutput(os.Stderr)
+
+	err := common.DropRootPrivs()
+	if err != nil {
+		return err
+	}
 
 	return getTopoFilePath(cmd)
 }

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
-	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/runtime"
@@ -24,7 +23,6 @@ var saveCmd = &cobra.Command{
 	Short: "save containers configuration",
 	Long: `save performs a configuration save. The exact command that is used to save the config depends on the node kind.
 Refer to the https://containerlab.dev/cmd/save/ documentation to see the exact command used per node's kind`,
-	PreRunE: common.SudoCheck,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if name == "" && topo == "" {
 			return fmt.Errorf("provide topology file path  with --topo flag")

--- a/cmd/tools_netem.go
+++ b/cmd/tools_netem.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/internal/tc"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/runtime"
@@ -70,7 +71,7 @@ var netemSetCmd = &cobra.Command{
 	Long: `The netem queue discipline provides Network Emulation
 functionality for testing protocols by emulating the properties
 of real-world networks.`,
-	PreRunE: validateInput,
+	PreRunE: validateInputAndRoot,
 	RunE:    netemSetFn,
 }
 
@@ -153,7 +154,7 @@ func netemSetFn(_ *cobra.Command, _ []string) error {
 	return err
 }
 
-func validateInput(_ *cobra.Command, _ []string) error {
+func validateInputAndRoot(c *cobra.Command, args []string) error {
 	if netemLoss < 0 || netemLoss > 100 {
 		return fmt.Errorf("packet loss must be in the range between 0 and 100")
 	}
@@ -161,6 +162,8 @@ func validateInput(_ *cobra.Command, _ []string) error {
 	if netemJitter != 0 && netemDelay == 0 {
 		return fmt.Errorf("jitter cannot be set without setting delay")
 	}
+
+	common.CheckAndGetRootPrivs(c, args)
 
 	return nil
 }

--- a/cmd/tools_netem.go
+++ b/cmd/tools_netem.go
@@ -76,9 +76,10 @@ of real-world networks.`,
 }
 
 var netemShowCmd = &cobra.Command{
-	Use:   "show",
-	Short: "show link impairments for a node",
-	RunE:  netemShowFn,
+	Use:     "show",
+	Short:   "show link impairments for a node",
+	PreRunE: validateInputAndRoot,
+	RunE:    netemShowFn,
 }
 
 func netemSetFn(_ *cobra.Command, _ []string) error {

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/srl-labs/containerlab/clab"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/nodes"
 	"github.com/srl-labs/containerlab/nodes/state"
@@ -43,8 +44,9 @@ var vethCmd = &cobra.Command{
 }
 
 var vethCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a veth interface and attach its sides to the specified containers",
+	Use:     "create",
+	Short:   "Create a veth interface and attach its sides to the specified containers",
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 

--- a/cmd/version/upgrade.go
+++ b/cmd/version/upgrade.go
@@ -30,7 +30,7 @@ var upgradeCmd = &cobra.Command{
 		}
 		_ = downloadFile(downloadURL, f)
 
-		c := exec.Command("bash", f.Name())
+		c := exec.Command("sudo", "bash", f.Name())
 		// pass the environment variables to the upgrade script
 		// so that GITHUB_TOKEN is available
 		c.Env = os.Environ()

--- a/cmd/version/upgrade.go
+++ b/cmd/version/upgrade.go
@@ -21,8 +21,8 @@ const downloadURL = "https://github.com/srl-labs/containerlab/raw/main/get.sh"
 var upgradeCmd = &cobra.Command{
 	Use:     "upgrade",
 	Short:   "upgrade containerlab to latest available version",
-	PreRunE: common.SudoCheck,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	PreRunE: common.CheckAndGetRootPrivs,
+	RunE: func(_ *cobra.Command, args []string) error {
 		f, err := os.CreateTemp("", "containerlab")
 		defer os.Remove(f.Name())
 		if err != nil {

--- a/cmd/vxlan.go
+++ b/cmd/vxlan.go
@@ -11,6 +11,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/srl-labs/containerlab/cmd/common"
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/utils"
 	"github.com/vishvananda/netlink"
@@ -54,8 +55,9 @@ var vxlanCmd = &cobra.Command{
 }
 
 var vxlanCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "create vxlan interface",
+	Use:     "create",
+	Short:   "create vxlan interface",
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		ctx := context.Background()
 
@@ -118,8 +120,9 @@ var vxlanCreateCmd = &cobra.Command{
 }
 
 var vxlanDeleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "delete vxlan interface",
+	Use:     "delete",
+	Short:   "delete vxlan interface",
+	PreRunE: common.CheckAndGetRootPrivs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		var ls []netlink.Link
 		var err error

--- a/docs/install.md
+++ b/docs/install.md
@@ -353,7 +353,7 @@ sudo groupadd -r clab_admins
 sudo usermod -aG "$USER" clab_admins
 ```
 
-Users who manage their Containerlab installation via `deb/yum/dnf` package managers will have the sudo-less functionality automatically enabled during the first upgrade from pre-`0.6.3` versions.
+Users who manage their Containerlab installation via `deb/yum/dnf` package managers will have the sudo-less functionality automatically enabled during the first upgrade from pre-`0.63.0` versions.
 
 To check whether Containerlab is enabled for sudo-less operations, run the following commands:
 
@@ -369,7 +369,7 @@ user@host$ groups
 ///
 
 Additionally, to prevent unathorised users from gaining root-level privileges through Containerlab, the usage of privileged Containerlab commands is gated behind a Unix user group membership check. Privileged Containerlab commands can only be performed by users who are part of the `clab_admins` group.  
-By default (starting with version `0.6.3`), the `clab_admins` Unix group is created during the initial installation of Containerlab, and the user installing Containerlab is automatically added to this user group. Additional users who require access to privileged Containerlab commands should also be added to this user group.
+By default (starting with version `0.63.0`), the `clab_admins` Unix group is created during the initial installation of Containerlab, and the user installing Containerlab is automatically added to this user group. Additional users who require access to privileged Containerlab commands should also be added to this user group.
 
 Users who are _not_ part of this group can still execute non-privileged commands, such as:
 - generate
@@ -393,7 +393,7 @@ sudo chmod u-s `which containerlab`
 ```
 
 Containerlab installers will **not** attempt to set the SUID flag or create the `clab_admins` group as long as the empty file `/etc/containerlab/suid_setup_done` exists.  
-This file is automatically created during the first installation of Containerlab `0.6.3` or newer.
+This file is automatically created during the first installation of Containerlab `0.63.0` or newer.
 
 [^1]: Most containerized NOS will require >1 vCPU. RAM size depends on the lab size. IPv6 should not be disabled in the kernel.
 [^2]: only available if installed from packages

--- a/docs/install.md
+++ b/docs/install.md
@@ -337,14 +337,16 @@ sudo setsebool -P selinuxuser_execmod 1
 ```
 
 ## Sudo-less operation
+
 Containerlab requires root privileges to perform certain operations.
 
 To simplify usage, by default, Containerlab is installed as a _SUID binary_[^3] to permit sudo-less operation.
 
 /// details | Enabling sudo-less operations for manually built/installed Containerlab
+    type: subtle-note
 To enable sudo-less operation for users who who manually built and installed Containerlab, or did not use a package manager to install it, the following commands need to be run:
 
-```
+```bash
 # Set SUID bit on Containerlab binary
 sudo chmod u+s `which containerlab`
 # Create clab_admins Unix group
@@ -357,34 +359,48 @@ Users who manage their Containerlab installation via `deb/yum/dnf` package manag
 
 To check whether Containerlab is enabled for sudo-less operations, run the following commands:
 
+```{.bash .no-select}
+ls -hal `which containerlab`
 ```
-$ ls -hal `which containerlab` 
+
+<div class="embed-result">
+```{.bash .no-select .no-copy}
 -rwsr-xr-x 1 root root 131M Jan 17 17:56 /usr/bin/containerlab
 #  ^ SUID bit set, owned by root
-
-user@host$ groups
+```
+</div>
+```{.bash .no-select}
+groups
+```
+<div class="embed-result">
+```{.bash .no-select .no-copy}
 ... clab_admins ...
 #   ^ user is member of clab_admins group
 ```
+</div>
+
 ///
 
-Additionally, to prevent unathorised users from gaining root-level privileges through Containerlab, the usage of privileged Containerlab commands is gated behind a Unix user group membership check. Privileged Containerlab commands can only be performed by users who are part of the `clab_admins` group.  
+Additionally, to prevent unauthorized users from gaining root-level privileges through Containerlab, the usage of privileged Containerlab commands is gated behind a Unix user group membership check. Privileged Containerlab commands can only be performed by users who are part of the `clab_admins` group.  
 By default (starting with version `0.63.0`), the `clab_admins` Unix group is created during the initial installation of Containerlab, and the user installing Containerlab is automatically added to this user group. Additional users who require access to privileged Containerlab commands should also be added to this user group.
 
 Users who are _not_ part of this group can still execute non-privileged commands, such as:
-- exec (requires `docker` group membership)
-- generate
-- graph
-- inspect (requires `docker` group membership)
-- save
-- version (no upgrade)
+
+* exec (requires `docker` group membership)
+* generate
+* graph
+* inspect (requires `docker` group membership)
+* save
+* version (no upgrade)
 
 Non-privileged commands are executed as the user running the Containerlab commands. Privileged commands are executed as root during runtime.
 
 To allow _any user on the host_ to use all Containerlab commands, simply delete the `clab_admins` Unix group.
 
 /// danger
-Much like the `docker` group, any users part of the `clab_admins` group are effectively given root-level privileges to the system running Containerlab. **If this group does not exist and the binary still has the SUID bit set, any user who can run Containerlab should be treated as having root privileges.**
+Much like the `docker` group, any users part of the `clab_admins` group are effectively given root-level privileges to the system running Containerlab.
+
+**If this group does not exist and the binary still has the SUID bit set, any user who can run Containerlab should be treated as having root privileges.**
 ///
 
 To **disable sudo-less operation**, simply unset the SUID flag on the Containerlab binary:

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,9 +37,10 @@ To install all components at once, run the following command on any of the suppo
 ```bash
 curl -sL https://containerlab.dev/setup | sudo -E bash -s "all"
 ```
+<!-- --8<-- [end:quick-setup-script-cmd] -->
 
 By default, this will also configure sshd on the system to increase max auth tries so unknown keys don't lock ssh attempts.
-This behaviour can be turned off by setting the environment variable "SETUP_SSHD" to "false" **before** running the command shown above.
+This behavior can be turned off by setting the environment variable "SETUP_SSHD" to "false" **before** running the command shown above.
 The environment variable can be set and exported with the command shown below.
 
 ```bash
@@ -49,8 +50,6 @@ export SETUP_SSHD="false"
 To complete installation and enable sudo-less `docker` command execution, please run `newgrp docker` or logout and log back in.
 
 Containerlab is also set up for sudo-less operation, and the user executing the quick install script is automatically granted access to privileged commands. For further information, see [Sudo-less operation](#sudo-less-operation).
-
-<!-- --8<-- [end:quick-setup-script-cmd] -->
 
 To install an individual component, specify the function name as an argument to the script. For example, to install only `docker`:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -392,7 +392,8 @@ Users who are _not_ part of this group can still execute non-privileged commands
 * save
 * version (no upgrade)
 
-Non-privileged commands are executed as the user running the Containerlab commands. Privileged commands are executed as root during runtime.
+Non-privileged commands are executed as the user running the Containerlab commands. Privileged commands are executed as root during runtime.  
+Non-privileged command execution is only supported when the default container runtime, Docker.
 
 To allow _any user on the host_ to use all Containerlab commands, simply delete the `clab_admins` Unix group.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -372,6 +372,7 @@ Additionally, to prevent unathorised users from gaining root-level privileges th
 By default (starting with version `0.63.0`), the `clab_admins` Unix group is created during the initial installation of Containerlab, and the user installing Containerlab is automatically added to this user group. Additional users who require access to privileged Containerlab commands should also be added to this user group.
 
 Users who are _not_ part of this group can still execute non-privileged commands, such as:
+- exec (requires `docker` group membership)
 - generate
 - graph
 - inspect (requires `docker` group membership)

--- a/get.sh
+++ b/get.sh
@@ -250,7 +250,11 @@ downloadFile() {
 installFile() {
     tar xf "$TMP_FILE" -C "$TMP_ROOT"
     echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} into ${BIN_INSTALL_DIR}"
-    runAsRoot cp "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
+    # Set SUID bit on the containerlab binary
+    runAsRoot install -m 4755 "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
+    # Add clab admins group and add current user to it
+    runAsRoot groupadd clab_admins
+    runAsRoot usermod -aG "$SUDO_USER" clab_admins
     echo "$BINARY_NAME installed into $BIN_INSTALL_DIR/$BINARY_NAME"
 }
 

--- a/get.sh
+++ b/get.sh
@@ -250,11 +250,15 @@ downloadFile() {
 installFile() {
     tar xf "$TMP_FILE" -C "$TMP_ROOT"
     echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} into ${BIN_INSTALL_DIR}"
-    # Set SUID bit on the containerlab binary
-    runAsRoot install -m 4755 "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
-    # Add clab admins group and add current user to it
-    runAsRoot groupadd -r clab_admins
-    runAsRoot usermod -aG "$SUDO_USER" clab_admins
+    # If SUID setup is running for the first time
+    if [ ! -f /etc/containerlab/suid_setup_done ]; then
+        # Set SUID bit on the containerlab binary
+        runAsRoot install -m 4755 "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
+        # Add clab admins group and add current user to it
+        runAsRoot groupadd -r clab_admins
+        runAsRoot usermod -aG "$SUDO_USER" clab_admins
+        runAsRoot touch /etc/containerlab/suid_setup_done
+    fi
     echo "$BINARY_NAME installed into $BIN_INSTALL_DIR/$BINARY_NAME"
 }
 

--- a/get.sh
+++ b/get.sh
@@ -253,7 +253,7 @@ installFile() {
     # Set SUID bit on the containerlab binary
     runAsRoot install -m 4755 "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
     # Add clab admins group and add current user to it
-    runAsRoot groupadd clab_admins
+    runAsRoot groupadd -r clab_admins
     runAsRoot usermod -aG "$SUDO_USER" clab_admins
     echo "$BINARY_NAME installed into $BIN_INSTALL_DIR/$BINARY_NAME"
 }

--- a/mocks/mockruntime/runtime.go
+++ b/mocks/mockruntime/runtime.go
@@ -44,6 +44,20 @@ func (m *MockContainerRuntime) EXPECT() *MockContainerRuntimeMockRecorder {
 	return m.recorder
 }
 
+// CheckConnection mocks base method.
+func (m *MockContainerRuntime) CheckConnection(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckConnection", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckConnection indicates an expected call of CheckConnection.
+func (mr *MockContainerRuntimeMockRecorder) CheckConnection(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConnection", reflect.TypeOf((*MockContainerRuntime)(nil).CheckConnection), ctx)
+}
+
 // Config mocks base method.
 func (m *MockContainerRuntime) Config() runtime.RuntimeConfig {
 	m.ctrl.T.Helper()

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -381,7 +381,7 @@ func (n *iol) UpdateMgmtIntf(ctx context.Context) error {
 	return n.Runtime.WriteToStdinNoWait(ctx, n.Cfg.ContainerID, []byte(mgmt_str))
 }
 
-// SaveConfig is used for "clab save" functionality -- it saves the running config to the startup configuration
+// SaveConfig is used for "clab save" functionality -- it saves the running config to the startup configuration.
 func (n *iol) SaveConfig(_ context.Context) error {
 	p, err := platform.NewPlatform(
 		"cisco_iosxe",
@@ -390,7 +390,6 @@ func (n *iol) SaveConfig(_ context.Context) error {
 		options.WithAuthUsername(defaultCredentials.GetUsername()),
 		options.WithAuthPassword(defaultCredentials.GetPassword()),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to create platform; error: %+v", err)
 	}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -1071,3 +1071,16 @@ func (d *DockerRuntime) WriteToStdinNoWait(ctx context.Context, cID string, data
 
 	return stdin.Conn.Close()
 }
+
+func (d *DockerRuntime) CheckConnection(ctx context.Context) error {
+	_, err := d.Client.Ping(ctx)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("could not connect to the Docker runtime, make sure your user is part of the `docker` group: %w", err)
+		} else {
+			return fmt.Errorf("could not connect to the Docker runtime: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -242,7 +242,6 @@ func (nftC *NftablesClient) getRules(chainName, tableName string, family nftable
 	}
 
 	return nftC.nftConn.GetRules(chain.Table, chain)
-
 }
 
 func (nftC *NftablesClient) newClabNftablesRule(chainName, tableName string,

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -476,3 +476,12 @@ func (*IgniteRuntime) WriteToStdinNoWait(ctx context.Context, cID string, data [
 	log.Infof("WriteToStdinNoWait is not yet implemented for Ignite runtime")
 	return nil
 }
+
+func (*IgniteRuntime) CheckConnection(_ context.Context) error {
+	// For now, we only check that KVM path exists and assume Ignite works otherwise
+	if _, err := os.Stat(kvmPath); err != nil {
+		return fmt.Errorf("cannot find %q: %s", kvmPath, err)
+	}
+
+	return nil
+}

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -411,3 +411,12 @@ func (*PodmanRuntime) WriteToStdinNoWait(ctx context.Context, cID string, data [
 	log.Infof("WriteToStdinNoWait is not yet implemented for Podman runtime")
 	return nil
 }
+
+func (r *PodmanRuntime) CheckConnection(ctx context.Context) error {
+	_, err := r.connect(ctx)
+	if err != nil {
+		return fmt.Errorf("could not connect to Podman runtime: %w", err)
+	}
+
+	return nil
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -64,6 +64,8 @@ type ContainerRuntime interface {
 	IsHealthy(ctx context.Context, cID string) (bool, error)
 	// Immediately write to the stdin of a container, returns error
 	WriteToStdinNoWait(ctx context.Context, cID string, data []byte) error
+	// CheckConnectivity returns an error if it cannot connect to the runtime, nil otherwise
+	CheckConnection(ctx context.Context) error
 }
 
 type ContainerStatus string

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -4,7 +4,7 @@ Library             String
 Library             Process
 Resource            ../common.robot
 
-Suite Teardown      Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
+Suite Teardown      Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/01-linux-nodes.clab.yml --cleanup
 
 
 *** Variables ***
@@ -29,7 +29,7 @@ Verify number of Hosts entries before deploy
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # save output to be used in next steps
@@ -44,7 +44,7 @@ Ensure exec node option works
 Exec command with no filtering
     [Documentation]    This tests ensures that when `exec` command is called without user provided filters, the command is executed on all nodes of the lab.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --cmd 'uname -n'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --cmd 'uname -n'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # check if output contains the escaped string, as this is how logrus prints to non tty outputs.
@@ -61,7 +61,7 @@ Exec command with no filtering
 Exec command with filtering
     [Documentation]    This tests ensures that when `exec` command is called with user provided filters, the command is executed ONLY on selected nodes of the lab.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'uname -n'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'uname -n'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # check if output contains the escaped string, as this is how logrus prints to non tty outputs.
@@ -74,7 +74,7 @@ Exec command with filtering
 Exec command with json output and filtering
     [Documentation]    This tests ensures that when `exec` command is called with user provided filters and json output, the command is executed ONLY on selected nodes of the lab and the actual JSON is populated to stdout.
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --format json --cmd 'cat /test.json' | jq '.[][0].stdout.containerlab'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --format json --cmd 'cat /test.json' | jq '.[][0].stdout.containerlab'
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -87,7 +87,7 @@ Ensure CLAB_INTFS env var is set
     ...    This test ensures that the CLAB_INTFS environment variable is set in the container
     ...    and that it contains the correct number of interfaces.
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'ash -c "echo $CLAB_INTFS"'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'ash -c "echo $CLAB_INTFS"'
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -104,7 +104,7 @@ Ensure default no_proxy env var is set
     ...    This test ensures that the NO_PROXY env var is populated by clab automatically
     ...    with the relevant addresses and names
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'ash -c "echo $NO_PROXY"'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd 'ash -c "echo $NO_PROXY"'
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -116,7 +116,7 @@ Ensure default no_proxy env var is set
 
 Inspect ${lab-name} lab using its name
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -203,7 +203,7 @@ Verify links on host
 
 Ensure "inspect all" outputs IP addresses
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --all
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --all
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -371,7 +371,7 @@ Verify DNS-Options Config
 Verify Exec rc == 0 on containers match
     [Documentation]    Checking that the return code is != 0 if on the exce call not containers match
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --cmd "echo test"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --cmd "echo test"
     Log    ${output}
     Should Contain    ${output}    test
     Should Not Contain    ${output}    Error: filter did not match any containers
@@ -380,7 +380,7 @@ Verify Exec rc == 0 on containers match
 Verify Exec rc != 0 on no containers match
     [Documentation]    Checking that the return code is != 0 if on the exce call not containers match
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name=nonexist --cmd "echo test"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name=nonexist --cmd "echo test"
     Log    ${output}
     Should Not Contain    ${output}    test
     Should Contain    ${output}    Error: filter did not match any containers
@@ -403,7 +403,7 @@ Verify l1 node is healthy
 
 Destroy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -449,7 +449,7 @@ Verify containerlab version
     [Documentation]    Ensures that 'containerlab version' subcommand runs successfully
     ...                and prints basic version fields.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} version
+    ...    ${CLAB_BIN} version
     Log    ${output}
     # The command should exit with 0
     Should Be Equal As Integers    ${rc}    0
@@ -463,7 +463,7 @@ Verify containerlab version check
     [Documentation]    Ensures that 'containerlab version check' either says you're on latest version
     ...                or that a new version is available. Also verifies the command succeeds.
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} version check
+    ...    ${CLAB_BIN} version check
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 

--- a/tests/01-smoke/02-destroy-all.robot
+++ b/tests/01-smoke/02-destroy-all.robot
@@ -10,7 +10,7 @@ Library             OperatingSystem
 Library             Process
 Resource            ../common.robot
 
-Suite Teardown      Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
+Suite Teardown      Run    ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
 
 
 *** Variables ***
@@ -25,7 +25,7 @@ ${lab2-name}    single-node
 *** Test Cases ***
 Deploy first lab
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab1-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab1-file}
     ...    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
@@ -36,7 +36,7 @@ Deploy first lab
 
 Deploy second lab
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab2-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab2-file}
     ...    cwd=/tmp    # using a different cwd to check lab resolution via container labels
     ...    shell=True
     Log    ${result.stdout}
@@ -46,7 +46,7 @@ Deploy second lab
 
 Inspect ${lab2-name} lab using its name
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab2-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab2-name}
     Log    \n--> LOG: Inspect output\n${output}    console=True
     Should Be Equal As Integers    ${rc}    0
 
@@ -57,7 +57,7 @@ Inspect ${lab2-name} lab using its name
 
 Inspect ${lab2-name} lab using topology file reference
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect -t ${orig_dir}/${lab2-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect -t ${orig_dir}/${lab2-file}
     ...    shell=True
     Log    \n--> LOG: Inspect output\n${result.stdout}    console=True
     Log    ${result.stderr}
@@ -69,7 +69,7 @@ Inspect ${lab2-name} lab using topology file reference
 
 Inspect all
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --all
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --all
     Log    \n--> LOG: Inspect all output\n${output}    console=True
     Should Be Equal As Integers    ${rc}    0
 
@@ -90,13 +90,13 @@ Verify host mode networking for node l3
 Verify ipv4-range is set correctly
     Skip If    '${runtime}' != 'docker'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect -t ${CURDIR}/01-linux-single-node.clab.yml
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect -t ${CURDIR}/01-linux-single-node.clab.yml
     Log    ${output}
     Should Contain    ${output}    172.20.30.9
 
 Redeploy second lab
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} redeploy -c -t ${CURDIR}/${lab2-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} redeploy -c -t ${CURDIR}/${lab2-file}
     ...    cwd=/tmp    # using a different cwd to check lab resolution via container labels
     ...    shell=True
     Log    ${result.stdout}
@@ -106,13 +106,13 @@ Redeploy second lab
 
 Destroy all labs
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Check all labs have been removed
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --all
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --all
     Log    ${output}
     Should Contain    ${output}    no containers found
     Should Not Exist    /tmp/single-node

--- a/tests/01-smoke/03-bridges-and-host.robot
+++ b/tests/01-smoke/03-bridges-and-host.robot
@@ -34,7 +34,7 @@ Create linux bridge
 
 Deploy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy --skip-labdir-acl -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy --skip-labdir-acl -t ${CURDIR}/${lab-file}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -58,7 +58,7 @@ Verify management network is using user-specified bridge
     # show management interface info and cut the information about the ifindex of the remote veth
     # note that exec returns the info in the stderr stream, thus we use stderr to parse the ifindex
     ${rc}    ${iface} =    OperatingSystem.Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd "ip l show eth0" 2>&1 | perl -lne '/.*[0-9]+: .*\\@if(.*:) .*/ && print $1'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=l1 --cmd "ip l show eth0" 2>&1 | perl -lne '/.*[0-9]+: .*\\@if(.*:) .*/ && print $1'
     Log    ${iface}
     Should Be Equal As Integers    ${rc}    0
     ${rc}    ${res} =    OperatingSystem.Run And Return Rc And Output
@@ -115,7 +115,7 @@ Setup
 
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 

--- a/tests/01-smoke/04-generate.robot
+++ b/tests/01-smoke/04-generate.robot
@@ -12,14 +12,14 @@ ${runtime}      docker
 Deploy ${lab-name} lab with generate command
     Skip If    '${runtime}' != 'docker'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} generate --name ${lab-name} --kind linux --image ghcr.io/srl-labs/network-multitool --nodes 2,1,1 --deploy
+    ...    ${CLAB_BIN} --runtime ${runtime} generate --name ${lab-name} --kind linux --image ghcr.io/srl-labs/network-multitool --nodes 2,1,1 --deploy
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Verify nodes
     Skip If    '${runtime}' != 'docker'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    clab-${lab-name}-node1-1
@@ -34,7 +34,7 @@ Deploy ${lab-name}-scale lab with generate command
     ...    This test verifies that scaled topology can be deployed without concurrent errors.
     Skip If    '${runtime}' != 'docker'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} generate --name ${lab-name}-scale --kind linux --image alpine:3 --nodes 5,5,5 --deploy
+    ...    ${CLAB_BIN} --runtime ${runtime} generate --name ${lab-name}-scale --kind linux --image alpine:3 --nodes 5,5,5 --deploy
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${output}    failed
@@ -49,7 +49,7 @@ Cleanup
 
     Skip If    '${runtime}' != 'docker'
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${lab-name}.clab.yml --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${lab-name}.clab.yml --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     OperatingSystem.Remove File    ${lab-name}.clab.yml

--- a/tests/01-smoke/05-docker-bridge.robot
+++ b/tests/01-smoke/05-docker-bridge.robot
@@ -17,13 +17,13 @@ ${table-delimit}    │
 *** Test Cases ***
 Deploy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     Log    \n--> LOG: Deploy output\n${output}    console=True
     Should Be Equal As Integers    ${rc}    0
 
 Ensure inspect outputs IP addresses
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --name ${lab-name}
     Log    \n--> LOG: Inspect output\n${output}    console=True
     Should Be Equal As Integers    ${rc}    0
 
@@ -45,5 +45,5 @@ Setup
 
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}

--- a/tests/01-smoke/06-tools-certs.robot
+++ b/tests/01-smoke/06-tools-certs.robot
@@ -20,7 +20,7 @@ ${node-cert-dir}    /tmp/clab-tests/certs/06-node-cert
 *** Test Cases ***
 Create CA certificate
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} tools cert ca create --path ${root-ca-dir} --name root-ca --expiry 1m --locality CICD -d
+    ...    ${CLAB_BIN} tools cert ca create --path ${root-ca-dir} --name root-ca --expiry 1m --locality CICD -d
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain
@@ -37,7 +37,7 @@ Create CA certificate
 
 Create and sign end node certificates
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} tools cert sign --ca-cert ${root-ca-dir}/root-ca.pem --ca-key ${root-ca-dir}/root-ca.key --hosts node.io,192.168.0.1 --path ${node-cert-dir} -d
+    ...    ${CLAB_BIN} tools cert sign --ca-cert ${root-ca-dir}/root-ca.pem --ca-key ${root-ca-dir}/root-ca.key --hosts node.io,192.168.0.1 --path ${node-cert-dir} -d
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain

--- a/tests/01-smoke/07-keep-mgmt-net.robot
+++ b/tests/01-smoke/07-keep-mgmt-net.robot
@@ -10,7 +10,7 @@ Library             String
 Resource            ../common.robot
 
 Suite Setup         Setup
-Suite Teardown      Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+Suite Teardown      Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
 
 
 *** Variables ***
@@ -23,13 +23,13 @@ ${mgmt-bridge}      01-07-net
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Destroy ${lab-name} lab keep mgmt net
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --keep-mgmt-net
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --keep-mgmt-net
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -42,13 +42,13 @@ Check ${lab-name} mgmt network remains
 Deploy ${lab-name} lab again
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Destroy ${lab-name} lab dont keep mgmt net
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 

--- a/tests/01-smoke/08-tools-cmds.robot
+++ b/tests/01-smoke/08-tools-cmds.robot
@@ -9,7 +9,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../common.robot
 
-Suite Teardown      Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+Suite Teardown      Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
 
 
 *** Variables ***
@@ -22,13 +22,13 @@ ${topo}         ${CURDIR}/01-linux-nodes.clab.yml
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Add link impairments
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools netem set -n clab-${lab-name}-l1 -i eth3 --delay 100ms --jitter 2ms --loss 10 --rate 1000 --corruption 2
+    ...    ${CLAB_BIN} --runtime ${runtime} tools netem set -n clab-${lab-name}-l1 -i eth3 --delay 100ms --jitter 2ms --loss 10 --rate 1000 --corruption 2
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    100ms
@@ -39,7 +39,7 @@ Add link impairments
 
 Show link impairments
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools netem show -n clab-${lab-name}-l1
+    ...    ${CLAB_BIN} --runtime ${runtime} tools netem show -n clab-${lab-name}-l1
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    100ms

--- a/tests/01-smoke/09-external-ca.robot
+++ b/tests/01-smoke/09-external-ca.robot
@@ -36,7 +36,7 @@ Generate Certificate
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # save output to be used in next steps
@@ -76,5 +76,5 @@ Setup
     Run    rm -f ${ca-key-file} ${ca-cert-file}
 
 Teardown
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
     Run    rm -f ${ca-key-file} ${ca-cert-file}

--- a/tests/01-smoke/10-ca-parameter.robot
+++ b/tests/01-smoke/10-ca-parameter.robot
@@ -31,7 +31,7 @@ ${l3-cert}                  ${CURDIR}/clab-${lab-name}/.tls/l3/l3.pem
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # save output to be used in next steps
@@ -106,7 +106,7 @@ Verify l2 extra SANs
 
 *** Keywords ***
 Teardown
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${topo} --cleanup
 
 Get Certificate Date
     [Arguments]    ${certificate_output}    ${type}

--- a/tests/01-smoke/11-node-filter.robot
+++ b/tests/01-smoke/11-node-filter.robot
@@ -17,7 +17,7 @@ ${runtime-cli-exec-cmd}     sudo docker exec
 *** Test Cases ***
 Test filter 1
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} --node-filter node1,node2,node4
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} --node-filter node1,node2,node4
     ...    shell=True
 
     Log    ${output.stdout}
@@ -30,7 +30,7 @@ Test filter 1
 
     # check that node1 contains only two interfaces eth1 and eth3 and doesn't contain eth2
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=node1 --cmd 'ip link'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=node1 --cmd 'ip link'
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -42,7 +42,7 @@ Test filter 1
 
 Test filter 2
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} --node-filter node1
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} --node-filter node1
     ...    shell=True
 
     Log    ${output.stdout}
@@ -58,7 +58,7 @@ Test filter 2
 
     # check that node1 contains no interfaces besides management
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=node1 --cmd 'ip link'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file} --label clab-node-name\=node1 --cmd 'ip link'
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -70,5 +70,5 @@ Test filter 2
 
 *** Keywords ***
 Cleanup
-    Process.Run Process    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    Process.Run Process    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
 ...    shell=True

--- a/tests/01-smoke/12-tools-veth.robot
+++ b/tests/01-smoke/12-tools-veth.robot
@@ -24,7 +24,7 @@ ${runtime-cli-exec-cmd}     sudo docker exec
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     # save output to be used in next steps
@@ -45,7 +45,7 @@ Verify links in node n1 pre-deploy
 Deploy veth between bridge and n1
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n1:eth1 -b bridge:${bridge-name}:${bridge-n1-iface}
+    ...    ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n1:eth1 -b bridge:${bridge-name}:${bridge-n1-iface}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -65,7 +65,7 @@ Verify bridge link
 Deploy veth between n1 and n2
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n1:eth2 -b clab-${lab-name}-n2:eth2
+    ...    ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n1:eth2 -b clab-${lab-name}-n2:eth2
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -86,7 +86,7 @@ Verify links in node n2 post-deploy
 Deploy veth between n2 and host
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n2:eth3 -b host:${host-n1-iface}
+    ...    ${CLAB_BIN} --runtime ${runtime} tools veth create -d -a clab-${lab-name}-n2:eth3 -b host:${host-n1-iface}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -110,5 +110,5 @@ Setup
     Run    sudo ip l add dev ${bridge-name} type bridge
 
 Teardown
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Run    sudo ip l del dev ${bridge-name}

--- a/tests/01-smoke/13-stdin-lab.robot
+++ b/tests/01-smoke/13-stdin-lab.robot
@@ -14,13 +14,13 @@ ${lab-url}      https://gist.githubusercontent.com/hellt/9baa28d7e3cb8290ade1e1b
 *** Test Cases ***
 Deploy remote lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo curl -s ${lab-url} | sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -c -t -
+    ...    sudo curl -s ${lab-url} | ${CLAB_BIN} --runtime ${runtime} deploy -c -t -
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Ensure inspect works
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect --all
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --all
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -28,4 +28,4 @@ Ensure inspect works
 *** Keywords ***
 Teardown
     # destroy all labs
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -a
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -a

--- a/tests/01-smoke/14-macvlan.robot
+++ b/tests/01-smoke/14-macvlan.robot
@@ -51,7 +51,7 @@ Check macvlan interface on l1
 *** Keywords ***
 Teardown
     # destroy all labs
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -a
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -a
 
 Setup
     # skipping this test suite for podman for now

--- a/tests/01-smoke/15-netw-modes.robot
+++ b/tests/01-smoke/15-netw-modes.robot
@@ -15,7 +15,7 @@ ${lab}      ${CURDIR}/netmodes.clab.yml
 *** Test Cases ***
 Deploy lab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab}
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -25,4 +25,4 @@ Deploy lab
 *** Keywords ***
 Teardown
     # destroy all labs
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -a
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -a

--- a/tests/01-smoke/16-mgmtnet.robot
+++ b/tests/01-smoke/16-mgmtnet.robot
@@ -17,7 +17,7 @@ ${runtime}          docker
 *** Test Cases ***
 Deploy ${lab-name} lab
     ${result} =    Run Process   
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${topo}
     ...    shell=True
     Log    ${result.stdout}
     Should Be Equal As Integers    ${result.rc}    0
@@ -38,7 +38,7 @@ Check host side interface is attached to mgmt bridge and up
 *** Keywords ***
 Teardown
     # destroy all labs
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -a
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -a
 
 Setup
     # skipping this test suite for podman for now

--- a/tests/01-smoke/17-cloned-lab.robot
+++ b/tests/01-smoke/17-cloned-lab.robot
@@ -22,7 +22,7 @@ ${runtime}              docker
 *** Test Cases ***
 Test lab1 with Github
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-url}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-url}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -36,7 +36,7 @@ Test lab1 with Github
 
 Test lab1 with Gitlab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-gitlab-url}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-gitlab-url}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -50,7 +50,7 @@ Test lab1 with Gitlab
 
 Test lab2 with Github
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-url2}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-url2}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -64,7 +64,7 @@ Test lab2 with Github
 
 Test lab2 with Gitlab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-gitlab-url2}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-gitlab-url2}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -78,7 +78,7 @@ Test lab2 with Gitlab
 
 Test lab3 with Github
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab2-url}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab2-url}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -92,7 +92,7 @@ Test lab3 with Github
 
 Test lab3 with Gitlab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab2-gitlab-url}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab2-gitlab-url}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -106,7 +106,7 @@ Test lab3 with Gitlab
 
 Test lab1 with short github url
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-shorturl}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${lab1-shorturl}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -119,7 +119,7 @@ Test lab1 with short github url
 
 Test lab1 downloaded from https url
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${http-lab-url}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${http-lab-url}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -132,7 +132,7 @@ Test lab1 downloaded from https url
 
 Test deploy referencing folder as topo
     ${output_pre} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${single-topo-folder}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${single-topo-folder}
     ...    shell=True
 
     Log    ${output_pre.stdout}
@@ -150,7 +150,7 @@ Test deploy referencing folder as topo
 
     ## destroy with just a reference to a folder
     ${output_post1} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${single-topo-folder}
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${single-topo-folder}
     ...    shell=True
 
     ## double check deletion via runtime ps 
@@ -163,7 +163,7 @@ Test deploy referencing folder as topo
 
 *** Keywords ***
 Cleanup
-    Process.Run Process    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
+    Process.Run Process    ${CLAB_BIN} --runtime ${runtime} destroy --all --cleanup
     ...    shell=True
 
     Process.Run Process    sudo -E rm -rf clab-test-repo

--- a/tests/01-smoke/18-stages.robot
+++ b/tests/01-smoke/18-stages.robot
@@ -28,7 +28,7 @@ Pre-Pull Image
 
 Deploy ${lab-name} lab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -100,7 +100,7 @@ Deploy ${lab-name} lab with a single worker
     Run Keyword    Teardown
 
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy --max-workers 1 -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy --max-workers 1 -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -133,11 +133,11 @@ Ensure node3 started after node4 after a single worker run
 
 *** Keywords ***
 Teardown
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
 
 Setup
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}

--- a/tests/01-smoke/19-stages-race.robot
+++ b/tests/01-smoke/19-stages-race.robot
@@ -20,7 +20,7 @@ ${runtime}      docker
 *** Test Cases ***
 Deploy ${lab-name} lab
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}
@@ -35,11 +35,11 @@ Deploy ${lab-name} lab
 
 *** Keywords ***
 Teardown
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
 
 Setup
     ${output} =    Process.Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -c -t ${CURDIR}/${lab-file}
     ...    shell=True
 
     Log    ${output.stdout}

--- a/tests/02-basic-srl/01-two-srls.robot
+++ b/tests/02-basic-srl/01-two-srls.robot
@@ -33,20 +33,20 @@ Create SSH keypair - ecdsa512
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Verify links in node srl1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip link show e1-1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify links in node srl2
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "ip link show e1-1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "ip link show e1-1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
@@ -56,21 +56,21 @@ Verify e1-1 interface have been admin enabled on srl1
     ...    This test cases ensures that e1-1 interface referenced in links section
     ...    has been automatically admin enabled
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    ethernet-1/1 is up
 
 Verify srl2 accepted user-provided CLI config
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "sr_cli 'info /system information location'"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl2 --cmd "sr_cli 'info /system information location'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    test123
 
 Verify saving config
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${output}    ERRO
@@ -112,7 +112,7 @@ Ensure srl1 is reachable over ssh with public key ECDSA512 auth
 Ensure srl1 can ping srl2 over ethernet-1/1 interface
     Sleep    5s    give some time for networking stack to settle
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0% packet loss
@@ -156,6 +156,6 @@ Verify NETCONF works
 
 *** Keywords ***
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    sudo docker rm -f net-cons2-clab
     Run    rm -f ${key-path}*

--- a/tests/02-basic-srl/03-srl-bgp.robot
+++ b/tests/02-basic-srl/03-srl-bgp.robot
@@ -17,7 +17,7 @@ ${runtime}          docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -26,7 +26,7 @@ Verify e1-1 interface have been admin enabled on srl1
     ...    This test cases ensures that e1-1 interface referenced in links section
     ...    has been automatically admin enabled
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "sr_cli 'show interface ethernet-1/1'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    ethernet-1/1 is up
@@ -34,7 +34,7 @@ Verify e1-1 interface have been admin enabled on srl1
 Ensure srl1 can ping srl2 over ethernet-1/1 interface
     Sleep    5s    give some time for networking stack to settle
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd "ip netns exec srbase-default ping 192.168.0.1 -c2 -w 3"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0% packet loss
@@ -52,26 +52,26 @@ Check BGP session sent routes count
 *** Keywords ***
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Log    ${output}
 
 Check BGP session is Established
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 session-state'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 session-state'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    established
 
 Check BGP session received routes count
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 afi-safi ipv4-unicast received-routes'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 afi-safi ipv4-unicast received-routes'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    received-routes 2
 
 Check BGP session sent routes count
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 afi-safi ipv4-unicast sent-routes'
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=srl1 --cmd 'sr_cli -- info from state network-instance default protocols bgp neighbor 192.168.0.1 afi-safi ipv4-unicast sent-routes'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    sent-routes 2

--- a/tests/03-basic-ceos/01-two-ceos.robot
+++ b/tests/03-basic-ceos/01-two-ceos.robot
@@ -21,7 +21,7 @@ ${runtime}          docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -53,7 +53,7 @@ Ensure IPv6 default route is in the config file
 
 Ensure MGMT VRF is present
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${node1-name} --cmd "Cli -p 15 -c 'show vrf MGMT'"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${node1-name} --cmd "Cli -p 15 -c 'show vrf MGMT'"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    MGMT
@@ -75,5 +75,5 @@ Ensure n2 is reachable over ssh
 
 *** Keywords ***
 Cleanup
-    Run    sudo -E ${CLAB_BIN} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    rm -rf ${CURDIR}/${lab-name}

--- a/tests/04-basic-ixiacone/01-ixiacone.robot
+++ b/tests/04-basic-ixiacone/01-ixiacone.robot
@@ -20,7 +20,7 @@ ${runtime}              docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -28,14 +28,14 @@ Verify link eth1 in keysight_ixia-c-one node n1
     # give time for the link to come up
     Sleep    10s
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${ixia-node-name} --cmd "docker exec -t ixia-c-port-dp-${ifc1-name} ip link show ${ifc1-name}"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${ixia-node-name} --cmd "docker exec -t ixia-c-port-dp-${ifc1-name} ip link show ${ifc1-name}"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify link eth2 in keysight_ixia-c-one node n1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${ixia-node-name} --cmd "docker exec -t ixia-c-port-dp-${ifc2-name} ip link show ${ifc2-name}"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=${ixia-node-name} --cmd "docker exec -t ixia-c-port-dp-${ifc2-name} ip link show ${ifc2-name}"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
@@ -43,5 +43,5 @@ Verify link eth2 in keysight_ixia-c-one node n1
 
 *** Keywords ***
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    rm -rf ${CURDIR}/${lab-name}

--- a/tests/05-k8s-kind/01-basic-k8s-kind.robot
+++ b/tests/05-k8s-kind/01-basic-k8s-kind.robot
@@ -20,7 +20,7 @@ Create Bridge
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name} -d
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name} -d
     ...    timeout=800s
     ...    shell=True
     Log    ${result.stderr}
@@ -95,7 +95,7 @@ Verify kind cluster k02 nodes are ready
     Should Be Equal As Integers    ${output}    1
 
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    rm -rf ${CURDIR}/${lab-name}
     Run    sudo ip l set dev br01 down
     Run    sudo ip l del dev br01

--- a/tests/06-ext-container/01-ext-container.robot
+++ b/tests/06-ext-container/01-ext-container.robot
@@ -23,27 +23,27 @@ Start ext-containers
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Verify links in node ext1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext1 --cmd "ip link show dev eth1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext1 --cmd "ip link show dev eth1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify ip and thereby exec on ext1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext1 --cmd "ip address show dev eth1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext1 --cmd "ip address show dev eth1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    192.168.0.1/24
 
 Inspect the lab using topology file reference
     ${result} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} inspect -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect -t ${CURDIR}/${lab-file-name}
     ...    shell=True
     Log    \n--> LOG: Inspect output\n${result.stdout}    console=True
     Log    ${result.stderr}
@@ -55,14 +55,14 @@ Inspect the lab using topology file reference
 
 Verify links in node ext2
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext2 --cmd "ip link show dev eth1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext2 --cmd "ip link show dev eth1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify ip and thereby exec on ext2
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext2 --cmd "ip address show dev eth1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext2 --cmd "ip address show dev eth1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    192.168.0.2/24
@@ -82,6 +82,6 @@ Setup
     Skip If    '${runtime}' != 'docker'
 
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
     Run    ${runtime} rm -f ext1
     Run    ${runtime} rm -f ext2

--- a/tests/06-ext-container/02-shared-namespace.robot
+++ b/tests/06-ext-container/02-shared-namespace.robot
@@ -18,7 +18,7 @@ ${runtime}          docker
 Deploy ${lab-name}-ext lab
     Log    ${CURDIR}
     ${output} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-1}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-1}
     ...    shell=True
     Log    ${output.stdout}
     Log    ${output.stderr}
@@ -27,7 +27,7 @@ Deploy ${lab-name}-ext lab
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${output} =    Run Process
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-2}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -d -t ${CURDIR}/${lab-file-name-2}
     ...    shell=True
     ...    timeout=30s
     Log    ${output.stdout}
@@ -36,28 +36,28 @@ Deploy ${lab-name} lab
 
 Verify ip on ext-node
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext-node --cmd "ip address show dev d1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=ext-node --cmd "ip address show dev d1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    128.66.0.1/32
 
 Verify links in node0
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node0 --cmd "ip link show dev net0"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node0 --cmd "ip link show dev net0"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
 
 Verify ext-node defined interface is present for node1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip address show dev d1"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip address show dev d1"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    128.66.0.1/32
 
 Verify topo defined link in node1
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip link show dev net0"
+    ...    ${CLAB_BIN} --runtime ${runtime} exec --label clab-node-name\=node1 --cmd "ip link show dev net0"
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    state UP
@@ -68,5 +68,5 @@ Setup
     Cleanup
 
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-1} --cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-2} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-1} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name-2} --cleanup

--- a/tests/07-sros/01-single-sros.robot
+++ b/tests/07-sros/01-single-sros.robot
@@ -17,7 +17,7 @@ ${runtime}          docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     IF    ${rc} != 0    Fatal Error    Failed to deploy ${lab-name} lab
@@ -47,4 +47,4 @@ Cleanup
     ${contents} =    OperatingSystem.Get File    /tmp/${lab-name}-sros1.log
     Log    ${contents}
 
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/tests/08-vxlan/01-vxlan.robot
+++ b/tests/08-vxlan/01-vxlan.robot
@@ -19,7 +19,7 @@ ${vxlan-br-ip}      172.20.25.1/24
 *** Test Cases ***
 Deploy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} -d
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} -d
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -86,7 +86,7 @@ Setup
 
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
 
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/08-vxlan/02-vxlan-stitch.robot
+++ b/tests/08-vxlan/02-vxlan-stitch.robot
@@ -19,7 +19,7 @@ ${vxlan-br-ip}      172.20.25.1/24
 *** Test Cases ***
 Deploy ${lab-name} lab
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} -d
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file} -d
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -103,7 +103,7 @@ Setup
 
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
 
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/08-vxlan/03-tools-veth-vxlan.robot
+++ b/tests/08-vxlan/03-tools-veth-vxlan.robot
@@ -38,7 +38,7 @@ Deploy ${lab-name} lab
     Should Contain    ${output}    mtu 9100    msg=Bridge mtu is not 9100 before lab deployment
 
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -105,7 +105,7 @@ Deploy vxlab link between l1 and l3 with tools cmd
     Should Contain    ${output}    mtu 9100
 
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools vxlan create --remote 172.20.25.23 --link ${l1_host_link} --id 101 --port 14788
+    ...    ${CLAB_BIN} --runtime ${runtime} tools vxlan create --remote 172.20.25.23 --link ${l1_host_link} --id 101 --port 14788
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -126,7 +126,7 @@ Check VxLAN connectivity l1-l3
 
 Deploy vxlab link between l2 and l4 with tools cmd
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} tools vxlan create --remote 172.20.25.24 --link ${l2_host_link} --id 102
+    ...    ${CLAB_BIN} --runtime ${runtime} tools vxlan create --remote 172.20.25.24 --link ${l2_host_link} --id 102
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -167,7 +167,7 @@ Setup
 
 Cleanup
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file} --cleanup
     Log    ${output}
 
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/09-fortigate/01-two-fortigates.robot
+++ b/tests/09-fortigate/01-two-fortigates.robot
@@ -15,7 +15,7 @@ ${runtime}          docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     IF    ${rc} != 0    Fatal Error    Failed to deploy ${lab-name} lab
@@ -47,4 +47,4 @@ Cleanup
     ${contents} =    OperatingSystem.Get File    /tmp/${lab-name}-forti1.log
     Log    ${contents}
 
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -16,7 +16,7 @@ ${runtime}          docker
 Deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -55,7 +55,7 @@ Verify full startup configuration on router3
 
 Save running-config to startup-config to NVRAM with clab save
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} save -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -94,14 +94,14 @@ Log IP addresses for switch
 Destroy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
 Re-deploy ${lab-name} lab
     Log    ${CURDIR}
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sudo -E ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
+    ...    ${CLAB_BIN} --runtime ${runtime} deploy -t ${CURDIR}/${lab-file-name}
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
@@ -147,4 +147,4 @@ Verify connectivity via new management addresses on switch
 
 *** Keywords ***
 Cleanup
-    Run    sudo -E ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/utils/file.go
+++ b/utils/file.go
@@ -156,6 +156,12 @@ func CopyFileContents(src, dst string, mode os.FileMode) (err error) {
 		return err
 	}
 
+	// Change file ownership to user running Containerlab instead of effective UID
+	err = SetUIDAndGID(dst)
+	if err != nil {
+		return err
+	}
+
 	err = out.Chmod(mode)
 	if err != nil {
 		return err
@@ -192,6 +198,12 @@ func CreateFile(file, content string) (err error) {
 	}
 
 	_, err = f.WriteString(content)
+	if err != nil {
+		return err
+	}
+
+	// Change file ownership to user running Containerlab instead of effective UID
+	err = SetUIDAndGID(file)
 	if err != nil {
 		return err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -362,32 +362,44 @@ func NewHTTPClient() *http.Client {
 	return &http.Client{Transport: tr}
 }
 
-// AdjustFileACLs takes the given fs path, tries to load
-// the access file acl of that path and adds ACL rules
-// rwx for the SUDO_UID and r-x for the SUDO_GID group.
+func getRealUserIDs() (int, int, error) {
+	// Here we check whether SUDO set the SUDO_UID and SUDO_GID variables
+	var userUID, userGID int
+	var err error
+
+	sudoUID, isSudoUIDSet := os.LookupEnv("SUDO_UID")
+	if isSudoUIDSet {
+		userUID, err = strconv.Atoi(sudoUID)
+		if err != nil {
+			return -1, -1, fmt.Errorf("unable to convert SUDO_UID %q to int", sudoUID)
+		}
+		sudoGID, isSudoGIDSet := os.LookupEnv("SUDO_GID")
+		if isSudoGIDSet {
+			userGID, err = strconv.Atoi(sudoGID)
+			if err != nil {
+				return -1, -1, fmt.Errorf("unable to convert SUDO_GID %q to int", sudoGID)
+			}
+		}
+		// Otherwise just check for the real UID/GID (instead of the effective UID)
+	} else {
+		userUID = os.Getuid()
+		userGID = os.Getgid()
+	}
+
+	return userUID, userGID, nil
+}
+
+// AdjustFileACLs takes the given fs path, tries to load the access file acl of that path and adds ACL rules:
+// rwx for the real UID user and r-x for the real GID group
 func AdjustFileACLs(fsPath string) error {
-	/// here we trust sudo to set up env variables
-	// a missing SUDO_UID env var indicates the root user
-	// runs clab without sudo
-	uid, isSet := os.LookupEnv("SUDO_UID")
-	if !isSet {
-		// nothing to do, already running as root
+	userUID, userGID, err := getRealUserIDs()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve real user UID and GID: %v", err)
+	}
+
+	if userUID == 0 && userGID == 0 {
+		// We are running as root without sudo, return early
 		return nil
-	}
-
-	gid, isSet := os.LookupEnv("SUDO_GID")
-	if !isSet {
-		return fmt.Errorf("unable to retrieve GID. will only adjust UID for %q", fsPath)
-	}
-
-	iUID, err := strconv.Atoi(uid)
-	if err != nil {
-		return fmt.Errorf("unable to convert SUDO_UID %q to int", uid)
-	}
-
-	iGID, err := strconv.Atoi(gid)
-	if err != nil {
-		return fmt.Errorf("unable to convert SUDO_GID %q to int", gid)
 	}
 
 	// create a new ACL instance
@@ -399,13 +411,13 @@ func AdjustFileACLs(fsPath string) error {
 	}
 
 	// add an entry for the group
-	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_GROUP, uint32(iGID), 5))
+	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_GROUP, uint32(userGID), 5))
 	if err != nil {
 		return err
 	}
 
 	// add an entry for the User
-	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_USER, uint32(iUID), 7))
+	err = a.AddEntry(acls.NewEntry(acls.TAG_ACL_USER, uint32(userUID), 7))
 	if err != nil {
 		return err
 	}
@@ -425,36 +437,20 @@ func AdjustFileACLs(fsPath string) error {
 	return a.Apply(fsPath, acls.PosixACLDefault)
 }
 
-// SetUIDAndGID changes the UID and GID
-// of the given path recursively to the values taken from
-// SUDO_UID and SUDO_GID. Which should reflect be the non-root
-// user that called clab via sudo.
+// SetUIDAndGID changes the UID and GID of the given path recursively to the values taken from getRealUserIDs,
+// which should reflect the non-root user's UID and GID.
 func SetUIDAndGID(fsPath string) error {
-	// here we trust sudo to set up env variables
-	// a missing SUDO_UID env var indicates the root user
-	// runs clab without sudo
-	uid, isSet := os.LookupEnv("SUDO_UID")
-	if !isSet {
-		// nothing to do, already running as root
+	userUID, userGID, err := getRealUserIDs()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve real user UID and GID: %v", err)
+	}
+
+	if userUID == 0 && userGID == 0 {
+		// We are running as root without sudo, return early
 		return nil
 	}
 
-	gid, isSet := os.LookupEnv("SUDO_GID")
-	if !isSet {
-		return errors.New("failed to lookup SUDO_GID env var")
-	}
-
-	iUID, err := strconv.Atoi(uid)
-	if err != nil {
-		return fmt.Errorf("unable to convert SUDO_UID %q to int", uid)
-	}
-
-	iGID, err := strconv.Atoi(gid)
-	if err != nil {
-		return fmt.Errorf("unable to convert SUDO_GID %q to int", gid)
-	}
-
-	err = recursiveChown(fsPath, iUID, iGID)
+	err = recursiveChown(fsPath, userUID, userGID)
 	if err != nil {
 		return err
 	}

--- a/utils/file.go
+++ b/utils/file.go
@@ -390,7 +390,7 @@ func getRealUserIDs() (int, int, error) {
 }
 
 // AdjustFileACLs takes the given fs path, tries to load the access file acl of that path and adds ACL rules:
-// rwx for the real UID user and r-x for the real GID group
+// rwx for the real UID user and r-x for the real GID group.
 func AdjustFileACLs(fsPath string) error {
 	userUID, userGID, err := getRealUserIDs()
 	if err != nil {

--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -33,5 +33,8 @@ elif type "wget" > /dev/null 2>&1; then
     exit 0
 fi
 
-groupadd -r clab_admins
-usermod -aG clab_admins "$SUDO_USER"
+if [ ! -f /etc/containerlab/suid_setup_done ]; then
+    groupadd -r clab_admins
+    usermod -aG clab_admins "$SUDO_USER"
+    touch /etc/containerlab/suid_setup_done
+fi

--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# this post install script is used to count the number of installations of containerlab
+# this post install script is used for setting up the clab_admins group and to count the number of installations of containerlab
 # when the installation is done via apt or yum package manager
 
 # exit if sh shell is not found
@@ -32,3 +32,6 @@ elif type "wget" > /dev/null 2>&1; then
     wget -T 2 -q -O /dev/null "$REPO_URL" || true
     exit 0
 fi
+
+groupadd clab_admins
+usermod -aG clab_admins "$SUDO_USER"

--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -33,5 +33,5 @@ elif type "wget" > /dev/null 2>&1; then
     exit 0
 fi
 
-groupadd clab_admins
+groupadd -r clab_admins
 usermod -aG clab_admins "$SUDO_USER"

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -260,7 +260,7 @@ function install-containerlab {
 
     echo "Adding ${USER} to clab_admins group..."
 
-    sudo groupadd clab_admins
+    sudo groupadd -r clab_admins
     sudo usermod -aG clab_admins "$SUDO_USER"
 }
 

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -257,11 +257,6 @@ function install-containerlab {
 
         sudo apt update -y && sudo apt install containerlab -y
     fi
-
-    echo "Adding ${USER} to clab_admins group..."
-
-    sudo groupadd -r clab_admins
-    sudo usermod -aG clab_admins "$SUDO_USER"
 }
 
 function all {

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -257,6 +257,11 @@ function install-containerlab {
 
         sudo apt update -y && sudo apt install containerlab -y
     fi
+
+    echo "Adding ${USER} to clab_admins group..."
+
+    sudo groupadd clab_admins
+    sudo usermod -aG clab_admins "$SUDO_USER"
 }
 
 function all {


### PR DESCRIPTION
This PR adds sudo-less operation to Containerlab. See #2307 for more information on this feature.

## Sudo-less?

The sudo-less operation is implemented via setting the SUID (or sticky) bit on the Containerlab binary. The changes include handling of SUID-based running of Containerlab, and properly grabbing the correct user for lab directory ACL/ownership management when not run with `sudo`. 

## Security?

Root privileges are not used where they are not needed, as Containerlab immediately drops to regular user privilege on startup, and only escalates to root privilege where needed (this is currently done on a per-command granularity).

For use-cases where sudo-less operation is required (for example, Containerlab hosts and labs shared between colleagues, or in education), it is not necessarily desired for every user to be able to perform privileged operations on containerlabs, after all, being able to spin up arbitrary containers is the same as granting `sudo` rights. However, operations that don't require such privileges, such as saving configs, or creating topology graphs might still be useful for these users.

This feature also includes an optional check for group membership of the `clab_admins` group:
- If the group does not exist, the check is bypassed
- If the group exists, a check is performed whether the user running Containerlab is a member of the `clab_admins` Unix group before escalating to root privileges

The `clab_admins` group is created and the user running the command is added to it by default by the upgrade script, the quick install script and the post-install script.

## Potential breakages

- `groupadd/usermod` might not work on the post-install script for Alpine without `shadow` utils installed -- this platform is not officially supported by Containerlab, but nfpm is still configured to emit an `apk` file. 