### PR TITLE
Add SUID to containerlab binary in postinstall script

### DIFF
--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -33,6 +33,8 @@ elif type "wget" > /dev/null 2>&1; then
     exit 0
 fi
 
+chmod 4755 /usr/bin/containerlab
+
 if [ ! -f /etc/containerlab/suid_setup_done ]; then
     groupadd -r clab_admins
     usermod -aG clab_admins "$SUDO_USER"


### PR DESCRIPTION
This enables sudoless mode.