### PR TITLE
packaging: Fix SUID and group not created for some users upgrading via `clab version upgrade`

### DIFF
--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -1,14 +1,23 @@
 #!/bin/sh
 
-# this post install script is used for setting up the clab_admins group and to count the number of installations of containerlab
-# when the installation is done via apt or yum package manager
+# this post install script is used for setting up the clab_admins group
+# and to count the number of installations of containerlab when the installation is done via apt or yum package manager
 
 # exit if sh shell is not found
 if [ ! -e /bin/sh ]; then
     exit 0
 fi
 
-# exit if no /etc/apt/sources.list.d/netdevops.list or /etc/yum.repos.d/yum.fury.io_netdevops_.repo is found
+chmod 4755 /usr/bin/containerlab
+
+if [ ! -f /etc/containerlab/suid_setup_done ]; then
+    groupadd -r clab_admins
+    usermod -aG clab_admins "$SUDO_USER"
+    touch /etc/containerlab/suid_setup_done
+fi
+
+# exit at this point if no /etc/apt/sources.list.d/netdevops.list or /etc/yum.repos.d/yum.fury.io_netdevops_.repo is found
+# no need to count these installs
 if [ ! -e /etc/apt/sources.list.d/netdevops.list ] && [ ! -e /etc/yum.repos.d/yum.fury.io_netdevops_.repo ]; then
     exit 0
 fi
@@ -31,12 +40,4 @@ if type "curl" > /dev/null 2>&1; then
 elif type "wget" > /dev/null 2>&1; then
     wget -T 2 -q -O /dev/null "$REPO_URL" || true
     exit 0
-fi
-
-chmod 4755 /usr/bin/containerlab
-
-if [ ! -f /etc/containerlab/suid_setup_done ]; then
-    groupadd -r clab_admins
-    usermod -aG clab_admins "$SUDO_USER"
-    touch /etc/containerlab/suid_setup_done
 fi


### PR DESCRIPTION
This fixes an edge-case where users upgrading via `containerlab version upgrade` without package sources set up will not have a working sudoless setup.