### PR TITLE
Add user to `clab_admins` group

### DIFF
--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -261,6 +261,12 @@ function install-containerlab {
 }
 
 function post-install-clab {
+    if [ $(getent group clab_admins) ]; then
+        echo "clab_admins group exists"
+    else
+      echo "Creating clab_admins group..."
+      groupadd -r clab_admins 
+    fi
     sudo usermod -aG clab_admins "$SUDO_USER"
 }
 

--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -1,5 +1,6 @@
 DISTRO_TYPE=""
 SETUP_SSHD="${SETUP_SSHD:-true}"
+CLAB_ADMINS="${CLAB_ADMINS:-true}"
 
 # Docker version that will be installed by this install script.
 DOCKER_VERSION="26.1.4"
@@ -259,6 +260,10 @@ function install-containerlab {
     fi
 }
 
+function post-install-clab {
+    sudo usermod -aG clab_admins "$SUDO_USER"
+}
+
 function all {
     # check OS to determine distro
     check_os
@@ -275,6 +280,10 @@ function all {
     add-ssh-socket-env-for-sudo
 
     install-containerlab
+
+    if [ "${CLAB_ADMINS}" = "true" ]; then
+        post-install-clab
+    fi
 }
 
 "$@"


### PR DESCRIPTION
Add the user to the `clab_admins` group for sudoless clab operation as per v0.64.

Also a new var `CLAB_ADMINS`. Similar to the `SETUP_SSHD`, it will default to `true`. If it is not true, then user won't be added to clab_admins.

PR is in draft state while I test a few things. 