### PR TITLE
Feature: Introduce Oper-State flag per Link Endpoint.

### DIFF
--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -248,15 +248,17 @@ The veth link is the most common link type used in containerlab. It creates a vi
 links:
   - type: veth
     endpoints:
-      - node: <NodeA-Name>                  # mandatory
-        interface: <NodeA-Interface-Name>   # mandatory
-        mac: <NodeA-Interface-Mac>          # optional
-      - node: <NodeB-Name>                  # mandatory
-        interface: <NodeB-Interface-Name>   # mandatory
-        mac: <NodeB-Interface-Mac>          # optional
-    mtu: <link-mtu>                         # optional
-    vars: <link-variables>                  # optional (used in templating)
-    labels: <link-labels>                   # optional (used in templating)
+      - node: <NodeA-Name>                        # mandatory
+        interface: <NodeA-Interface-Name>         # mandatory
+        mac: <NodeA-Interface-Mac>                # optional
+        oper-state: <up/down | enable/disable>    # optional 
+      - node: <NodeB-Name>                        # mandatory
+        interface: <NodeB-Interface-Name>         # mandatory
+        mac: <NodeB-Interface-Mac>                # optional
+        oper-state: <up/down | enable/disable>    # optional
+    mtu: <link-mtu>                                  # optional
+    vars: <link-variables>                           # optional (used in templating)
+    labels: <link-labels>                            # optional (used in templating)
 ```
 
 ###### mgmt-net
@@ -267,13 +269,14 @@ The mgmt-net link type represents a veth pair that is connected to a container n
   links:
   - type: mgmt-net
     endpoint:
-      node: <NodeA-Name>                  # mandatory
-      interface: <NodeA-Interface-Name>   # mandatory
-      mac: <NodeA-Interface-Mac>          # optional
-    host-interface: <interface-name         # mandatory
-    mtu: <link-mtu>                         # optional
-    vars: <link-variables>                  # optional (used in templating)
-    labels: <link-labels>                   # optional (used in templating)
+      node: <NodeA-Name>                          # mandatory
+      interface: <NodeA-Interface-Name>           # mandatory
+      mac: <NodeA-Interface-Mac>                  # optional
+      oper-state: <up/down | enable/disable>      # optional
+    host-interface: <interface-name                  # mandatory
+    mtu: <link-mtu>                                  # optional
+    vars: <link-variables>                           # optional (used in templating)
+    labels: <link-labels>                            # optional (used in templating)
 ```
 
 The `host-interface` is the desired interface name that will be attached to the management network in the host namespace.
@@ -286,13 +289,14 @@ The macvlan link type creates a MACVlan interface with the `host-interface` as i
   links:
   - type: macvlan
     endpoint:
-      node: <NodeA-Name>                  # mandatory
-      interface: <NodeA-Interface-Name>   # mandatory
-      mac: <NodeA-Interface-Mac>          # optional
-    host-interface: <interface-name>        # mandatory
-    mode: <macvlan-mode>                    # optional ("bridge" by default)
-    vars: <link-variables>                  # optional (used in templating)
-    labels: <link-labels>                   # optional (used in templating)
+      node: <NodeA-Name>                        # mandatory
+      interface: <NodeA-Interface-Name>         # mandatory
+      mac: <NodeA-Interface-Mac>                # optional
+      oper-state: <up/down | enable/disable>    # optional
+    host-interface: <interface-name>              # mandatory
+    mode: <macvlan-mode>                          # optional ("bridge" by default)
+    vars: <link-variables>                        # optional (used in templating)
+    labels: <link-labels>                         # optional (used in templating)
 ```
 
 The `host-interface` is the name of the existing interface present in the host namespace.
@@ -308,13 +312,14 @@ In comparison to the veth type, no bridge or other namespace is required to be r
   links:
   - type: host
     endpoint:
-      node: <NodeA-Name>                  # mandatory
-      interface: <NodeA-Interface-Name>   # mandatory
-      mac: <NodeA-Interface-Mac>          # optional
-    host-interface: <interface-name>        # mandatory
-    mtu: <link-mtu>                         # optional
-    vars: <link-variables>                  # optional (used in templating)
-    labels: <link-labels>                   # optional (used in templating)
+      node: <NodeA-Name>                        # mandatory
+      interface: <NodeA-Interface-Name>         # mandatory
+      mac: <NodeA-Interface-Mac>                # optional
+      oper-state: <up/down | enable/disable>    # optional
+    host-interface: <interface-name>               # mandatory
+    mtu: <link-mtu>                                # optional
+    vars: <link-variables>                         # optional (used in templating)
+    labels: <link-labels>                          # optional (used in templating)
 ```
 
 The `host-interface` parameter defines the name of the veth interface in the host's network namespace.
@@ -326,16 +331,17 @@ The vxlan type results in a vxlan tunnel interface that is created in the host n
 ```yaml
   links:
     - type: vxlan                       
-      endpoint:                              # mandatory
-        node: <Node-Name>                    # mandatory
-        interface: <Node-Interface-Name>     # mandatory
-        mac: <Node-Interface-Mac>            # optional
-      remote: <Remote-VTEP-IP>               # mandatory
-      vni: <VNI>                             # mandatory
-      udp-port: <VTEP-UDP-Port>              # mandatory
-      mtu: <link-mtu>                        # optional
-      vars: <link-variables>                 # optional (used in templating)
-      labels: <link-labels>                  # optional (used in templating)
+      endpoint:                                   # mandatory
+        node: <Node-Name>                         # mandatory
+        interface: <Node-Interface-Name>          # mandatory
+        mac: <Node-Interface-Mac>                 # optional
+        oper-state: <up/down | enable/disable>    # optional
+      remote: <Remote-VTEP-IP>                       # mandatory
+      vni: <VNI>                                     # mandatory
+      udp-port: <VTEP-UDP-Port>                      # mandatory
+      mtu: <link-mtu>                                # optional
+      vars: <link-variables>                         # optional (used in templating)
+      labels: <link-labels>                          # optional (used in templating)
 ```
 
 ###### vxlan-stitched
@@ -346,16 +352,17 @@ In addition to these interfaces, tc rules are being provisioned to stitch the vx
 ```yaml
   links:
     - type: vxlan-stitch
-      endpoint:                              # mandatory
-        node: <Node-Name>                    # mandatory
-        interface: <Node-Interface-Name>     # mandatory
-        mac: <Node-Interface-Mac>            # optional
-      remote: <Remote-VTEP-IP>               # mandatory
-      vni: <VNI>                             # mandatory
-      udp-port: <VTEP-UDP-Port>              # mandatory
-      mtu: <link-mtu>                        # optional
-      vars: <link-variables>                 # optional (used in templating)
-      labels: <link-labels>                  # optional (used in templating)
+      endpoint:                                   # mandatory
+        node: <Node-Name>                         # mandatory
+        interface: <Node-Interface-Name>          # mandatory
+        mac: <Node-Interface-Mac>                 # optional
+        oper-state: <up/down | enable/disable>    # optional
+      remote: <Remote-VTEP-IP>                       # mandatory
+      vni: <VNI>                                     # mandatory
+      udp-port: <VTEP-UDP-Port>                      # mandatory
+      mtu: <link-mtu>                                # optional
+      vars: <link-variables>                         # optional (used in templating)
+      labels: <link-labels>                          # optional (used in templating)
 ```
 
 ###### dummy
@@ -368,12 +375,13 @@ Such interfaces are useful for testing and debugging purposes where we want to m
   links:
   - type: dummy
     endpoint:
-      node: <NodeA-Name>                    # mandatory
-      interface: <NodeA-Interface-Name>     # mandatory
-      mac: <NodeA-Interface-Mac>            # optional
-    mtu: <link-mtu>                         # optional
-    vars: <link-variables>                  # optional (used in templating)
-    labels: <link-labels>                   # optional (used in templating)
+      node: <NodeA-Name>                        # mandatory
+      interface: <NodeA-Interface-Name>         # mandatory
+      mac: <NodeA-Interface-Mac>                # optional
+      oper-state: <up/down | enable/disable>    # optional
+    mtu: <link-mtu>                                # optional
+    vars: <link-variables>                         # optional (used in templating)
+    labels: <link-labels>                          # optional (used in templating)
 ```
 
 #### Kinds

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -117,7 +117,7 @@ func (e *EndpointGeneric) GetNode() Node {
 }
 
 func (e *EndpointGeneric) Remove(ctx context.Context) error {
-	return e.GetNode().ExecFunction(ctx, func(n ns.NetNS) error {
+	return e.GetNode().ExecFunction(ctx, func(_ ns.NetNS) error {
 		brSideEp, err := netlink.LinkByName(e.GetIfaceName())
 		_, notfound := err.(netlink.LinkNotFoundError)
 

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -45,6 +45,7 @@ type Endpoint interface {
 	// Setters for ifaceName and Alias
 	SetIfaceName(string)
 	SetIfaceAlias(string)
+	GetOperState() OperState
 }
 
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.
@@ -53,21 +54,27 @@ type EndpointGeneric struct {
 	IfaceName  string
 	IfaceAlias string
 	// Link is the link this endpoint belongs to.
-	Link     Link
-	MAC      net.HardwareAddr
-	randName string
+	Link      Link
+	MAC       net.HardwareAddr
+	randName  string
+	OperState OperState
 }
 
-func NewEndpointGeneric(node Node, iface string, link Link) *EndpointGeneric {
+func NewEndpointGeneric(node Node, iface string, operState OperState, link Link) *EndpointGeneric {
 	return &EndpointGeneric{
 		Node:       node,
 		IfaceName:  iface,
 		IfaceAlias: "",
 		// random name is generated for the endpoint to avoid name collisions
 		// when it is first deployed in the root namespace
-		randName: genRandomIfName(),
-		Link:     link,
+		randName:  genRandomIfName(),
+		Link:      link,
+		OperState: operState,
 	}
+}
+
+func (e *EndpointGeneric) GetOperState() OperState {
+	return e.OperState
 }
 
 func (e *EndpointGeneric) GetRandIfaceName() string {

--- a/links/link.go
+++ b/links/link.go
@@ -398,9 +398,9 @@ const (
 	LinkEndpointTypeHost   = "host"
 )
 
-// SetNameMACAndUpInterface is a helper function that will bind interface name and Mac
+// SetNameMACAndOperStateInterface is a helper function that will bind interface name and Mac
 // and return a function that can run in the netns.Do() call for execution in a network namespace.
-func SetNameMACAndUpInterface(l netlink.Link, endpt Endpoint) func(ns.NetNS) error {
+func SetNameMACAndOperStateInterface(l netlink.Link, endpt Endpoint) func(ns.NetNS) error {
 	return func(_ ns.NetNS) error {
 		// rename the link created with random name if its length is acceptable by linux
 		if IsValidInterfaceName(endpt.GetIfaceName()) {
@@ -440,10 +440,13 @@ func SetNameMACAndUpInterface(l netlink.Link, endpt Endpoint) func(ns.NetNS) err
 			}
 		}
 
-		// bring the given link up
-		if err := netlink.LinkSetUp(l); err != nil {
-			return fmt.Errorf("failed to set %q up: %v",
-				endpt.GetIfaceName(), err)
+		// if operStateUp is true, bring the interface up
+		if endpt.GetOperState() == up {
+			// bring the given link up
+			if err := netlink.LinkSetUp(l); err != nil {
+				return fmt.Errorf("failed to set %q up: %v",
+					endpt.GetIfaceName(), err)
+			}
 		}
 
 		return nil

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -87,7 +87,7 @@ func (l *LinkDummy) Deploy(ctx context.Context, ep Endpoint) error {
 	// if the node is a regular namespace node
 	// add link to node, rename, set mac and Up
 	err = ep.GetNode().AddLinkToContainer(ctx, link,
-		SetNameMACAndUpInterface(link, ep))
+		SetNameMACAndOperStateInterface(link, ep))
 	if err != nil {
 		return err
 	}

--- a/links/link_host.go
+++ b/links/link_host.go
@@ -68,7 +68,7 @@ func (r *LinkHostRaw) Resolve(params *ResolveParams) (Link, error) {
 		return nil, err
 	}
 	hostEp := &EndpointHost{
-		EndpointGeneric: *NewEndpointGeneric(GetHostLinkNode(), r.HostInterface, link),
+		EndpointGeneric: *NewEndpointGeneric(GetHostLinkNode(), r.HostInterface, r.Endpoint.OperState, link),
 	}
 
 	hostEp.MAC, err = utils.GenMac(ClabOUI)

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -71,7 +71,7 @@ func (r *LinkMacVlanRaw) Resolve(params *ResolveParams) (Link, error) {
 	}
 	// create the host side MacVlan Endpoint
 	link.HostEndpoint = &EndpointMacVlan{
-		EndpointGeneric: *NewEndpointGeneric(GetHostLinkNode(), r.HostInterface, link),
+		EndpointGeneric: *NewEndpointGeneric(GetHostLinkNode(), r.HostInterface, r.Endpoint.OperState, link),
 	}
 
 	// populate the host interfaces mac address
@@ -155,7 +155,7 @@ func (l *LinkMacVlan) Deploy(ctx context.Context, _ Endpoint) error {
 
 	// add the link to the Node Namespace
 	err = l.NodeEndpoint.GetNode().AddLinkToContainer(ctx, mvInterface,
-		SetNameMACAndUpInterface(mvInterface, l.NodeEndpoint))
+		SetNameMACAndOperStateInterface(mvInterface, l.NodeEndpoint))
 	return err
 }
 

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -47,7 +47,7 @@ func (r *LinkMgmtNetRaw) Resolve(params *ResolveParams) (Link, error) {
 
 	mgmtBridgeNode := GetMgmtBrLinkNode()
 
-	bridgeEp := NewEndpointBridge(NewEndpointGeneric(mgmtBridgeNode, r.HostInterface, link), true)
+	bridgeEp := NewEndpointBridge(NewEndpointGeneric(mgmtBridgeNode, r.HostInterface, r.Endpoint.OperState, link), true)
 
 	var err error
 	bridgeEp.MAC, err = utils.GenMac(ClabOUI)

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -147,7 +147,7 @@ func (l *LinkVEth) deployAEnd(ctx context.Context, idx int) error {
 	// if the node is a regular namespace node
 	// add link to node, rename, set mac and Up
 	err = ep.GetNode().AddLinkToContainer(ctx, linkA,
-		SetNameMACAndUpInterface(linkA, ep))
+		SetNameMACAndOperStateInterface(linkA, ep))
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (l *LinkVEth) deployBEnd(ctx context.Context, idx int) error {
 	// if the node is a regular namespace node
 	// add link to node, rename, set mac and Up
 	err = ep.GetNode().AddLinkToContainer(ctx, link,
-		SetNameMACAndUpInterface(link, ep))
+		SetNameMACAndOperStateInterface(link, ep))
 	if err != nil {
 		return err
 	}

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -61,8 +61,9 @@ func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(params *ResolveParams) (*Li
 		LinkCommonParams: lr.LinkCommonParams,
 		HostInterface:    hostIface,
 		Endpoint: &EndpointRaw{
-			Node:  lr.Endpoint.Node,
-			Iface: lr.Endpoint.Iface,
+			Node:      lr.Endpoint.Node,
+			Iface:     lr.Endpoint.Iface,
+			OperState: up,
 		},
 	}
 
@@ -185,6 +186,7 @@ func (lr *LinkVxlanRaw) resolveLocalEndpoint(stitched bool, params *ResolveParam
 		// in the stitched vxlan mode we create vxlan interface in the host node namespace
 		vxlanRawEp.Node = "host"
 		vxlanRawEp.MAC = ""
+		vxlanRawEp.OperState = up
 
 		// resolve local Endpoint
 		return vxlanRawEp.Resolve(params, link)

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -219,7 +219,7 @@ func (l *LinkVxlan) Deploy(ctx context.Context, _ Endpoint) error {
 
 	// add the link to the Node Namespace
 	err = l.localEndpoint.GetNode().AddLinkToContainer(ctx, mvInterface,
-		SetNameMACAndUpInterface(mvInterface, l.localEndpoint))
+		SetNameMACAndOperStateInterface(mvInterface, l.localEndpoint))
 	return err
 }
 

--- a/links/oper_state.go
+++ b/links/oper_state.go
@@ -1,0 +1,45 @@
+package links
+
+import "github.com/charmbracelet/log"
+
+type OperState string
+
+const (
+	up   OperState = "up"
+	down OperState = "down"
+)
+
+// Map of string values to OperState enum
+var operStateMap = map[string]OperState{
+	"up":      up,
+	"down":    down,
+	"enable":  up,
+	"disable": down,
+}
+
+// Reverse map for string conversion
+var operStateToString = map[OperState]string{
+	up:   "up",
+	down: "down",
+}
+
+// Implement UnmarshalYAML for YAML v2
+func (s *OperState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var operStateStr string
+	if err := unmarshal(&operStateStr); err != nil {
+		return err
+	}
+
+	if state, exists := operStateMap[operStateStr]; exists {
+		*s = state
+	} else {
+		log.Errorf("oper-state value of %s not supported, defaulting to \"up\"", operStateStr)
+		*s = up // Default to up
+	}
+	return nil
+}
+
+// Implement MarshalYAML for OperState (optional)
+func (s OperState) MarshalYAML() (interface{}, error) {
+	return operStateToString[s], nil
+}

--- a/links/oper_state.go
+++ b/links/oper_state.go
@@ -23,7 +23,7 @@ var operStateToString = map[OperState]string{
 	down: "down",
 }
 
-// Implement UnmarshalYAML for YAML v2
+// UnmarshalYAML Implement UnmarshalYAML for OperState
 func (s *OperState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var operStateStr string
 	if err := unmarshal(&operStateStr); err != nil {
@@ -39,7 +39,7 @@ func (s *OperState) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// Implement MarshalYAML for OperState (optional)
-func (s OperState) MarshalYAML() (interface{}, error) {
-	return operStateToString[s], nil
+// MarshalYAML Implement MarshalYAML for OperState
+func (s *OperState) MarshalYAML() (interface{}, error) {
+	return operStateToString[*s], nil
 }


### PR DESCRIPTION
The oper-state can be set to up/down or enable/disable to defien the expected state of an endpoint after deployment. 

Example:
```
...
  links:
    - type: veth
      endpoints:
       - node: srl1
         interface: e1-15
         mac:  5C:80:B6:aa:aa:aa
       - node: srl2
         interface: e1-5
         mac:  5C:80:B6:bb:bb:bb
         oper-state: down                                                  # setting the oper state.
```