### PR TITLE
fix setup qemu action

### DIFF
--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          # workaround for https://github.com/tonistiigi/binfmt/issues/240
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Setup-qemu action is based on tonistiigi/binfmt image that is broken after the latest release. Every ARM build will fail.
Check https://github.com/tonistiigi/binfmt/issues/240 for the details.
The workaround is to fix image at tonistiigi/binfmt:qemu-v7.0.0-28. Anything above is broken.