### PR TITLE
Fix export template when using dummy links

### DIFF
--- a/clab/export.go
+++ b/clab/export.go
@@ -17,10 +17,12 @@ import (
 )
 
 // GenerateExports generates various export files and writes it to a file in the lab directory.
+// `p` is the path to the template.
+// `f` is the file to write the exported data to.
 func (c *CLab) GenerateExports(ctx context.Context, f io.Writer, p string) error {
 	err := c.exportTopologyDataWithTemplate(ctx, f, p)
 	if err != nil {
-		log.Warnf("Cannot parse export template %s: %v", p, err)
+		log.Warn("Failed to execute the export template", "template", p, "err", err)
 		// a minimal topology data file that just provides the name of a lab that failed to generate a proper export data
 		err = c.exportTopologyDataWithMinimalTemplate(f)
 		if err != nil {
@@ -47,7 +49,7 @@ var defaultExportTemplate string
 //go:embed export_templates/full.tmpl
 var fullExportTemplate string
 
-// exportTopologyDataWithTemplate generates and writes topology data file to w using a template.
+// exportTopologyDataWithTemplate generates and writes topology data file to w using a template referenced by path `p`.
 func (c *CLab) exportTopologyDataWithTemplate(_ context.Context, w io.Writer, p string) error {
 	name := "export"
 	if p != "" {

--- a/clab/export_templates/auto.tmpl
+++ b/clab/export_templates/auto.tmpl
@@ -45,15 +45,17 @@
         "node": "{{ $ep.GetNode.GetShortName }}",
         "interface": "{{ $ep.GetIfaceName }}",
         "mac": "{{ $ep.GetMac }}",
-        "peer": "z"
-      },
-      {{- $ep :=  index $eps 1 }}
+        "peer": "{{if eq (len $eps) 2}}z{{else}}dummy{{end}}"
+      }
+      {{- if eq (len $eps) 2 }}
+      {{- $ep :=  index $eps 1 }},
       "z": {
         "node": "{{  $ep.GetNode.GetShortName }}",
         "interface": "{{ $ep.GetIfaceName }}",
         "mac": "{{ $ep.GetMac }}",
         "peer": "a"
       }
+      {{- end }}
     }{{end}}
   ]
 }

--- a/clab/export_templates/full.tmpl
+++ b/clab/export_templates/full.tmpl
@@ -14,15 +14,17 @@
         "node": "{{ $ep.GetNode.GetShortName }}",
         "interface": "{{ $ep.GetIfaceName }}",
         "mac": "{{ $ep.GetMac }}",
-        "peer": "z"
-      },
-      {{- $ep :=  index $eps 1 }}
+        "peer": "{{if eq (len $eps) 2}}z{{else}}dummy{{end}}"
+      }
+      {{- if eq (len $eps) 2 }}
+      {{- $ep :=  index $eps 1 }},
       "z": {
         "node": "{{  $ep.GetNode.GetShortName }}",
         "interface": "{{ $ep.GetIfaceName }}",
         "mac": "{{ $ep.GetMac }}",
         "peer": "a"
       }
+      {{- end }}
     }{{end}}
   ]
 }

--- a/docs/rn/0.65.md
+++ b/docs/rn/0.65.md
@@ -32,3 +32,10 @@ The snippet above will have the `SRL_LOCATION` variable set to `default-value` i
 * json output format added to [netem](../cmd/tools/netem/show.md#format) output #2454
 * new logging library with structured logging #2449
 * updated VS Code extension documentation #2427 #2451
+
+## Patches
+
+### 0.65.1
+
+* fix template export errors when using dummy links #2483
+* update termenv dependency to enable colorized logging in ghostty #2482


### PR DESCRIPTION
fix #2480 
when dummy links are used, the endpoint section in the export template will now contain only "a" side, with the peer set to `dummy`:


```json
  "links": [
    {
      "a": {
        "node": "l1",
        "interface": "eth1",
        "mac": "aa:c1:ab:97:93:32",
        "peer": "dummy"
      }
    }
  ]
}
```