### PR TITLE
Add a reset command for network impairments in netem tool

### DIFF
--- a/docs/cmd/tools/netem/reset.md
+++ b/docs/cmd/tools/netem/reset.md
@@ -1,0 +1,45 @@
+# Resetting Link Impairments
+
+With the `containerlab tools netem reset` command users can remove (reset) all network impairments on a specified interface of a containerlab node. This command deletes the netem qdisc associated with the interface, restoring it to its default state. If no impairments are present, the command will complete successfully without error.
+
+## Usage
+
+```bash
+containerlab tools netem reset [local-flags]
+```
+
+## Flags
+
+### node
+
+The mandatory `--node | -n` flag specifies the name of the containerlab node on which to reset link impairments.
+
+### interface
+
+The mandatory `--interface | -i` flag specifies the interface on which the netem impairments should be reset.
+
+## Examples
+
+### Resetting impairments on an interface
+
+This example resets the impairments on the interface `eth1` of node `clab-netem-r1`:
+
+```bash
+containerlab tools netem reset -n clab-netem-r1 -i eth1
+```
+
+Output:
+```bash
+Reset impairments on node "clab-netem-r1", interface "eth1"
+```
+
+### Resetting impairments when none are set
+
+If no impairments are configured on the specified interface, the command will complete without error:
+```bash
+containerlab tools netem reset -n clab-netem-r1 -i eth0
+```
+Output:
+```bash
+Reset impairments on node "clab-netem-r1", interface "eth0"
+```

--- a/docs/cmd/tools/netem/reset.md
+++ b/docs/cmd/tools/netem/reset.md
@@ -29,6 +29,7 @@ containerlab tools netem reset -n clab-netem-r1 -i eth1
 ```
 
 Output:
+
 ```bash
 Reset impairments on node "clab-netem-r1", interface "eth1"
 ```
@@ -36,10 +37,13 @@ Reset impairments on node "clab-netem-r1", interface "eth1"
 ### Resetting impairments when none are set
 
 If no impairments are configured on the specified interface, the command will complete without error:
+
 ```bash
 containerlab tools netem reset -n clab-netem-r1 -i eth0
 ```
+
 Output:
+
 ```bash
 Reset impairments on node "clab-netem-r1", interface "eth0"
 ```

--- a/docs/manual/impairments.md
+++ b/docs/manual/impairments.md
@@ -8,7 +8,7 @@ Labs are meant to be a reflection of real-world scenarios. To make simulated net
 
 * [`tools netem set`](../cmd/tools/netem/set.md)
 * [`tools netem show`](../cmd/tools/netem/show.md)
-* [`tools netem show`](../cmd/tools/netem/reset.md)
+* [`tools netem reset`](../cmd/tools/netem/reset.md)
 
 These commands allow users to set, show and reset link impairments (delay, jitter, packet loss) on any link that belongs to a container node and create labs simulating real-world network conditions.
 

--- a/docs/manual/impairments.md
+++ b/docs/manual/impairments.md
@@ -8,8 +8,9 @@ Labs are meant to be a reflection of real-world scenarios. To make simulated net
 
 * [`tools netem set`](../cmd/tools/netem/set.md)
 * [`tools netem show`](../cmd/tools/netem/show.md)
+* [`tools netem show`](../cmd/tools/netem/reset.md)
 
-These commands allow users to set link impairments (delay, jitter, packet loss) on any link that belongs to a container node and create labs simulating real-world network conditions.
+These commands allow users to set, show and reset link impairments (delay, jitter, packet loss) on any link that belongs to a container node and create labs simulating real-world network conditions.
 
 ```bash title="setting packet loss at 10% rate on eth1 interface of clab-netem-r1 node"
 containerlab tools netem set -n clab-netem-r1 -i eth1 --loss 10

--- a/internal/tc/tc.go
+++ b/internal/tc/tc.go
@@ -84,6 +84,24 @@ func SetImpairments(tcnl *tc.Tc, nodeName string, link *net.Interface, delay, ji
 	return nil, fmt.Errorf("could not find qdisc for interface %q", link.Name)
 }
 
+// DeleteImpairments deletes the netem impairments from the given interface.
+func DeleteImpairments(tcnl *tc.Tc, link *net.Interface) error {
+	qdisc := tc.Object{
+		Msg: tc.Msg{
+			Family:  unix.AF_UNSPEC,
+			Ifindex: uint32(link.Index),
+			Handle:  core.BuildHandle(0x1, 0x0),
+			Parent:  tc.HandleRoot,
+			Info:    0,
+		},
+		Attribute: tc.Attribute{
+			Kind:  "netem",
+			Netem: &tc.Netem{},
+		},
+	}
+	return tcnl.Qdisc().Delete(&qdisc)
+}
+
 // setDelay sets delay and jitter to the qdisc.
 func setDelay(qdisc *tc.Object, delay, jitter time.Duration) error {
 	delayTcTime, err := core.Duration2TcTime(delay)

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -156,7 +156,8 @@ func (l *LinkMacVlan) Deploy(ctx context.Context, _ Endpoint) error {
 	// enable promiscuous mode
 	err = netlink.SetPromiscOn(mvInterface)
 	if err != nil {
-		return fmt.Errorf("failed setting promiscuous mode for interface %s (%s:%s): %v", l.NodeEndpoint.GetRandIfaceName(), l.NodeEndpoint.GetNode().GetShortName(), l.NodeEndpoint.GetIfaceName(), err)
+		return fmt.Errorf("failed setting promiscuous mode for interface %s (%s:%s): %v",
+			l.NodeEndpoint.GetRandIfaceName(), l.NodeEndpoint.GetNode().GetShortName(), l.NodeEndpoint.GetIfaceName(), err)
 	}
 
 	// add the link to the Node Namespace

--- a/tests/01-smoke/08-tools-cmds.robot
+++ b/tests/01-smoke/08-tools-cmds.robot
@@ -67,3 +67,22 @@ Show link impairments in JSON format
     Should Contain    ${output}    10
     Should Contain    ${output}    1000
     Should Contain    ${output}    2
+
+Reset link impairments
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools netem reset -n clab-${lab-name}-l1 -i eth3
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    Reset impairments on node "clab-${lab-name}-l1", interface "eth3"
+
+    # Show impairments again to verify they have been reset.
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} tools netem show -n clab-${lab-name}-l1
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    # Verify that the previous impairment values are no longer present.
+    Should Not Contain    ${output}    100ms
+    Should Not Contain    ${output}    2ms
+    Should Not Contain    ${output}    10.00%
+    Should Not Contain    ${output}    1000
+    Should Not Contain    ${output}    2

--- a/tests/01-smoke/08-tools-cmds.robot
+++ b/tests/01-smoke/08-tools-cmds.robot
@@ -85,4 +85,3 @@ Reset link impairments
     Should Not Contain    ${output}    2ms
     Should Not Contain    ${output}    10.00%
     Should Not Contain    ${output}    1000
-    Should Not Contain    ${output}    2


### PR DESCRIPTION
This add as reset command to the netem as pure setting 0 will not be the same as the original untouched:

```
##Before: qdisc netem 1: dev e1-10 root refcnt 81 limit 10000 b

nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-vlan-srl1) -n tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc noqueue 0: dev mgmt0 root refcnt 2 
qdisc noqueue 0: dev e1-1 root refcnt 2 
qdisc netem 1: dev e1-10 root refcnt 81 limit 10000
qdisc netem 1: dev gway-2800 root refcnt 17 limit 10000
qdisc netem 1: dev monit_in root refcnt 17 limit 10000
qdisc netem 1: dev mgmt0-0 root refcnt 17 limit 10000

~/projects/containerlab/bin   main !2 ❯ ./containerlab tools netem reset -n clab-vlan-srl1 -i e1-10
Reset impairments on node "clab-vlan-srl1", interface "e1-10"

## After:qdisc noqueue 0: dev e1-10 root refcnt 2  

## Set to to 0 interfaces are: qdisc netem 1: dev gway-2800 root refcnt 17 limit 10000 not clean as untouched

~/projects/containerlab/bin   main !2 ❯ nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-vlan-srl1) -n tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc noqueue 0: dev mgmt0 root refcnt 2 
qdisc noqueue 0: dev e1-1 root refcnt 2 
qdisc noqueue 0: dev e1-10 root refcnt 2 
qdisc netem 1: dev gway-2800 root refcnt 17 limit 10000
qdisc netem 1: dev monit_in root refcnt 17 limit 10000
qdisc netem 1: dev mgmt0-0 root refcnt 17 limit 10000

## Untouched interfaces ( how it should look like after a reset ) 

~/projects/containerlab/bin   main !2 ❯ nsenter -t $(docker inspect -f '{{.State.Pid}}' clab-vlan-srl2) -n tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc noqueue 0: dev mgmt0 root refcnt 2 
qdisc noqueue 0: dev e1-10 root refcnt 2 
qdisc noqueue 0: dev e1-1 root refcnt 2 
qdisc noqueue 0: dev gway-2800 root refcnt 2 
qdisc noqueue 0: dev monit_in root refcnt 2 
qdisc noqueue 0: dev mgmt0-0 root refcnt 2 
```