### PR TITLE
Filter netem qdiscs in JSON output for improved clarity

### DIFF
--- a/cmd/tools_netem.go
+++ b/cmd/tools_netem.go
@@ -379,6 +379,9 @@ func netemShowFn(_ *cobra.Command, _ []string) error {
 		if netemFormat == "json" {
 			var impairments []types.ImpairmentData
 			for _, q := range qdiscs {
+				if q.Attribute.Kind != "netem" {
+					continue // skip clsact or other qdisc types
+				}
 				impairments = append(impairments, qdiscToJSONData(q))
 			}
 			// Structure output as a map keyed by the node name.


### PR DESCRIPTION
Nodes that have not any impairments configured will return in json:

```
./containerlab tools netem show -n clab-vlan-srl2 -f json 
{
  "clab-vlan-srl2": null
}
```

otherwise we would have duplicated interfaces for some kinds, because of clsact or other qdisc types:

```
{
  "clab-edge": [
    {
      "interface": "eth1",
      "delay": "10ms",
      "jitter": "30ms",
      "packet_loss": 0.05,
      "rate": 700,
      "corruption": 0.09
    },
    {
      "interface": "eth1",
      "delay": "",
      "jitter": "",
      "packet_loss": 0,
      "rate": 0,
      "corruption": 0
    },
    
    ```