### PR TITLE
utils/userauth: Fix group membership checks for AD/LDAP groups

### DIFF
--- a/utils/userauth.go
+++ b/utils/userauth.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+func UnixGroupExists(groupName string) (bool, error) {
+	cmd := exec.Command("getent", "group", groupName)
+	out, err := cmd.Output()
+
+	if err != nil {
+		return false, fmt.Errorf("error while looking up user groups using getent command %v: %v", groupName, err)
+	}
+
+	if string(out) == "" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func getUnixGroupMembers(groupName string) ([]string, error) {
+	var users []string
+	cmd := exec.Command("getent", "group", groupName)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error while looking up user groups using getent command %v: %w", groupName, err)
+	}
+
+	// output format is `username:x:uid:users,comma,separated`
+	// we need to extract the users, also trim the newline from the end of the output
+	parts := strings.Split(strings.TrimSuffix(string(out), "\n"), ":")
+	if len(parts) < 4 {
+		return nil, fmt.Errorf("error while looking up user groups using getent command %v: unexpected output format", groupName)
+	}
+
+	users = strings.Split(parts[3], ",")
+
+	return users, nil
+}
+
+func UserInUnixGroup(username, groupName string) (bool, error) {
+	groupMembers, err := getUnixGroupMembers(groupName)
+	if err != nil {
+		return false, err
+	}
+
+	if slices.Contains(groupMembers, username) {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/utils/userauth.go
+++ b/utils/userauth.go
@@ -12,7 +12,6 @@ import (
 func UnixGroupExists(groupName string) (bool, error) {
 	cmd := exec.Command("getent", "group", groupName)
 	_, err := cmd.Output()
-
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			// Exit code 2 means group does not exist

--- a/utils/userauth.go
+++ b/utils/userauth.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+// UnixGroupExists checks if the group, given as a group name, exists on the system.
+// `getent group` is used to retrieve domain-joined group information, as `os/user`'s pure Go implementation only checks against /etc/groups.
 func UnixGroupExists(groupName string) (bool, error) {
 	cmd := exec.Command("getent", "group", groupName)
 	out, err := cmd.Output()
@@ -42,6 +44,7 @@ func getUnixGroupMembers(groupName string) ([]string, error) {
 	return users, nil
 }
 
+// UserInUnixGroup returns whether the given user (via username) is part of the Unix group given in the second argument.
 func UserInUnixGroup(username, groupName string) (bool, error) {
 	groupMembers, err := getUnixGroupMembers(groupName)
 	if err != nil {


### PR DESCRIPTION
This PR adds a fix for the clab_admins group membership check in case LDAP/AD is used to manage Unix group memberships.

The membership checking code has been refactored into `utils/userauth.go`.