### PR TITLE
Add vr-openwrt kind with overlay bind mount for OpenWRT persistence

### DIFF
--- a/clab/register.go
+++ b/clab/register.go
@@ -47,6 +47,7 @@ import (
 	vr_vsrx "github.com/srl-labs/containerlab/nodes/vr_vsrx"
 	vr_xrv "github.com/srl-labs/containerlab/nodes/vr_xrv"
 	vr_xrv9k "github.com/srl-labs/containerlab/nodes/vr_xrv9k"
+	vr_openwrt "github.com/Takalele/containerlab/nodes/vr_openwrt"
 	xrd "github.com/srl-labs/containerlab/nodes/xrd"
 )
 

--- a/clab/register.go
+++ b/clab/register.go
@@ -47,7 +47,7 @@ import (
 	vr_vsrx "github.com/srl-labs/containerlab/nodes/vr_vsrx"
 	vr_xrv "github.com/srl-labs/containerlab/nodes/vr_xrv"
 	vr_xrv9k "github.com/srl-labs/containerlab/nodes/vr_xrv9k"
-	vr_openwrt "github.com/Takalele/containerlab/nodes/vr_openwrt"
+	vr_openwrt "github.com/srl-labs/containerlab/nodes/vr_openwrt"
 	xrd "github.com/srl-labs/containerlab/nodes/xrd"
 )
 
@@ -90,6 +90,7 @@ func (c *CLab) RegisterNodes() {
 	vr_xrv9k.Register(c.Reg)
 	vr_sonic.Register(c.Reg)
 	vr_cat9kv.Register(c.Reg)
+	vr_openwrt.Register(c.Reg)
 	xrd.Register(c.Reg)
 	rare.Register(c.Reg)
 	c8000.Register(c.Reg)

--- a/nodes/vr_openwrt/vr_openwrt.go
+++ b/nodes/vr_openwrt/vr_openwrt.go
@@ -13,7 +13,7 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
-var kindNames = []string{"vr-openwrt"}
+var kindNames = []string{"openwrt"}
 
 const (
 	generateable     = true

--- a/nodes/vr_openwrt/vr_openwrt.go
+++ b/nodes/vr_openwrt/vr_openwrt.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+package vr_openwrt
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
+)
+
+var kindNames = []string{"vr-openwrt"}
+
+const (
+	generateable     = true
+	generateIfFormat = "eth%d"
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *nodes.NodeRegistry) {
+	generateNodeAttributes := nodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := nodes.NewNodeRegistryEntryAttributes(nil, generateNodeAttributes)
+
+	r.Register(kindNames, func() nodes.Node {
+		return new(vrOpenWrt)
+	}, nrea)
+}
+
+type vrOpenWrt struct {
+	nodes.DefaultNode
+}
+
+func (n *vrOpenWrt) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error {
+	// Init DefaultNode
+	n.DefaultNode = *nodes.NewDefaultNode(n)
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+
+	// Add a simple bind-mount for the 'overlay' directory
+	n.Cfg.Binds = append(n.Cfg.Binds,
+		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "overlay"), ":/config/overlay"),
+	)
+
+	return nil
+}
+
+func (n *vrOpenWrt) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error {
+	// Ensure the overlay directory exists
+	utils.CreateDirectory(filepath.Join(n.Cfg.LabDir, "overlay"), 0777)
+	return nil
+}

--- a/nodes/vr_openwrt/vr_openwrt.go
+++ b/nodes/vr_openwrt/vr_openwrt.go
@@ -45,7 +45,7 @@ func (n *vrOpenWrt) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error 
 
 	// Add a simple bind-mount for the 'overlay' directory
 	n.Cfg.Binds = append(n.Cfg.Binds,
-		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "overlay"), ":/config/overlay"),
+		fmt.Sprint(filepath.Join(n.Cfg.LabDir, "overlay"), ":/overlay"),
 	)
 
 	return nil


### PR DESCRIPTION
This PR adds a new `vr-openwrt` kind to Containerlab, based on the existing `rare` kind.

### Key behavior:
- Automatically bind-mounts the node's lab directory as `/overlay` inside the container
- This allows persistent configuration storage across lab restarts

### Implementation notes:
- If desired, a more generic `vr` kind with overlay support could be created
  → This would require changes in `vrnetlab.py` so that overlay images are always created in `/overlay` instead of `/`

### Related work:
- Requires updated `vrnetlab/openwrt` image that supports `/overlay` handling
- See related image PR: https://github.com/hellt/vrnetlab/pull/339
---

#### Example usage:
```yaml
topology:
  nodes:
    openwrt:
      kind: vr-openwrt
      image: vrnetlab/openwrt_openwrt:24.10.0
      
```

BR
Takalele