### PR TITLE
PA-VM typo fixed

### DIFF
--- a/docs/manual/kinds/vr-pan.md
+++ b/docs/manual/kinds/vr-pan.md
@@ -2,7 +2,7 @@
 search:
   boost: 4
 kind_code_name: paloalto_panos
-kind_display_name: Cisco Nexus9000v
+kind_display_name: Palo Alto PA-VM
 ---
 # Palo Alto PA-VM
 


### PR DESCRIPTION
The documentation for Palo Alto PA-VM has the wrong display name (Cisco Nexus9000v)

https://containerlab.dev/manual/kinds/vr-pan/#palo-alto-pa-vm