### PR TITLE
docs/juniper: Fix docs for Juniper kinds' interface counts and naming

### DIFF
--- a/docs/manual/kinds/crpd.md
+++ b/docs/manual/kinds/crpd.md
@@ -8,6 +8,13 @@ search:
 
 cRPD nodes launched with containerlab comes up pre-provisioned with SSH service enabled, `root` user created and NETCONF enabled.
 
+Once downloaded, load the Docker image:
+
+```bash
+# load cRPD container image, shows up as crpd:24.2R1.14 in docker images
+docker load junos-routing-crpd-docker-24.2R1.14.tgz
+```
+
 ## Managing cRPD nodes
 
 Juniper cRPD node launched with containerlab can be managed via the following interfaces:

--- a/docs/manual/kinds/vr-vjunosevolved.md
+++ b/docs/manual/kinds/vr-vjunosevolved.md
@@ -59,7 +59,7 @@ Data port numbering starts at `0`.
 
 The example ports above would be mapped to the following Linux interfaces inside the container running the -{{ kind_display_name }}- VM:
 
-Juniper vJunosEvolved container can have up to 17 interfaces and uses the following mapping rules:
+Juniper vJunosEvolved container can have up to 13 interfaces (1 management and 12 data-plane interfaces) and uses the following mapping rules:
 
 * `eth0` - management interface connected to the containerlab management network
 * `eth1` - first data interface, mapped to a first data port of vJunosEvolved VM, which is `et-0/0/0` **and not `et-0/0/1`**.

--- a/docs/manual/kinds/vr-vjunosrouter.md
+++ b/docs/manual/kinds/vr-vjunosrouter.md
@@ -50,12 +50,12 @@ Juniper vJunos-router node launched with containerlab can be managed via the fol
 
 You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in -{{ kind_display_name }}-.
 
-The interface naming convention is: `et-0/0/X` (or `ge-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
+The interface naming convention is: `ge-0/0/X` (or `et-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
 
 With that naming convention in mind:
 
-* `et-0/0/0` - first data port available
-* `et-0/0/1` - second data port, and so on...
+* `ge-0/0/0` - first data port available
+* `ge-0/0/1` - second data port, and so on...
 
 /// admonition
     type: note
@@ -64,15 +64,15 @@ Data port numbering starts at `0`.
 
 The example ports above would be mapped to the following Linux interfaces inside the container running the -{{ kind_display_name }}- VM:
 
-Juniper vJunosEvolved container can have up to 17 interfaces and uses the following mapping rules:
+Juniper vJunos-Router container can have up to 13 interfaces (1 management + 12 data-plane interfaces) and uses the following mapping rules:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface, mapped to a first data port of vJunosEvolved VM, which is `et-0/0/0` **and not `et-0/0/1`**.
+* `eth1` - first data interface, mapped to a first data port of vJunos-Router VM, which is `ge-0/0/0` **and not `ge-0/0/1`**.
 * `eth2+` - second and subsequent data interface
 
 When containerlab launches -{{ kind_display_name }}- node the management interface of the VM gets assigned `10.0.0.15/24` address from the QEMU DHCP server. This interface is transparently stitched with container's `eth0` interface such that users can reach the management plane of the -{{ kind_display_name }}- using containerlab's assigned IP.
 
-Data interfaces `et-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
+Data interfaces `ge-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
 
 ## Features and options
 

--- a/docs/manual/kinds/vr-vjunosswitch.md
+++ b/docs/manual/kinds/vr-vjunosswitch.md
@@ -45,12 +45,12 @@ Juniper vJunos-switch node launched with containerlab can be managed via the fol
 
 You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in -{{ kind_display_name }}-.
 
-The interface naming convention is: `et-0/0/X` (or `ge-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
+The interface naming convention is: `ge-0/0/X` (or `et-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
 
 With that naming convention in mind:
 
-* `et-0/0/0` - first data port available
-* `et-0/0/1` - second data port, and so on...
+* `ge-0/0/0` - first data port available
+* `ge-0/0/1` - second data port, and so on...
 
 /// admonition
     type: note
@@ -59,15 +59,15 @@ Data port numbering starts at `0`.
 
 The example ports above would be mapped to the following Linux interfaces inside the container running the -{{ kind_display_name }}- VM:
 
-Juniper vJunosEvolved container can have up to 17 interfaces and uses the following mapping rules:
+Juniper vJunos-Switch container can have up to 57 interfaces (1 management + 56 data-plane interfaces) and uses the following mapping rules:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface, mapped to a first data port of vJunosEvolved VM, which is `et-0/0/0` **and not `et-0/0/1`**.
+* `eth1` - first data interface, mapped to a first data port of vJunos-Switch VM, which is `ge-0/0/0` **and not `ge-0/0/1`**.
 * `eth2+` - second and subsequent data interface
 
 When containerlab launches -{{ kind_display_name }}- node the management interface of the VM gets assigned `10.0.0.15/24` address from the QEMU DHCP server. This interface is transparently stitched with container's `eth0` interface such that users can reach the management plane of the -{{ kind_display_name }}- using containerlab's assigned IP.
 
-Data interfaces `et-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
+Data interfaces `ge-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
 
 ## Features and options
 

--- a/docs/manual/kinds/vr-vsrx.md
+++ b/docs/manual/kinds/vr-vsrx.md
@@ -36,12 +36,12 @@ Juniper vSRX node launched with containerlab can be managed via the following in
 
 You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in -{{ kind_display_name }}-.
 
-The interface naming convention is: `et-0/0/X` (or `ge-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
+The interface naming convention is: `ge-0/0/X` (or `et-0/0/X`, `xe-0/0/X`, all are accepted), where X denotes the port number.
 
 With that naming convention in mind:
 
-* `et-0/0/0` - first data port available
-* `et-0/0/1` - second data port, and so on...
+* `ge-0/0/0` - first data port available
+* `ge-0/0/1` - second data port, and so on...
 
 /// admonition
     type: note
@@ -50,15 +50,15 @@ Data port numbering starts at `0`.
 
 The example ports above would be mapped to the following Linux interfaces inside the container running the -{{ kind_display_name }}- VM:
 
-Juniper vJunosEvolved container can have up to 17 interfaces and uses the following mapping rules:
+Juniper vSRX container can have up to 10 interfaces (1 management + 9 data-plane interfaces) and uses the following mapping rules:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface, mapped to a first data port of vJunosEvolved VM, which is `et-0/0/0` **and not `et-0/0/1`**.
+* `eth1` - first data interface, mapped to a first data port of vSRX VM, which is `ge-0/0/0` **and not `ge-0/0/1`**.
 * `eth2+` - second and subsequent data interface
 
 When containerlab launches -{{ kind_display_name }}- node the management interface of the VM gets assigned `10.0.0.15/24` address from the QEMU DHCP server. This interface is transparently stitched with container's `eth0` interface such that users can reach the management plane of the -{{ kind_display_name }}- using containerlab's assigned IP.
 
-Data interfaces `et-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
+Data interfaces `ge-0/0/0+` need to be configured with IP addressing manually using CLI or other available management interfaces.
 
 ## Features and options
 


### PR DESCRIPTION
To be merged once https://github.com/hellt/vrnetlab/pull/342 is merged.

Also adds a note about loading cRPD, since it is done differently than cEOS.