### PR TITLE
Add logging to CLI topo option resolution

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -207,12 +207,14 @@ func (c *CLab) ProcessTopoPath(path string) (string, error) {
 
 	switch {
 	case path == "-" || path == "stdin":
+		log.Debugf("interpretting topo %q as stdin", path)
 		file, err = readFromStdin(c.TopoPaths.ClabTmpDir())
 		if err != nil {
 			return "", err
 		}
 	// if the path is not a local file and a URL, download the file and store it in the tmp dir
 	case !utils.FileOrDirExists(path) && utils.IsHttpURL(path, true):
+		log.Debugf("interpretting topo %q as remote URL", path)
 		file, err = downloadTopoFile(path, c.TopoPaths.ClabTmpDir())
 		if err != nil {
 			return "", err
@@ -222,6 +224,7 @@ func (c *CLab) ProcessTopoPath(path string) (string, error) {
 		return "", fmt.Errorf("provide a path to the clab topology file")
 
 	default:
+		log.Debugf("interpretting topo %q as file path", path)
 		file, err = FindTopoFileByPath(path)
 		if err != nil {
 			return "", err

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -170,7 +170,7 @@ func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 }
 
 // getTopologyPath returns the relative path to the topology file
-// if the relative path is shorted than the absolute path.
+// if the relative path is shorter than the absolute path.
 func getTopologyPath(p string) (string, error) {
 	if p == "" {
 		return "", nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,8 @@ func addSubcommands() {
 func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().CountVarP(&debugCount, "debug", "d", "enable debug mode")
-	rootCmd.PersistentFlags().StringVarP(&common.Topo, "topo", "t", "", "path to the topology file")
+	rootCmd.PersistentFlags().StringVarP(&common.Topo, "topo", "t", "",
+		"path to the topology definition file, a directory containing one, 'stdin', or a URL")
 	rootCmd.PersistentFlags().StringVarP(&common.VarsFile, "vars", "", "",
 		"path to the topology template variables file")
 	_ = rootCmd.MarkPersistentFlagFilename("topo", "*.yaml", "*.yml")


### PR DESCRIPTION
- Adds debug-level logging for the resolution logic for `--topo` CLI option
- Expands the CLI `--help` option description for `--topo`
- Fixes a typo I noticed

Fixes #2525

This shouldn't have any functional changes 🤞