### PR TITLE
Schema improvments

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -189,18 +189,24 @@
                     "uniqueItems": true
                 },
                 "env": {
-                  "type": "object",
-                  "description": "environment variables",
-                  "markdownDescription": "[environment variables](https://containerlab.dev/manual/nodes/#env)",
-                  "patternProperties": {
-                    ".*": {
-                    "anyOf": [
-                        { "type": "string" },
-                        { "type": "number" },
-                        { "type": "boolean" }
-                      ]
+                    "type": "object",
+                    "description": "environment variables",
+                    "markdownDescription": "[environment variables](https://containerlab.dev/manual/nodes/#env)",
+                    "patternProperties": {
+                        ".*": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
                     }
-                  }
                 },
                 "user": {
                     "description": "user to use within the container",
@@ -447,7 +453,7 @@
                     "type": "object"
                 }
             },
-          "additionalProperties": false
+            "additionalProperties": false
         },
         "extras-config": {
             "type": "object",
@@ -468,7 +474,7 @@
                     "description": "http/s proxy to be used by mysocketctl"
                 }
             },
-          "additionalProperties": false
+            "additionalProperties": false
         },
         "config-config": {
             "type": "object",
@@ -758,46 +764,52 @@
             ]
         },
         "stage-exec": {
-          "description": "per-stage exec configuration",
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "on-enter": {
-                  "$ref": "#/definitions/stage-exec-list"
+            "description": "per-stage exec configuration",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "on-enter": {
+                            "$ref": "#/definitions/stage-exec-list"
+                        },
+                        "on-exit": {
+                            "$ref": "#/definitions/stage-exec-list"
+                        }
+                    },
+                    "additionalProperties": false
                 },
-                "on-exit": {
-                  "$ref": "#/definitions/stage-exec-list"
+                {
+                    "type": "array",
+                    "description": "List of exec commands as objects, each containing `command`, `target`, and `phase`",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "description": "Shell command to execute"
+                            },
+                            "target": {
+                                "type": "string",
+                                "description": "Location to run the command (e.g. 'container', 'host')",
+                                "default": "container"
+                            },
+                            "phase": {
+                                "type": "string",
+                                "enum": [
+                                    "on-enter",
+                                    "on-exit"
+                                ],
+                                "description": "Phase to execute this command (on-enter or on-exit)"
+                            }
+                        },
+                        "required": [
+                            "command",
+                            "phase"
+                        ]
+                    }
                 }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "array",
-              "description": "List of exec commands as objects, each containing `command`, `target`, and `phase`",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "command": {
-                    "type": "string",
-                    "description": "Shell command to execute"
-                  },
-                  "target": {
-                    "type": "string",
-                    "description": "Location to run the command (e.g. 'container', 'host')",
-                    "default": "container"
-                  },
-                  "phase": {
-                    "type": "string",
-                    "enum": ["on-enter", "on-exit"],
-                    "description": "Phase to execute this command (on-enter or on-exit)"
-                  }
-                },
-                "required": ["command", "phase"]
-              }
-            }
-          ]
+            ]
         },
         "stage-exec-list": {
             "type": "array",
@@ -1096,7 +1108,7 @@
                     "$ref": "#/definitions/certificate-authority-config"
                 }
             },
-          "additionalProperties": false
+            "additionalProperties": false
         }
     },
     "additionalProperties": false,

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -193,7 +193,7 @@
                     "description": "environment variables",
                     "markdownDescription": "[environment variables](https://containerlab.dev/manual/nodes/#env)",
                     "patternProperties": {
-                        ".*": {
+                        ".+": {
                             "anyOf": [
                                 {
                                     "type": "string"

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -446,7 +446,8 @@
                     "markdownDescription": "link-scoped variables used by config engine",
                     "type": "object"
                 }
-            }
+            },
+          "additionalProperties": false
         },
         "extras-config": {
             "type": "object",
@@ -466,7 +467,8 @@
                     "type": "string",
                     "description": "http/s proxy to be used by mysocketctl"
                 }
-            }
+            },
+          "additionalProperties": false
         },
         "config-config": {
             "type": "object",
@@ -477,7 +479,8 @@
                     "description": "config variables passed to config engine",
                     "markdownDescription": "config variables passed to config engine"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "certificate-config": {
             "type": "object",
@@ -507,7 +510,8 @@
                     "description": "Duration for how long the certificate issued by the CA will be valid.",
                     "markdownDescription": "Duration for how long the certificate issued by the CA will be valid."
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "healthcheck-config": {
             "type": "object",
@@ -540,7 +544,8 @@
                     "type": "integer",
                     "description": "time in seconds to wait before starting the healthcheck"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "dns-config": {
             "type": "object",
@@ -571,7 +576,8 @@
                     },
                     "uniqueItems": true
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "certificate-authority-config": {
             "type": "object",
@@ -595,6 +601,7 @@
                     "description": "CA certificate validity duration. Can only be set if the external CA certificate is not provided"
                 }
             },
+            "additionalProperties": false,
             "oneOf": [
                 {
                     "required": [
@@ -873,7 +880,8 @@
                     "default": 1500
                 }
             },
-            "minProperties": 1
+            "minProperties": 1,
+            "additionalProperties": false
         },
         "topology": {
             "description": "topology configuration container",
@@ -1058,7 +1066,8 @@
                         "generic_vm": {
                             "$ref": "#/definitions/node-config"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "defaults": {
                     "$ref": "#/definitions/node-config"
@@ -1073,6 +1082,7 @@
                     }
                 }
             },
+            "additionalProperties": false,
             "required": [
                 "nodes"
             ]
@@ -1085,7 +1095,8 @@
                 "certificate-authority": {
                     "$ref": "#/definitions/certificate-authority-config"
                 }
-            }
+            },
+          "additionalProperties": false
         }
     },
     "additionalProperties": false,

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -189,23 +189,18 @@
                     "uniqueItems": true
                 },
                 "env": {
-                    "type": "object",
-                    "description": "environment variables",
-                    "markdownDescription": "[environment variables](https://containerlab.dev/manual/nodes/#env)",
-                    "patternProperties": {
-                        ".+": {
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "minItems": 1
-                                },
-                                {
-                                    "type": "number",
-                                    "minItems": 1
-                                }
-                            ]
-                        }
+                  "type": "object",
+                  "description": "environment variables",
+                  "markdownDescription": "[environment variables](https://containerlab.dev/manual/nodes/#env)",
+                  "patternProperties": {
+                    ".*": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "number" },
+                        { "type": "boolean" }
+                      ]
                     }
+                  }
                 },
                 "user": {
                     "description": "user to use within the container",
@@ -756,16 +751,46 @@
             ]
         },
         "stage-exec": {
-            "type": "object",
-            "description": "per-stage exec configuration",
-            "properties": {
+          "description": "per-stage exec configuration",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
                 "on-enter": {
-                    "$ref": "#/definitions/stage-exec-list"
+                  "$ref": "#/definitions/stage-exec-list"
                 },
                 "on-exit": {
-                    "$ref": "#/definitions/stage-exec-list"
+                  "$ref": "#/definitions/stage-exec-list"
                 }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "array",
+              "description": "List of exec commands as objects, each containing `command`, `target`, and `phase`",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "command": {
+                    "type": "string",
+                    "description": "Shell command to execute"
+                  },
+                  "target": {
+                    "type": "string",
+                    "description": "Location to run the command (e.g. 'container', 'host')",
+                    "default": "container"
+                  },
+                  "phase": {
+                    "type": "string",
+                    "enum": ["on-enter", "on-exit"],
+                    "description": "Phase to execute this command (on-enter or on-exit)"
+                  }
+                },
+                "required": ["command", "phase"]
+              }
             }
+          ]
         },
         "stage-exec-list": {
             "type": "array",


### PR DESCRIPTION
This change will make the stage-exec valid for:

```
      healthcheck:
        test: ["CMD-SHELL", "curl -f http://netbox:8000/api/ || exit 1"]
        timeout: 10
        retries: 100
      stages:
        create:
          wait-for:
            - node: postgres
              stage: create
            - node: redis
              stage: create
        healthy:
          exec:
            - command: bash /config/netbox-init.sh
              target: container
              phase: on-exit
      binds:
        - config/configuration.py:/config/configuration.py
        - config/netbox-init.sh:/config/netbox-init.sh
 ```
 
 Addionally, I added: 
 "additionalProperties": false
 
 which makes it stricter on the allowed items. For example
 
 ``` 
 mgmt:
  ipv5-subnet: 172.30.21.0/24
  
  or
  
    kinds:
    unknwon:
      image: ghcr.io/nokia/unknown:latest
  ```
  
  is than not allowed anymore.
  