### PR TITLE
Fix inspect json

### DIFF
--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -1,3 +1,7 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package inspect
 
 import (

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -185,7 +185,6 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 	return err
 }
 
-// toTableData remains unchanged
 func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 	tabData := make([]tableWriter.Row, 0, len(contDetails))
 	for i := range contDetails {
@@ -223,7 +222,6 @@ func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 	return tabData
 }
 
-// getTopologyPath remains unchanged
 func getTopologyPath(p string) (string, error) {
 	if p == "" {
 		return "", nil
@@ -412,7 +410,6 @@ func PrintContainerInspect(containers []runtime.GenericContainer, format string)
 	return fmt.Errorf("internal error: unhandled format %q", format)
 }
 
-// parseStatus remains unchanged
 func parseStatus(status string) string {
 	if strings.Contains(status, "healthy") {
 		status = "healthy"
@@ -425,13 +422,11 @@ func parseStatus(status string) string {
 	return status
 }
 
-// TokenFileResults remains unchanged
 type TokenFileResults struct {
 	File    string
 	Labname string
 }
 
-// ipWithoutPrefix remains unchanged
 func ipWithoutPrefix(ip string) string {
 	if strings.Contains(ip, "N/A") {
 		return ip

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -245,18 +245,16 @@ func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 		}
 
 		// we do not want to print status other than health in the table view
-		statusDisplay := d.Status
-		if !strings.Contains(d.Status, "health") {
-			statusDisplay = ""
+		if !strings.Contains(d.Status, "health") { // Checks the status directly
+			d.Status = "" // Modifies the field directly
 		} else {
-			statusDisplay = fmt.Sprintf("(%s)", d.Status)
+			d.Status = fmt.Sprintf("(%s)", d.Status) // Modifies the field directly
 		}
-
 		// Common fields
 		tabRow = append(tabRow,
 			d.Name,
-			fmt.Sprintf("%s\n%s", d.Kind, d.Image), // Combine Kind and Image
-			fmt.Sprintf("%s\n%s", d.State, statusDisplay), // Combine State and Status
+			fmt.Sprintf("%s\n%s", d.Kind, d.Image),   // Combine Kind and Image
+			fmt.Sprintf("%s\n%s", d.State, d.Status), // Combine State and Status
 			fmt.Sprintf("%s\n%s", // Combine IPv4 and IPv6
 				ipWithoutPrefix(d.IPv4Address),
 				ipWithoutPrefix(d.IPv6Address)))
@@ -494,7 +492,7 @@ func parseStatus(status string) string {
 		return "unhealthy"
 	}
 	// Return empty if no specific health status found, table logic will hide it
-	return ""
+	return status
 }
 
 // TokenFileResults helper struct (seems unused in current inspect logic, kept for completeness).

--- a/code
+++ b/code
@@ -1,0 +1,2 @@
+=== ./package.json ===
+

--- a/docs/cmd/inspect/index.md
+++ b/docs/cmd/inspect/index.md
@@ -75,8 +75,8 @@ Provide information about the running lab named `srlceos01`
 #### Provide information about a specific running lab by its topology file
 
 ```bash
-❯ clab inspect -t srl02.clab.yml 
-INFO[0000] Parsing & checking topology file: srl02.clab.yml 
+❯ clab inspect -t srl02.clab.yml
+INFO[0000] Parsing & checking topology file: srl02.clab.yml
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
 | # |      Name       | Container ID |         Image         | Kind |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
@@ -103,34 +103,36 @@ clab inspect --all --wide
 #### Provide information about a specific running lab in json format
 
 ```bash
-❯ containerlab inspect --name srlceos01 -f json
+❯ containerlab inspect --name clan -f json
 {
-  "srlceos01": [
+  "vlan": [
     {
-      "lab_name": "srlceos01",
-      "lab_path": "path/to/srlceos01.clab.yml",
-      "name": "clab-srlceos01-srl",
-      "container_id": "82e9aa3c7e6b",
-      "image": "srlinux",
-      "kind": "srl",
+      "lab_name": "vlan",
+      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
+      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
+      "name": "clab-vlan-client1",
+      "container_id": "2c70173f3f41",
+      "image": "ghcr.io/srl-labs/alpine",
+      "kind": "linux",
       "state": "running",
-      "status": "Up 2 hours",
-      "ipv4_address": "172.20.20.3/24",
-      "ipv6_address": "3fff:172:20:20::3/80",
-      "owner": "user1"
+      "status": "Up 4 hours",
+      "ipv4_address": "172.20.20.4/24",
+      "ipv6_address": "3fff:172:20:20::4/64",
+      "owner": "root"
     },
     {
-      "lab_name": "srlceos01",
-      "lab_path": "path/to/srlceos01.clab.yml",
-      "name": "clab-srlceos01-ceos",
-      "container_id": "90bebb1e2c5f",
-      "image": "ceos",
-      "kind": "ceos",
+      "lab_name": "vlan",
+      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
+      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
+      "name": "clab-vlan-client2",
+      "container_id": "9a12e9566d8c",
+      "image": "ghcr.io/srl-labs/alpine",
+      "kind": "linux",
       "state": "running",
-      "status": "Up 2 hours",
-      "ipv4_address": "172.20.20.4/24",
-      "ipv6_address": "3fff:172:20:20::4/80",
-      "owner": "user1"
+      "status": "Up 4 hours",
+      "ipv4_address": "172.20.20.2/24",
+      "ipv6_address": "3fff:172:20:20::2/64",
+      "owner": "root"
     }
   ]
 }

--- a/docs/cmd/inspect/index.md
+++ b/docs/cmd/inspect/index.md
@@ -104,26 +104,34 @@ clab inspect --all --wide
 
 ```bash
 ❯ containerlab inspect --name srlceos01 -f json
-[
-  {
-    "lab_name": "srlceos01",
-    "name": "clab-srlceos01-srl",
-    "container_id": "82e9aa3c7e6b",
-    "image": "srlinux",
-    "kind": "srl",
-    "state": "running",
-    "ipv4_address": "172.20.20.3/24",
-    "ipv6_address": "3fff:172:20:20::3/80"
-  },
-  {
-    "lab_name": "srlceos01",
-    "name": "clab-srlceos01-ceos",
-    "container_id": "90bebb1e2c5f",
-    "image": "ceos",
-    "kind": "ceos",
-    "state": "running",
-    "ipv4_address": "172.20.20.4/24",
-    "ipv6_address": "3fff:172:20:20::4/80"
-  }
-]
+{
+  "srlceos01": [
+    {
+      "lab_name": "srlceos01",
+      "lab_path": "path/to/srlceos01.clab.yml",
+      "name": "clab-srlceos01-srl",
+      "container_id": "82e9aa3c7e6b",
+      "image": "srlinux",
+      "kind": "srl",
+      "state": "running",
+      "status": "Up 2 hours",
+      "ipv4_address": "172.20.20.3/24",
+      "ipv6_address": "3fff:172:20:20::3/80",
+      "owner": "user1"
+    },
+    {
+      "lab_name": "srlceos01",
+      "lab_path": "path/to/srlceos01.clab.yml",
+      "name": "clab-srlceos01-ceos",
+      "container_id": "90bebb1e2c5f",
+      "image": "ceos",
+      "kind": "ceos",
+      "state": "running",
+      "status": "Up 2 hours",
+      "ipv4_address": "172.20.20.4/24",
+      "ipv6_address": "3fff:172:20:20::4/80",
+      "owner": "user1"
+    }
+  ]
+}
 ```

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -133,6 +133,54 @@ Inspect ${lab-name} lab using its name
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
 
+Inspect Lab Using JSON Format
+    [Documentation]    Verify inspect command with JSON format output using topology file.
+    # Run inspect command with JSON format
+    ${result} =    Process.Run Process
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect -t ${CURDIR}/${lab-file} --format json
+    ...    shell=True
+    Log    STDOUT: ${result.stdout}
+    Log    STDERR: ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0    Inspect command failed
+    Should Not Be Empty    ${result.stdout}    JSON output should not be empty
+
+    # Verify it's valid JSON and has the correct number of nodes (using jq)
+    # The jq command uses -e to set exit code based on boolean result
+    ${jq_check} =    Process.Run Process
+    ...    echo '${result.stdout}' | jq -e 'length == 3'
+    ...    shell=True
+    Log    JQ Length Check -> RC: ${jq_check.rc} Stderr: ${jq_check.stderr}
+    Should Be Equal As Integers    ${jq_check.rc}    0    JQ validation failed: Expected JSON array of length 3
+
+    # Verify name of the first node (l1)
+    ${jq_check} =    Process.Run Process
+    ...    echo '${result.stdout}' | jq -e '.[0].name == "clab-${lab-name}-l1"'
+    ...    shell=True
+    Log    JQ Name Check (l1) -> RC: ${jq_check.rc} Stderr: ${jq_check.stderr}
+    Should Be Equal As Integers    ${jq_check.rc}    0    JQ validation failed: Expected node name clab-${lab-name}-l1
+
+    # Verify kind of the second node (l2)
+    ${jq_check} =    Process.Run Process
+    ...    echo '${result.stdout}' | jq -e '.[1].kind == "linux"'
+    ...    shell=True
+    Log    JQ Kind Check (l2) -> RC: ${jq_check.rc} Stderr: ${jq_check.stderr}
+    Should Be Equal As Integers    ${jq_check.rc}    0    JQ validation failed: Expected node kind linux
+
+    # Verify state of the third node (l3)
+    ${jq_check} =    Process.Run Process
+    ...    echo '${result.stdout}' | jq -e '.[2].state == "running"'
+    ...    shell=True
+    Log    JQ State Check (l3) -> RC: ${jq_check.rc} Stderr: ${jq_check.stderr}
+    Should Be Equal As Integers    ${jq_check.rc}    0    JQ validation failed: Expected node state running
+
+    # Verify static IPv4 of the second node (l2) - Skip if Podman due to known issue #1291
+    Skip If    '${runtime}' == 'podman'    Skipping static IP check for Podman (Issue #1291)
+    ${jq_check} =    Process.Run Process
+    ...    echo '${result.stdout}' | jq -e '.[1].ipv4_address == "${n2-ipv4}"'
+    ...    shell=True
+    Log    JQ IPv4 Check (l2) -> RC: ${jq_check.rc} Stderr: ${jq_check.stderr}
+    Should Be Equal As Integers    ${jq_check.rc}    0    JQ validation failed: Expected node l2 IPv4 ${n2-ipv4}
+
 Define runtime exec command
     IF    "${runtime}" == "podman"
         Set Suite Variable    ${runtime-cli-exec-cmd}    sudo podman exec

--- a/types/types.go
+++ b/types/types.go
@@ -279,6 +279,7 @@ type K8sKindDeployExtras struct {
 type ContainerDetails struct {
 	LabName     string `json:"lab_name,omitempty"`
 	LabPath     string `json:"labPath,omitempty"`
+	AbsLabPath  string `json:"abs_lab_path,omitempty"`
 	Name        string `json:"name,omitempty"`
 	ContainerID string `json:"container_id,omitempty"`
 	Image       string `json:"image,omitempty"`

--- a/types/types.go
+++ b/types/types.go
@@ -279,7 +279,7 @@ type K8sKindDeployExtras struct {
 type ContainerDetails struct {
 	LabName     string `json:"lab_name,omitempty"`
 	LabPath     string `json:"labPath,omitempty"`
-	AbsLabPath  string `json:"abs_lab_path,omitempty"`
+	AbsLabPath  string `json:"absLabPath,omitempty"`
 	Name        string `json:"name,omitempty"`
 	ContainerID string `json:"container_id,omitempty"`
 	Image       string `json:"image,omitempty"`


### PR DESCRIPTION
This PR will change the format of the following commands:

containerlab inspect --all --format json
containerlab inspect --all --format json --details

the result is now group by the labname and the absolute path is added, will close #2549 

```
containerlab inspect --name srlceos01 -f json
{
  "vlan": [
    {
      "lab_name": "vlan",
      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
``` 