### PR TITLE
Json in now grouped by labs, and contains the absLabPath

### DIFF
--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -130,13 +130,10 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 
 	// Handle empty results
 	if len(containers) == 0 {
-		if inspectFormat == "json" { // Handles both details and non-details JSON
-			// Print an empty JSON object for consistency with grouped output
+		if inspectFormat == "json" {
 			fmt.Println("{}")
 		} else { // Table format
 			log.Info("no containers found")
-			// Let PrintContainerInspect render an empty table structure
-			err = PrintContainerInspect(containers, inspectFormat)
 		}
 		return err // Return after handling empty results
 	}

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -42,7 +42,8 @@ var InspectCmd = &cobra.Command{
 }
 
 func init() {
-	InspectCmd.Flags().BoolVarP(&details, "details", "", false, "print all details of lab containers (JSON format, grouped by lab)")
+	InspectCmd.Flags().BoolVarP(&details, "details", "", false,
+		"print all details of lab containers (JSON format, grouped by lab)")
 	InspectCmd.Flags().StringVarP(&inspectFormat, "format", "f", "table", "output format. One of [table, json]")
 	InspectCmd.Flags().BoolVarP(&all, "all", "a", false, "show all deployed containerlab labs")
 	InspectCmd.Flags().BoolVarP(&wide, "wide", "w", false,
@@ -259,7 +260,7 @@ func getTopologyPath(p string) (string, error) {
 	return p, nil
 }
 
-// PrintContainerInspect handles non-details output (table or grouped JSON summary)
+// PrintContainerInspect handles non-details output (table or grouped JSON summary).
 func PrintContainerInspect(containers []runtime.GenericContainer, format string) error {
 	// Handle empty case for table rendering specifically
 	if len(containers) == 0 && format == "table" {
@@ -282,15 +283,27 @@ func PrintContainerInspect(containers []runtime.GenericContainer, format string)
 
 		if all {
 			header = append(tableWriter.Row{"Topology", "Lab Name"}, headerBase...)
-			colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 1, AutoMerge: true, VAlign: text.VAlignMiddle})
-			colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 2, AutoMerge: true, VAlign: text.VAlignMiddle})
+			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+				Number:    1,
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			})
+			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+				Number:    2,
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			})
 			if wide {
-				colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 3, AutoMerge: true, VAlign: text.VAlignMiddle})
+				colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+					Number:    3,
+					AutoMerge: true, VAlign: text.VAlignMiddle,
+				})
 			}
 		} else {
 			header = headerBase
 			if wide {
-				colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 1, AutoMerge: true, VAlign: text.VAlignMiddle})
+				colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+					Number:    1,
+					AutoMerge: true, VAlign: text.VAlignMiddle,
+				})
 			}
 		}
 
@@ -409,15 +422,27 @@ func PrintContainerInspect(containers []runtime.GenericContainer, format string)
 
 		if all {
 			header = append(tableWriter.Row{"Topology", "Lab Name"}, headerBase...)
-			colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 1, AutoMerge: true, VAlign: text.VAlignMiddle})
-			colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 2, AutoMerge: true, VAlign: text.VAlignMiddle})
+			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+				Number:    1,
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			})
+			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+				Number:    2,
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			})
 			if wide {
-				colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 3, AutoMerge: true, VAlign: text.VAlignMiddle})
+				colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+					Number:    3,
+					AutoMerge: true, VAlign: text.VAlignMiddle,
+				})
 			}
 		} else {
 			header = headerBase
 			if wide {
-				colConfigs = append(colConfigs, tableWriter.ColumnConfig{Number: 1, AutoMerge: true, VAlign: text.VAlignMiddle})
+				colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+					Number:    1,
+					AutoMerge: true, VAlign: text.VAlignMiddle,
+				})
 			}
 		}
 

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -89,9 +89,7 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 
 	c, err := clab.NewContainerLab(opts...)
 	if err != nil {
-		// do not wrap error message to avoid printing it twice
-		// when it originates from the topo parsing part
-		return err //nolint:wrapcheck
+		return err
 	}
 
 	err = c.CheckConnectivity(ctx)
@@ -100,7 +98,7 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 	}
 
 	var containers []runtime.GenericContainer
-	var glabels []*types.GenericFilter
+	var gLabels []*types.GenericFilter
 
 	if common.Topo != "" {
 		// List containers defined in the topology file
@@ -112,19 +110,19 @@ func inspectFn(_ *cobra.Command, _ []string) error {
 		// List containers based on labels (--name or --all)
 		if common.Name != "" {
 			// Filter by specific lab name
-			glabels = []*types.GenericFilter{{
+			gLabels = []*types.GenericFilter{{
 				FilterType: "label", Match: common.Name,
 				Field: labels.Containerlab, Operator: "=",
 			}}
 		} else { // --all case
 			// Filter for any containerlab container
-			glabels = []*types.GenericFilter{{
+			gLabels = []*types.GenericFilter{{
 				FilterType: "label",
 				Field:      labels.Containerlab, Operator: "exists",
 			}}
 		}
 
-		containers, err = c.ListContainers(ctx, glabels)
+		containers, err = c.ListContainers(ctx, gLabels)
 		if err != nil {
 			return fmt.Errorf("failed to list containers based on labels: %s", err)
 		}

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -197,7 +197,7 @@ func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 
 // getTopologyPath calculates the relative path to the topology file from the current working directory.
 // If the path is already relative and shorter, it returns the relative path.
-// Otherwise, it returns the original path (likely absolute or not easily relativized).
+// The path p is an absolute path.
 func getTopologyPath(p string) (string, error) {
 	if p == "" {
 		return "", nil
@@ -206,24 +206,18 @@ func getTopologyPath(p string) (string, error) {
 	// get topo file path relative of the cwd
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to get current working directory: %w", err)
+		return "", err
 	}
 
-	// Check if the path is already absolute
-	if filepath.IsAbs(p) {
-		relPath, err := filepath.Rel(cwd, p)
-		if err != nil {
-			// If relativization fails, return the original absolute path
-			return p, nil
-		}
-		// Return the shorter path (prefer relative if shorter)
-		if len(relPath) < len(p) {
-			return relPath, nil
-		}
-		return p, nil // Return absolute path if relative is not shorter
+	relPath, err := filepath.Rel(cwd, p)
+	if err != nil {
+		return "", err
 	}
 
-	// If the path is already relative, just return it
+	if len(relPath) < len(p) {
+		return relPath, nil
+	}
+
 	return p, nil
 }
 

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -52,8 +52,7 @@ func init() {
 
 func inspectFn(_ *cobra.Command, _ []string) error {
 	if common.Name == "" && common.Topo == "" && !all {
-		fmt.Println("provide either a lab name (--name) or a topology file path (--topo) or the --all flag")
-		return nil
+		return fmt.Errorf("provide either a lab name (--name) or a topology file path (--topo) or the --all flag")
 	}
 
 	// Format validation (only relevant if --details is NOT used)

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -167,29 +167,26 @@ func toTableData(contDetails []types.ContainerDetails) []tableWriter.Row {
 		tabRow := tableWriter.Row{}
 
 		if all {
-			tabRow = append(tabRow, d.LabPath, d.LabName) // Use relative LabPath for table
+			tabRow = append(tabRow, d.LabPath, d.LabName)
 		}
 
 		if wide {
-			tabRow = append(tabRow, d.Owner) // Append the actual owner value consistently
+			tabRow = append(tabRow, d.Owner)
 		}
 
-		// Status formatting
-		statusDisplay := d.Status
-		if !strings.Contains(statusDisplay, "health") {
-			statusDisplay = ""
+		// we do not want to print status other than health in the table view
+		if !strings.Contains(d.Status, "health") {
+			d.Status = ""
 		} else {
-			if statusDisplay != "" {
-				statusDisplay = fmt.Sprintf("(%s)", statusDisplay)
-			}
+			d.Status = fmt.Sprintf("(%s)", d.Status)
 		}
 
 		// Common fields
 		tabRow = append(tabRow,
 			d.Name,
-			fmt.Sprintf("%s\n%s", d.Kind, d.Image), // Combine Kind and Image
-			strings.TrimSpace(fmt.Sprintf("%s\n%s", d.State, statusDisplay)), // Combine State and formatted Status
-			fmt.Sprintf("%s\n%s", // Combine IPv4 and IPv6
+			fmt.Sprintf("%s\n%s", d.Kind, d.Image),
+			fmt.Sprintf("%s\n%s", d.State, d.Status),
+			fmt.Sprintf("%s\n%s",
 				ipWithoutPrefix(d.IPv4Address),
 				ipWithoutPrefix(d.IPv6Address)))
 

--- a/docs/cmd/inspect/index.md
+++ b/docs/cmd/inspect/index.md
@@ -75,8 +75,8 @@ Provide information about the running lab named `srlceos01`
 #### Provide information about a specific running lab by its topology file
 
 ```bash
-❯ clab inspect -t srl02.clab.yml 
-INFO[0000] Parsing & checking topology file: srl02.clab.yml 
+❯ clab inspect -t srl02.clab.yml
+INFO[0000] Parsing & checking topology file: srl02.clab.yml
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
 | # |      Name       | Container ID |         Image         | Kind |  State  |  IPv4 Address  |     IPv6 Address     |
 +---+-----------------+--------------+-----------------------+------+---------+----------------+----------------------+
@@ -103,27 +103,37 @@ clab inspect --all --wide
 #### Provide information about a specific running lab in json format
 
 ```bash
-❯ containerlab inspect --name srlceos01 -f json
-[
-  {
-    "lab_name": "srlceos01",
-    "name": "clab-srlceos01-srl",
-    "container_id": "82e9aa3c7e6b",
-    "image": "srlinux",
-    "kind": "srl",
-    "state": "running",
-    "ipv4_address": "172.20.20.3/24",
-    "ipv6_address": "3fff:172:20:20::3/80"
-  },
-  {
-    "lab_name": "srlceos01",
-    "name": "clab-srlceos01-ceos",
-    "container_id": "90bebb1e2c5f",
-    "image": "ceos",
-    "kind": "ceos",
-    "state": "running",
-    "ipv4_address": "172.20.20.4/24",
-    "ipv6_address": "3fff:172:20:20::4/80"
-  }
-]
+❯ containerlab inspect --name vlan -f json
+{
+  "vlan": [
+    {
+      "lab_name": "vlan",
+      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
+      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
+      "name": "clab-vlan-client1",
+      "container_id": "2c70173f3f41",
+      "image": "ghcr.io/srl-labs/alpine",
+      "kind": "linux",
+      "state": "running",
+      "status": "Up 4 hours",
+      "ipv4_address": "172.20.20.4/24",
+      "ipv6_address": "3fff:172:20:20::4/64",
+      "owner": "root"
+    },
+    {
+      "lab_name": "vlan",
+      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
+      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
+      "name": "clab-vlan-client2",
+      "container_id": "9a12e9566d8c",
+      "image": "ghcr.io/srl-labs/alpine",
+      "kind": "linux",
+      "state": "running",
+      "status": "Up 4 hours",
+      "ipv4_address": "172.20.20.2/24",
+      "ipv6_address": "3fff:172:20:20::2/64",
+      "owner": "root"
+    }
+  ]
+}
 ```

--- a/types/types.go
+++ b/types/types.go
@@ -279,6 +279,7 @@ type K8sKindDeployExtras struct {
 type ContainerDetails struct {
 	LabName     string `json:"lab_name,omitempty"`
 	LabPath     string `json:"labPath,omitempty"`
+	AbsLabPath  string `json:"absLabPath,omitempty"`
 	Name        string `json:"name,omitempty"`
 	ContainerID string `json:"container_id,omitempty"`
 	Image       string `json:"image,omitempty"`


### PR DESCRIPTION
This PR does changes the grouping of the json output and for --details on the inspect command.

In addution it add the absLabPath which cloes #2549 

```bash
❯ containerlab inspect --name vlan -f json
{
  "vlan": [
    {
      "lab_name": "vlan",
      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
      "name": "clab-vlan-client1",
      "container_id": "2c70173f3f41",
      "image": "ghcr.io/srl-labs/alpine",
      "kind": "linux",
      "state": "running",
      "status": "Up 4 hours",
      "ipv4_address": "172.20.20.4/24",
      "ipv6_address": "3fff:172:20:20::4/64",
      "owner": "root"
    },
    {
      "lab_name": "vlan",
      "labPath": "../../srlinux-vlan-handling-lab/vlan.clab.yml",
      "absLabPath": "/root/projects/srlinux-vlan-handling-lab/vlan.clab.yml",
      "name": "clab-vlan-client2",
      "container_id": "9a12e9566d8c",
      "image": "ghcr.io/srl-labs/alpine",
      "kind": "linux",
      "state": "running",
      "status": "Up 4 hours",
      "ipv4_address": "172.20.20.2/24",
      "ipv6_address": "3fff:172:20:20::2/64",
      "owner": "root"
    }
  ]
}