### PR TITLE
docs/quickstart: Use latest and greatest SR Linux version

### DIFF
--- a/docs/lab-examples/srl-ceos.md
+++ b/docs/lab-examples/srl-ceos.md
@@ -7,7 +7,7 @@
 | **Resource requirements**[^1] | :fontawesome-solid-microchip: 2 <br/>:fontawesome-solid-memory: 4 GB        |
 | **Topology file**             | [srlceos01.clab.yml][topofile]                                              |
 | **Name**                      | srlceos01                                                                   |
-| **Version information**[^2]   | `containerlab:0.56.0`, `srlinux:24.3.3`, `ceos:4.32.0F`, `docker-ce:26.0.0` |
+| **Version information**[^2]   | `containerlab:0.56.0`, `srlinux:24.10`, `ceos:4.32.0F`, `docker-ce:26.0.0`  |
 
 ## Description
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,7 +83,7 @@ Below you will find different image names you can come across when working with 
 
 Our topology file defines two nodes, where each node is defined with its own container image:
 
-* `ghcr.io/nokia/srlinux:24.3.3` - for Nokia SR Linux node
+* `ghcr.io/nokia/srlinux` - for Nokia SR Linux node
 * `ceos:4.32.0F` - for Arista cEOS node
 
 When containerlab starts to deploy the lab, it will first check if the images are available locally. Local images can be listed with `docker images` command.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,7 +83,7 @@ Below you will find different image names you can come across when working with 
 
 Our topology file defines two nodes, where each node is defined with its own container image:
 
-* `ghcr.io/nokia/srlinux` - for Nokia SR Linux node
+* `ghcr.io/nokia/srlinux:24.10` - for Nokia SR Linux node
 * `ceos:4.32.0F` - for Arista cEOS node
 
 When containerlab starts to deploy the lab, it will first check if the images are available locally. Local images can be listed with `docker images` command.

--- a/lab-examples/srlceos01/srlceos01.clab.yml
+++ b/lab-examples/srlceos01/srlceos01.clab.yml
@@ -5,10 +5,10 @@ topology:
   nodes:
     srl:
       kind: nokia_srlinux
-      image: ghcr.io/nokia/srlinux:24.3.3
+      image: ghcr.io/nokia/srlinux
     ceos:
       kind: arista_ceos
       image: ceos:4.32.0F
 
   links:
-    - endpoints: ["srl:e1-1", "ceos:eth1"]
+    - endpoints: ["srl:ethernet-1/1", "ceos:eth1"]

--- a/lab-examples/srlceos01/srlceos01.clab.yml
+++ b/lab-examples/srlceos01/srlceos01.clab.yml
@@ -5,7 +5,7 @@ topology:
   nodes:
     srl:
       kind: nokia_srlinux
-      image: ghcr.io/nokia/srlinux
+      image: ghcr.io/nokia/srlinux:24.10
     ceos:
       kind: arista_ceos
       image: ceos:4.32.0F


### PR DESCRIPTION
At the moment, we use a topology with SRL 24.3.3 in the quickstart example, so anyone following the guide on Ubuntu 23+ will run into the syslog AppArmor issue.

Probably best to bump the version to latest in the topology, so anyone using the guide will get the latest version of SRL to play with.

Also updated the topology with a more intuitive interface alias.