### PR TITLE
lab-examples/vsrx01: junoser convert the set-format

### DIFF
--- a/lab-examples/vsrx01/srx1.cfg
+++ b/lab-examples/vsrx01/srx1.cfg
@@ -1,0 +1,52 @@
+interfaces ge-0/0/0 {
+    unit 0 {
+        family {
+            inet {
+                address 192.168.1.1/30;
+            }
+        }
+    }
+}
+interfaces ge-0/0/1 {
+    unit 0 {
+        family {
+            inet {
+                address 192.168.2.1/30;
+            }
+        }
+    }
+}
+security {
+    zones {
+        security-zone trust {
+            interfaces ge-0/0/0 {
+                host-inbound-traffic {
+                    system-services all;
+                }
+            }
+            interfaces ge-0/0/1 {
+                host-inbound-traffic {
+                    system-services all;
+                }
+            }
+        }
+    }
+    forwarding-options {
+        family {
+            mpls {
+                mode {
+                    packet-based;
+                }
+            }
+        }
+    }
+}
+system {
+    services {
+        web-management {
+            https {
+                system-generated-certificate;
+            }
+        }
+    }
+}

--- a/lab-examples/vsrx01/srx1.txt
+++ b/lab-examples/vsrx01/srx1.txt
@@ -1,6 +1,0 @@
-set interfaces ge-0/0/0 unit 0 family inet address 192.168.1.1/30
-set interfaces ge-0/0/1 unit 0 family inet address 192.168.2.1/30
-set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services all
-set security zones security-zone trust interfaces ge-0/0/1 host-inbound-traffic system-services all
-set system services web-management https system-generated-certificate
-set security forwarding-options family mpls mode packet-based

--- a/lab-examples/vsrx01/vsrx01.yml
+++ b/lab-examples/vsrx01/vsrx01.yml
@@ -4,7 +4,7 @@ topology:
     srx1:
       kind: juniper_vsrx
       image: vrnetlab/vr-vsrx:23.2R1.13
-      startup-config: srx1.txt
+      startup-config: srx1.cfg
     client1:
       kind: "linux"
       image: wbitt/network-multitool:alpine-extra


### PR DESCRIPTION
After https://github.com/hellt/vrnetlab/pull/209 it seems the set-format config is less relevant. To encourage users using up-to-date vrnetlab, replace it with identical config generated with junoser from the set-based data.