### PR TITLE
tests/02-basic-srl: Test node-specific env vars

### DIFF
--- a/tests/02-basic-srl/02-srl02.clab.yml
+++ b/tests/02-basic-srl/02-srl02.clab.yml
@@ -16,6 +16,8 @@ topology:
     srl2:
       kind: nokia_srlinux
       image: ghcr.io/nokia/srlinux
+      env:
+        SRL_LOCATION: test123
       startup-config: https://raw.githubusercontent.com/srl-labs/containerlab/main/tests/02-basic-srl/srl2-startup.cli
       mgmt-ipv4: 172.20.20.201
 

--- a/tests/02-basic-srl/srl2-startup.cli
+++ b/tests/02-basic-srl/srl2-startup.cli
@@ -9,4 +9,4 @@ set / interface ethernet-1/1 subinterface 0 ipv6 address 2002::192.168.0.1/127
 set / network-instance default
 set / network-instance default interface ethernet-1/1.0
 
-set / system information location test123
+set / system information location ${SRL_LOCATION:=default-value}

--- a/tests/02-basic-srl/srl2-startup.cli
+++ b/tests/02-basic-srl/srl2-startup.cli
@@ -9,4 +9,4 @@ set / interface ethernet-1/1 subinterface 0 ipv6 address 2002::192.168.0.1/127
 set / network-instance default
 set / network-instance default interface ethernet-1/1.0
 
-set / system information location ${SRL_LOCATION:=default-value}
+set / system information location {{.Env.SRL_LOCATION}}


### PR DESCRIPTION
Instead of hardcoding system info location, try to retrieve it from node-specific env vars.

See also: #2580