### PR TITLE
Fix sorting logic in PrintContainerInspect to compare LabName correctly

### DIFF
--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -308,7 +308,7 @@ func PrintContainerInspect(containers []runtime.GenericContainer, format string)
 		if contDetails[i].LabName == contDetails[j].LabName {
 			return contDetails[i].Name < contDetails[j].Name
 		}
-		return contDetails[i].LabName < contDetails[j].Name
+		return contDetails[i].LabName < contDetails[j].LabName
 	})
 
 	// --- Output based on format ---


### PR DESCRIPTION
## Issue
Containers were not properly grouped by lab name in the `inspect` table output due to a typo in the sorting function.

## Fix
```go
// Before (incorrect)
return contDetails[i].LabName < contDetails[j].Name

// After (fixed)
return contDetails[i].LabName < contDetails[j].LabName
```

## Before
```
clab inspect --all                                                                                                              system root@flosch3
╭────────────────────────────────────────────────────┬──────────┬────────────────────────┬──────────────────────────────────────────┬────────────────────┬───────────────────╮
│                      Topology                      │ Lab Name │          Name          │                Kind/Image                │        State       │   IPv4/6 Address  │
├────────────────────────────────────────────────────┼──────────┼────────────────────────┼──────────────────────────────────────────┼────────────────────┼───────────────────┤
│ ../eda-telemetry-lab/eda-st.clab.yaml              │ eda-st   │ clab-eda-st-alloy      │ linux                                    │ running            │ 10.58.2.41        │
│                                                    │          │                        │ grafana/alloy:v1.6.1                     │                    │ N/A               │
│                                                    │          ├────────────────────────┼──────────────────────────────────────────┼────────────────────┼───────────────────┤
...
├────────────────────────────────────────────────────┼──────────┼────────────────────────┼──────────────────────────────────────────┼────────────────────┼───────────────────┤
│ ../clab-connector/example-topologies/sros.clab.yml │ sros     │ clab-sros-s1           │ nokia_srlinux                            │ running            │ 172.20.20.2       │
│                                                    │          │                        │ ghcr.io/nokia/srlinux:25.3.1             │                    │ 3fff:172:20:20::2 │
├────────────────────────────────────────────────────┼──────────┼────────────────────────┼──────────────────────────────────────────┼────────────────────┼───────────────────┤
│ ../eda-telemetry-lab/eda-st.clab.yaml              │ eda-st   │ clab-eda-st-leaf4      │ nokia_srlinux                            │ running            │ 10.58.2.14        │
│                                                    │          │                        │ ghcr.io/nokia/srlinux:24.10.1            │                    │ N/A               │
```
Notice how `eda-st` is split with `sros` in the middle.

## After
```
clab inspect --all                                                                                                             5s  system root@flosch3
╭────────────────────────────────────────────────────┬──────────┬────────────────────────┬──────────────────────────────────────────┬─────────┬───────────────────╮
│                      Topology                      │ Lab Name │          Name          │                Kind/Image                │  State  │   IPv4/6 Address  │
├────────────────────────────────────────────────────┼──────────┼────────────────────────┼──────────────────────────────────────────┼─────────┼───────────────────┤
│ ../eda-telemetry-lab/eda-st.clab.yaml              │ eda-st   │ clab-eda-st-alloy      │ linux                                    │ running │ 10.58.2.41        │
...
│                                                    │          │ clab-eda-st-spine2     │ nokia_srlinux                            │ running │ 10.58.2.22        │
│                                                    │          │                        │ ghcr.io/nokia/srlinux:24.10.1            │         │ N/A               │
├────────────────────────────────────────────────────┼──────────┼────────────────────────┼──────────────────────────────────────────┼─────────┼───────────────────┤
│ ../clab-connector/example-topologies/sros.clab.yml │ sros     │ clab-sros-d1           │ nokia_sros                               │ running │ 172.20.20.3       │
│                                                    │          │                        │ registry.srlinux.dev/pub/vr-sros:25.3.R2 │         │ 3fff:172:20:20::3 │
│                                                    │          ├────────────────────────┼──────────────────────────────────────────┼─────────┼───────────────────┤
│                                                    │          │ clab-sros-s1           │ nokia_srlinux                            │ running │ 172.20.20.2       │
│                                                    │          │                        │ ghcr.io/nokia/srlinux:25.3.1             │         │ 3fff:172:20:20::2 │
```
Now all `eda-st` containers are grouped together, followed by the `sros` lab containers.