### PR TITLE
DevContainer Dockerfile updated to prevent non-existent group error on build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /etc/sudoers.d && echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /et
 
 # Add vscode user to clab_admins group so that it can run sudo-less clab commands
 # the group is created when clab is installed via the installation script
-RUN usermod -aG clab_admins vscode
+RUN addgroup clab_admins && usermod -aG clab_admins vscode
 
 # Switch to the vscode user provided by the base image
 USER vscode

--- a/.devcontainer/slim.Dockerfile
+++ b/.devcontainer/slim.Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /etc/sudoers.d && echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /et
 
 # Add vscode user to clab_admins group so that it can run sudo-less clab commands
 # the group is created when clab is installed via the installation script
-RUN usermod -aG clab_admins vscode
+RUN addgroup clab_admins && usermod -aG clab_admins vscode
 
 # Switch to the vscode user provided by the base image
 USER vscode


### PR DESCRIPTION
Updated DevContainer Dockerfiles to create the group before attempting to add the vscode user to the group to prevent non-existant group errors