### PR TITLE
Add Nornir group support

### DIFF
--- a/clab/inventory.go
+++ b/clab/inventory.go
@@ -185,6 +185,7 @@ type NornirSimpleInventoryKindProps struct {
 // the node registry.
 type NornirSimpleInventoryNode struct {
 	*types.NodeConfig
+	NornirGroup string
 }
 
 // NornirSimpleInventory represents the data structure used to generate the nornir simple inventory file.
@@ -243,6 +244,7 @@ func (c *CLab) generateNornirSimpleInventory(w io.Writer) error {
 			}
 
 		}
+		nornirNode.NornirGroup = n.Config().Labels["nornir-group"]
 
 		inv.Nodes[n.Config().Kind] = append(inv.Nodes[n.Config().Kind], nornirNode)
 	}

--- a/clab/inventory_nornir_simple.go.tpl
+++ b/clab/inventory_nornir_simple.go.tpl
@@ -7,5 +7,9 @@
     password: {{ $kindProps.Password }}
     platform: {{ $kindProps.Platform }}
     hostname: {{ $node.MgmtIPv4Address }}
+    {{- if $node.NornirGroup }}
+    groups:
+      - {{ $node.NornirGroup }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/clab/inventory_test.go
+++ b/clab/inventory_test.go
@@ -174,6 +174,37 @@ node4:
     platform: linux
     hostname: `,
 		},
+		"case4-default-groups-platform": {
+			got:                              "test_data/topo8_ansible_groups.yml",
+			clab_nornir_platform_name_schema: "",
+			want: `---
+node4:
+    username: 
+    password: 
+    platform: linux
+    hostname: 172.100.100.14
+node1:
+    username: admin
+    password: NokiaSrl1!
+    platform: nokia_srlinux
+    hostname: 172.100.100.11
+    groups:
+      - spine
+node2:
+    username: admin
+    password: NokiaSrl1!
+    platform: nokia_srlinux
+    hostname: 172.100.100.12
+    groups:
+      - extra_group
+node3:
+    username: admin
+    password: NokiaSrl1!
+    platform: nokia_srlinux
+    hostname: 172.100.100.13
+    groups:
+      - extra_group`,
+		},
 	}
 
 	for name, tc := range tests {

--- a/clab/test_data/topo8_ansible_groups.yml
+++ b/clab/test_data/topo8_ansible_groups.yml
@@ -13,6 +13,7 @@ topology:
       mgmt-ipv4: 172.100.100.11
       labels:
         ansible-group: spine
+        nornir-group: spine
     node2:
       kind: nokia_srlinux
       license: node1.lic
@@ -21,6 +22,7 @@ topology:
       labels:
         node-label: value
         ansible-group: extra_group
+        nornir-group: extra_group
 
     node3:
       kind: nokia_srlinux
@@ -30,6 +32,7 @@ topology:
       labels:
         node-label: value
         ansible-group: extra_group
+        nornir-group: extra_group
 
     node4:
       kind: linux

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -172,6 +172,44 @@ node2:
   hostname: 172.200.20.3
 ```
 
+### User-defined groups
+
+Users can add custom grouping of nodes in the inventory by adding the `nornir-group` label to the node definition:
+
+```yaml
+name: custom-groups
+topology:
+  nodes:
+    node1:
+      # <some node config data>
+      labels:
+        nornir-group: spine
+    node2:
+      # <some node config data>
+      labels:
+        nornir-group: extra_group
+```
+
+As a result of this configuration, the generated inventory will look like this:
+
+```yaml
+---
+node1:
+  username: admin
+  password: NokiaSrl1!
+  platform: nokia_srlinux
+  hostname: 172.200.20.2
+  groups:
+    - spine
+node2:
+  username: admin
+  password: admin
+  platform: arista_eos
+  hostname: 172.200.20.3
+  groups:
+    - extra_group
+```
+
 ///
 
 The `platform` field can be influenced to support Napalm/Netmiko or scrapi compliant names.  To influence the platform used set the `CLAB_NORNIR_PLATFORM_NAME_SCHEMA` env variable to either `napalm` or `scrapi` as the value. By default the platform will be set to the `kind`.  Further reading is available below:

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -96,7 +96,7 @@ all:
 
 ### User-defined groups
 
-Users can enforce custom grouping of nodes in the inventory by adding the `ansible-inventory` label to the node definition:
+Users can enforce custom grouping of nodes in the inventory by adding the `ansible-group` label to the node definition:
 
 ```yaml
 name: custom-groups

--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -160,12 +160,12 @@ topology:
 
 ```yaml
 ---
-spine1:
+node1:
   username: admin
   password: NokiaSrl1!
   platform: nokia_srlinux
   hostname: 172.200.20.2
-spine2:
+node2:
   username: admin
   password: admin
   platform: arista_eos


### PR DESCRIPTION

Like with Ansible, use a label `nornir-group` to add nodes to a Nornir group in the inventory:

https://nornir.readthedocs.io/en/latest/tutorial/inventory.html#Inventory

Nornir would actually support multiple groups per node, but with the label approach we cannot do that nicely.

I wonder if we couldn't find a better way to do this. Like use a more generic `groups` notation?
https://github.com/srl-labs/containerlab/issues/2504
