### PR TITLE
Fix parseStatus function to prioritize 'unhealthy' status over 'healthy'

### DIFF
--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -398,12 +398,12 @@ func PrintContainerInspect(containers []runtime.GenericContainer, format string)
 
 // parseStatus extracts a simpler status string, focusing on health states.
 func parseStatus(status string) string {
-	if strings.Contains(status, "healthy") {
-		return "healthy"
+	if strings.Contains(status, "unhealthy") {
+		return "unhealthy"
 	} else if strings.Contains(status, "health: starting") {
 		return "health: starting"
-	} else if strings.Contains(status, "unhealthy") {
-		return "unhealthy"
+	} else if strings.Contains(status, "healthy") {
+		return "healthy"
 	}
 	// Return original status if no specific health info found
 	return status


### PR DESCRIPTION
As unhealthy also contains healthy, we need to check unhealthy first, otherwhise its already matched.