### PR TITLE
fixed bind mount of gshadow if the file is not available

### DIFF
--- a/cmd/tools_api_start.go
+++ b/cmd/tools_api_start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/srl-labs/containerlab/links"
 	"github.com/srl-labs/containerlab/runtime"
 	"github.com/srl-labs/containerlab/types"
+	"github.com/srl-labs/containerlab/utils"
 )
 
 func init() {
@@ -74,8 +75,11 @@ func NewAPIServerNode(name, image, labsDir string, runtime runtime.ContainerRunt
 		types.NewBind("/etc/passwd", "/etc/passwd", "ro"),
 		types.NewBind("/etc/shadow", "/etc/shadow", "ro"),
 		types.NewBind("/etc/group", "/etc/group", "ro"),
-		types.NewBind("/etc/gshadow", "/etc/gshadow", "ro"),
 		types.NewBind("/home", "/home", ""),
+	}
+	// if /etc/gshadow exists, add it to the binds
+	if utils.FileExists("/etc/gshadow") {
+		binds = append(binds, types.NewBind("/etc/gshadow", "/etc/gshadow", "ro"))
 	}
 
 	// get the runtime socket path


### PR DESCRIPTION
Several distros, e.g., in my case NixOS do not use /etc/shadow by default. When using "containerlab tools api-server start" in this case, the following error is thrown:

```
❯ clab tools api-server start
20:40:01 INFO Generated random JWT secret for API server
20:40:01 INFO Pulling image ghcr.io/srl-labs/clab-api-server/clab-api-server:latest...
20:40:01 INFO Pulling ghcr.io/srl-labs/clab-api-server/clab-api-server:latest Docker image
20:40:01 INFO Done pulling ghcr.io/srl-labs/clab-api-server/clab-api-server:latest
20:40:01 INFO Creating API server container clab-api-server
20:40:01 INFO Creating container name=clab-api-server
20:40:02 INFO Removed container name=clab-api-server
Error: failed to start API server container: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/etc/gshadow" to rootfs at "/etc/gshadow": create mountpoint for /etc/gshadow mount: cannot create subdirectories in "/var/lib/docker/overlay2/d052e24022e2bf7710d9f7ab804aa9c544c8465140bf606a3f4f000247b23e85/merged/etc/gshadow": not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

also, after running the command, /etc/gshadow is created as a directory as can also be seen from the output above because of the bind mount, which is wrong, as it should be a file. The error can be circumvented by running "sudo touch /etc/gshadow" and create an empty file before running "containerlab tools api-server start", but I don't think it's a good idea to create or modify files in the running distro. Therefore, I propose this PR to start the api-server also in a "clean" way, even if the distribution does not have /etc/gshadow. Using the fix and building containerlab, the api-server runs fine also without gshadow and contents of etc are not modified on NixOS.