### PR TITLE
Pass interface specs on Fortigate node creation

### DIFF
--- a/nodes/fortinet_fortigate/fortigate.go
+++ b/nodes/fortinet_fortigate/fortigate.go
@@ -84,6 +84,10 @@ func (n *fortigate) Init(cfg *types.NodeConfig, opts ...nodes.NodeOption) error 
 	n.Cfg.Cmd = fmt.Sprintf("--username %s --password %s --hostname %s --connection-mode %s --trace",
 		defaultCredentials.GetUsername(), defaultCredentials.GetPassword(), n.Cfg.ShortName, n.Cfg.Env["CONNECTION_MODE"])
 
+	n.InterfaceRegexp = InterfaceRegexp
+	n.InterfaceOffset = InterfaceOffset
+	n.InterfaceHelp = InterfaceHelp
+
 	return nil
 }
 


### PR DESCRIPTION
Fixed small bug where the interface specs where not passed, making it impossible to create any links with this kind node.