### PR TITLE
Use HostConfig.Mounts for anonymous volumes

### DIFF
--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -185,14 +185,14 @@ topology:
         - /root/files:/root/files:ro # (2)!
         - somefile:/somefile # (3)!
         - ~/.ssh/id_rsa:/root/.ssh/id_rsa # (4)!
-        - /var/run/somedir # (5)!
 ```
 
 1. mount a host file found by the path `/usr/local/bin/gobgp` to a container under `/root/gobgp` (implicit RW mode)
 2. mount a `/root/files` directory from a host to a container in RO mode
 3. when a host path is given in a relative format, the path is considered relative to the topology file and not a current working directory.
 4. The `~` char will be expanded to a user's home directory.
-5. mount an anonymous volume to a container under `/var/run/somedir` (implicit RW mode)
+
+> Binds are for host bind mounts only. Anonymous or named volumes should be configured via the [`volumes`](#volumes) stanza instead.
 
 /// details | Bind variables
 By default, binds are either provided as an absolute or a relative (to the current working dir) path. Although the majority of cases can be very well covered with this, there are situations in which it is desirable to use a path that is relative to the node-specific example.
@@ -276,6 +276,23 @@ topology:
 Binds defined on multiple levels (defaults -> kind -> node) will be merged with the duplicated values removed (the lowest level takes precedence).
 
 When a bind with the same destination is defined on multiple levels, the lowest level takes precedence. This allows to override the binds defined on the higher levels.
+
+### volumes
+
+Volumes (named or anonymous) are configured via the `volumes` stanza. Entries use the same short syntax as docker's `--volume` flag.
+
+```yaml
+name: mylab
+topology:
+  nodes:
+    srv:
+      kind: linux
+      volumes:
+        - shared-data:/srv/shared:ro   # named volume, may be shared between nodes
+        - /var/log/app                 # anonymousvolume
+```
+
+Volumes can be provided at `defaults`, `kinds`, or per-node level; lower levels override higher ones for the same destination path.
 
 ### ports
 

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -180,6 +180,16 @@
                     },
                     "uniqueItems": true
                 },
+                "volumes": {
+                    "type": "array",
+                    "description": "list of volumes to attach",
+                    "markdownDescription": "list of [volumes](https://containerlab.dev/manual/nodes/#volumes) to attach",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
                 "ports": {
                     "type": "array",
                     "description": "list of port mappings",

--- a/types/bind.go
+++ b/types/bind.go
@@ -39,15 +39,10 @@ func NewBindFromString(bind string) (*Bind, error) {
 	b := &Bind{}
 
 	split := strings.Split(bind, ":")
-	if len(split) == 1 {
-		// If there is only one part, the container runtime creates an anonymous
-		// volume and mounts it on the given destination.
-		b.dst = split[0]
 
-		return b, nil
-	}
-
-	if len(split) < 2 || len(split) > 3 {
+	if len(split) == 1 && split[0] != "" {
+		return nil, fmt.Errorf("bind %q looks like an anonymous volume target, please use the volumes stanza instead", bind)
+	} else if len(split) < 2 || len(split) > 3 {
 		return nil, fmt.Errorf("unable to parse bind %q", bind)
 	}
 

--- a/types/bind_test.go
+++ b/types/bind_test.go
@@ -79,6 +79,16 @@ func TestNewBindFromString(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "trailing_colon_empty_mode",
+			bind: "/host/path:/container/path:",
+			want: &Bind{
+				src:  "/host/path",
+				dst:  "/container/path",
+				mode: "",
+			},
+			wantErr: false,
+		},
+		{
 			name: "no_mode",
 			bind: "/host/path:/container/path",
 			want: &Bind{
@@ -96,7 +106,8 @@ func TestNewBindFromString(t *testing.T) {
 				dst:  "/container/path",
 				mode: "",
 			},
-			wantErr: false,
+			wantErr: true,
+			errStr:  "bind \"/container/path\" looks like an anonymous volume target, please use the volumes stanza instead",
 		},
 		{
 			name: "empty_string",
@@ -106,7 +117,8 @@ func TestNewBindFromString(t *testing.T) {
 				dst:  "",
 				mode: "",
 			},
-			wantErr: false,
+			wantErr: true,
+			errStr:  "unable to parse bind",
 		},
 		{
 			name:    "too_many_colons",

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -33,6 +33,8 @@ type NodeDefinition struct {
 	Exec []string `yaml:"exec,omitempty"`
 	// list of bind mount compatible strings
 	Binds []string `yaml:"binds,omitempty"`
+	// list of volume mount compatible strings
+	Volumes []string `yaml:"volumes,omitempty"`
 	// list of devices to map in the container
 	Devices []string `yaml:"devices,omitempty"`
 	// List of capabilities to add for the container

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -167,6 +167,10 @@ var topologyTestSet = map[string]struct {
 					"x:z",
 					"m:n", // overridden by node
 				},
+				Volumes: []string{
+					"default-vol:/app/default",
+					"shared-vol:/app/shared", // overriden by node
+				},
 			},
 			Kinds: map[string]*NodeDefinition{
 				"nokia_srlinux": {
@@ -184,6 +188,10 @@ var topologyTestSet = map[string]struct {
 					Binds: []string{
 						"a:b",
 						"c:d",
+					},
+					Volumes: []string{
+						"kind-vol:/app/kind",
+						"db-vol:/app/data",
 					},
 					Ports: []string{
 						"80:8080",
@@ -211,6 +219,10 @@ var topologyTestSet = map[string]struct {
 						"e:f",
 						"newm:n",
 					},
+					Volumes: []string{
+						"node-vol:/app/node",
+						"override-vol:/app/shared", // overrides defaults
+					},
 				},
 			},
 		},
@@ -235,6 +247,13 @@ var topologyTestSet = map[string]struct {
 					"c:d",
 					"x:z",
 					"newm:n",
+				},
+				Volumes: []string{
+					"node-vol:/app/node",
+					"kind-vol:/app/kind",
+					"db-vol:/app/data",
+					"default-vol:/app/default",
+					"override-vol:/app/shared",
 				},
 				Ports: []string{
 					"80:8080",
@@ -892,6 +911,20 @@ func TestGetNodeBinds(t *testing.T) {
 				item.want["node1"].Binds,
 				diff,
 			)
+		}
+	}
+}
+
+func TestGetNodeVolumes(t *testing.T) {
+	for _, item := range topologyTestSet {
+		volumes, _ := item.input.GetNodeVolumes("node1")
+
+		// sort the slices so we can compare them
+		slices.Sort(volumes)
+		slices.Sort(item.want["node1"].Volumes)
+
+		if d := cmp.Diff(volumes, item.want["node1"].Volumes); d != "" {
+			t.Fatalf("Volumes resolve failed.\nGot: %q\nWant: %q\nDiff\n%s", volumes, item.want["node1"].Volumes, d)
 		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -151,6 +151,8 @@ type NodeConfig struct {
 	Env  map[string]string `json:"env,omitempty"`
 	// Bind mounts strings (src:dest:options).
 	Binds []string `json:"binds,omitempty"`
+	// Volume mounts strings (name:dest:options).
+	Volumes []string `json:"volumes,omitempty"`
 	// Devices to map in the container
 	Devices []string `json:"devices,omitempty"`
 	// Capabilities required by the container (if not run in privileged mode)

--- a/types/volume.go
+++ b/types/volume.go
@@ -1,0 +1,110 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Volume represents a volume mount specification in short syntax form.
+// It mirrors the bind syntax but is limited to Docker-managed volumes.
+type Volume struct {
+	src  string
+	dst  string
+	mode string
+}
+
+// NewVolumeFromString parses a volume specification in the short syntax:
+// - "/container/path"
+// - "name:/container/path"
+// - "name:/container/path:options"
+func NewVolumeFromString(volume string) (*Volume, error) {
+	v := &Volume{}
+
+	split := strings.Split(volume, ":")
+
+	if len(split) == 1 && split[0] != "" {
+		// Anonymous volume, only destination is provided.
+		v.dst = split[0]
+		return v, nil
+	}
+
+	if strings.HasPrefix(split[0], "/") {
+		return nil, fmt.Errorf("volume %q references a host path; please use the binds stanza instead", volume)
+	} else if len(split) < 2 || len(split) > 3 {
+		return nil, fmt.Errorf("unable to parse volume %q", volume)
+	}
+
+	v.src = split[0]
+	v.dst = split[1]
+
+	if len(split) == 3 { //nolint: mnd
+		v.mode = split[2]
+	}
+
+	return v, nil
+}
+
+// Src returns the source (named volume) portion.
+func (v *Volume) Src() string {
+	return v.src
+}
+
+// Dst returns the destination path inside the container.
+func (v *Volume) Dst() string {
+	return v.dst
+}
+
+// Mode returns the raw option string.
+func (v *Volume) Mode() string {
+	return v.mode
+}
+
+// Options returns the option list split by comma.
+func (v *Volume) Options() []string {
+	if v.mode == "" {
+		return nil
+	}
+	return strings.Split(v.mode, ",")
+}
+
+// String renders the volume back to its short syntax form.
+func (v *Volume) String() string {
+	s := v.dst
+
+	if v.src != "" {
+		s = v.src + ":" + s
+	}
+
+	if v.mode != "" {
+		s += ":" + v.mode
+	}
+
+	return s
+}
+
+// VolumeOptions captures parsed options from the short syntax.
+type VolumeOptions struct {
+	ReadOnly bool
+	NoCopy   bool
+	Unknown  []string
+}
+
+// ParseVolumeOptions parses volume options from the short syntax.
+func ParseVolumeOptions(opts []string) VolumeOptions {
+	parsed := VolumeOptions{}
+
+	for _, opt := range opts {
+		switch opt {
+		case "ro":
+			parsed.ReadOnly = true
+		case "rw", "":
+			// ignore
+		case "nocopy", "volume-nocopy":
+			parsed.NoCopy = true
+		default:
+			parsed.Unknown = append(parsed.Unknown, opt)
+		}
+	}
+
+	return parsed
+}

--- a/types/volume_test.go
+++ b/types/volume_test.go
@@ -1,0 +1,309 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewVolumeFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		volume  string
+		want    *Volume
+		wantErr bool
+		errStr  string
+	}{
+		{
+			name:   "full_volume",
+			volume: "namedvol:/container/path:ro,nocopy",
+			want: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "ro,nocopy",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "no_mode",
+			volume: "namedvol:/container/path",
+			want: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "anonymous_volume",
+			volume: "/container/path",
+			want: &Volume{
+				src:  "",
+				dst:  "/container/path",
+				mode: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "trailing_colon_empty_mode",
+			volume: "namedvol:/container/path:",
+			want: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "host_path_error",
+			volume:  "/host/path:/container/path",
+			wantErr: true,
+			errStr:  "references a host path; please use the binds stanza instead",
+		},
+		{
+			name:    "empty_string",
+			volume:  "",
+			wantErr: true,
+			errStr:  "unable to parse volume",
+		},
+		{
+			name:    "too_many_colons",
+			volume:  "namedvol:/container:ro:extra",
+			wantErr: true,
+			errStr:  "unable to parse volume",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewVolumeFromString(tt.volume)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewVolumeFromString() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr && err != nil {
+				if tt.errStr != "" && !strings.Contains(err.Error(), tt.errStr) {
+					t.Fatalf("expected error containing %q, got %q", tt.errStr, err.Error())
+				}
+
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(Volume{})); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestVolume_Accessors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		volume   *Volume
+		wantSrc  string
+		wantDst  string
+		wantMode string
+	}{
+		{
+			name: "all_fields",
+			volume: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "ro",
+			},
+			wantSrc:  "namedvol",
+			wantDst:  "/container/path",
+			wantMode: "ro",
+		},
+		{
+			name: "empty_fields",
+			volume: &Volume{
+				src:  "",
+				dst:  "",
+				mode: "",
+			},
+			wantSrc:  "",
+			wantDst:  "",
+			wantMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.volume.Src(); got != tt.wantSrc {
+				t.Errorf("Volume.Src() = %v, want %v", got, tt.wantSrc)
+			}
+
+			if got := tt.volume.Dst(); got != tt.wantDst {
+				t.Errorf("Volume.Dst() = %v, want %v", got, tt.wantDst)
+			}
+
+			if got := tt.volume.Mode(); got != tt.wantMode {
+				t.Errorf("Volume.Mode() = %v, want %v", got, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestVolume_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		volume *Volume
+		want   string
+	}{
+		{
+			name: "full_volume",
+			volume: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "ro,nocopy",
+			},
+			want: "namedvol:/container/path:ro,nocopy",
+		},
+		{
+			name: "no_mode",
+			volume: &Volume{
+				src:  "namedvol",
+				dst:  "/container/path",
+				mode: "",
+			},
+			want: "namedvol:/container/path",
+		},
+		{
+			name: "anonymous",
+			volume: &Volume{
+				src:  "",
+				dst:  "/container/path",
+				mode: "",
+			},
+			want: "/container/path",
+		},
+		{
+			name: "anonymous_with_mode",
+			volume: &Volume{
+				src:  "",
+				dst:  "/container/path",
+				mode: "ro",
+			},
+			want: "/container/path:ro",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.volume.String()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestVolume_Options(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		volume *Volume
+		want   []string
+	}{
+		{
+			name: "no_mode",
+			volume: &Volume{
+				mode: "",
+			},
+			want: nil,
+		},
+		{
+			name: "single_option",
+			volume: &Volume{
+				mode: "ro",
+			},
+			want: []string{"ro"},
+		},
+		{
+			name: "multiple_options",
+			volume: &Volume{
+				mode: "ro,nocopy",
+			},
+			want: []string{"ro", "nocopy"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if diff := cmp.Diff(tt.want, tt.volume.Options()); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseVolumeOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts []string
+		want VolumeOptions
+	}{
+		{
+			name: "read_only_with_nocopy",
+			opts: []string{"ro", "nocopy"},
+			want: VolumeOptions{
+				ReadOnly: true,
+				NoCopy:   true,
+				Unknown:  nil,
+			},
+		},
+		{
+			name: "ignore_rw_and_empty",
+			opts: []string{"rw", "", "ro"},
+			want: VolumeOptions{
+				ReadOnly: true,
+				NoCopy:   false,
+				Unknown:  nil,
+			},
+		},
+		{
+			name: "unknown_options",
+			opts: []string{"volume-nocopy", "z", "user:1000"},
+			want: VolumeOptions{
+				ReadOnly: false,
+				NoCopy:   true,
+				Unknown:  []string{"z", "user:1000"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseVolumeOptions(tt.opts)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Containerlab passes all strings from the node "binds" property to Docker via the HostConfig.Binds field. This API supports anonymous volumes and the container does correctly start up with an new anonymous volume attached. But the volume itself is missing the "Name" attribute for some reason (docker inspect). This makes it impossible to then access the volume from other containers, like with `docker run --volumes-from <existing-container> ...`. An anonymous volume created with the new Mounts spec is for all intents and purposes equivalent to one created with Binds, except it has the "Name" attribute set to its random ID.

This has worked in the past, so maybe there is a regression in Docker? Anyway by fixing it here we can ensure it will work for all Docker versions while maintaining compatibility with existing containerlab topologies.

As a side note, while I was reviewing the Docker documentation, I noticed my change to add anonymous volume support to containerlab node `binds` in #1853 mixes up two distinct concepts: [Bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) and [Volumes](https://docs.docker.com/engine/storage/volumes/). In hindsight this feels like a mistake and volumes would be better handled in a new `volumes` node field. This would also align the syntax with docker-compose. What is the design guideline here?