### PR TITLE
schema: Update pattern to support integrated SR OS types

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -380,7 +380,7 @@
                                         ]
                                     },
                                     {
-                                        "pattern": "cp:.+"
+                                        "pattern": "^((lc|cp):\\s)?((cpu|ram|max_nics)=\\d+|slot=[A-Z]|chassis=[^\\s]+|card=.*|\\s)+$"
                                     }
                                 ]
                             }


### PR DESCRIPTION
This PR fixes integrated SR OS type lines marked as invalid:

![image](https://github.com/user-attachments/assets/e469cb52-c229-4786-bb30-22e8fc82f849)

Fixes #2616 