### PR TITLE
Fix "clab config not persistent after redeploy" #1685

### DIFF
--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -363,12 +363,12 @@ func (d *DefaultNode) GenerateConfig(dst, t string) error {
 	}
 
 	if d.Cfg.SuppressStartupConfig {
-		log.Infof("Startup config generation for '%s' node suppressed", d.Cfg.ShortName)
+		log.Info("Startup config generation suppressed", "node", d.Cfg.ShortName)
 		return nil
 	}
 
 	if !d.Cfg.EnforceStartupConfig && utils.FileExists(dst) {
-		log.Debug("Existing config found for '%s'", d.Cfg.ShortName, "path", dst)
+		log.Debug("Existing config found", "node", d.Cfg.ShortName, "path", dst)
 		return nil
 	} else {
 
@@ -378,7 +378,7 @@ func (d *DefaultNode) GenerateConfig(dst, t string) error {
 		if err != nil {
 			return err
 		}
-		log.Debugf("node '%s' generated config: %s", d.Cfg.ShortName, cfgBuf.String())
+		log.Debug("Generated config", "node", d.Cfg.ShortName, "content", cfgBuf.String())
 
 		f, err := os.Create(dst)
 		if err != nil {

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -350,41 +350,49 @@ func (d *DefaultNode) VerifyStartupConfig(topoDir string) error {
 
 // GenerateConfig generates configuration for the nodes
 // out of the template `t` based on the node configuration and saves the result to dst.
+// If the config file is already present in the node dir
+// we do not regenerate the config unless EnforceStartupConfig is explicitly set to true and startup-config points to a file
+// this will persist the changes that users make to a running config when booted from some startup config
 func (d *DefaultNode) GenerateConfig(dst, t string) error {
-	// If the config file is already present in the node dir
-	// we do not regenerate the config unless EnforceStartupConfig is explicitly set to true and startup-config points to a file
-	// this will persist the changes that users make to a running config when booted from some startup config
+	// Check for incompatible options
+	if d.Cfg.EnforceStartupConfig && d.Cfg.SuppressStartupConfig {
+		return ErrIncompatibleOptions
+	}
+	if d.Cfg.EnforceStartupConfig && d.Cfg.StartupConfig == "" {
+		return ErrNoStartupConfig
+	}
+
 	if d.Cfg.SuppressStartupConfig {
 		log.Infof("Startup config generation for '%s' node suppressed", d.Cfg.ShortName)
 		return nil
-	} else if d.Cfg.EnforceStartupConfig {
-		log.Infof("Startup config for '%s' node enforced: '%s'", d.Cfg.ShortName, dst)
-		// continue with config generation
-	} else if utils.FileExists(dst) && d.Cfg.StartupConfig == "" {
-		log.Infof("config file '%s' for node '%s' already exists and will not be generated/reset", dst, d.Cfg.ShortName)
+	}
+
+	if !d.Cfg.EnforceStartupConfig && utils.FileExists(dst) {
+		log.Debug("Existing config found for '%s'", d.Cfg.ShortName, "path", dst)
 		return nil
+	} else {
+
+		log.Debug("Generating config", "node", d.Cfg.ShortName, "file", d.Cfg.StartupConfig)
+
+		cfgBuf, err := utils.SubstituteEnvsAndTemplate(strings.NewReader(t), d.Cfg)
+		if err != nil {
+			return err
+		}
+		log.Debugf("node '%s' generated config: %s", d.Cfg.ShortName, cfgBuf.String())
+
+		f, err := os.Create(dst)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = f.Write(cfgBuf.Bytes())
+		if err != nil {
+			return err
+		}
 	}
 
-	log.Debug("Generating config", "node", d.Cfg.ShortName, "file", d.Cfg.StartupConfig)
-
-	cfgBuf, err := utils.SubstituteEnvsAndTemplate(strings.NewReader(t), d.Cfg)
-	if err != nil {
-		return err
-	}
-	log.Debugf("node '%s' generated config: %s", d.Cfg.ShortName, cfgBuf.String())
-
-	f, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(cfgBuf.Bytes())
-	if err != nil {
-		f.Close()
-		return err
-	}
-
-	return f.Close()
+	return nil
 }
 
 // NodeOverwrites is an interface that every node implements.

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -325,7 +325,7 @@ func TestInterfacesAliases(t *testing.T) { // skipcq: GO-R1005
 	}
 
 	for name, tc := range tests {
-		t.Run(name, func(tt *testing.T) {
+		t.Run(name, func(*testing.T) {
 			foundError := false
 			tc.node.OverwriteNode = tc.node
 			tc.node.InterfaceMappedPrefix = "eth"

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,54 +14,136 @@ import (
 )
 
 func TestGenerateConfigs(t *testing.T) {
+	defCfg := "default config"
+	oldCfg := "old config"
+	newCfg := "new config"
+
 	tests := map[string]struct {
-		node   *DefaultNode
-		err    error
-		exists bool
-		out    string
+		cfg        *types.NodeConfig
+		err        error
+		preExists  bool
+		postExists bool
+		template   string
+		out        string
 	}{
-		"suppress-true": {
-			node: &DefaultNode{
-				Cfg: &types.NodeConfig{
-					SuppressStartupConfig: true,
-					ShortName:             "suppress",
-				},
+		"suppress-true-first-start": {
+			cfg: &types.NodeConfig{
+				SuppressStartupConfig: true,
 			},
-			err:    nil,
-			exists: false,
-			out:    "",
+			err:        nil,
+			preExists:  false,
+			postExists: false,
+			template:   defCfg,
 		},
-		"suppress-false": {
-			node: &DefaultNode{
-				Cfg: &types.NodeConfig{
-					SuppressStartupConfig: false,
-					ShortName:             "configure",
-				},
+		"suppress-true-existing-lab": {
+			cfg: &types.NodeConfig{
+				SuppressStartupConfig: true,
 			},
-			err:    nil,
-			exists: true,
-			out:    "foo",
+			err:        nil,
+			preExists:  true,
+			postExists: true,
+			out:        oldCfg,
+			template:   defCfg,
+		},
+		"suppress-false-first-start": {
+			cfg: &types.NodeConfig{
+				SuppressStartupConfig: false,
+			},
+			err:        nil,
+			preExists:  false,
+			postExists: true,
+			out:        defCfg,
+			template:   defCfg,
+		},
+		"suppress-false-existing-lab": {
+			cfg: &types.NodeConfig{
+				SuppressStartupConfig: false,
+			},
+			err:        nil,
+			preExists:  true,
+			postExists: true,
+			out:        oldCfg,
+			template:   defCfg,
+		},
+		"startup-config-first-start": {
+			cfg: &types.NodeConfig{
+				StartupConfig: "other",
+			},
+			err:        nil,
+			preExists:  false,
+			postExists: true,
+			out:        newCfg,
+			template:   newCfg,
+		},
+		"startup-config-existing-lab": {
+			cfg: &types.NodeConfig{
+				StartupConfig: "other",
+			},
+			err:        nil,
+			preExists:  true,
+			postExists: true,
+			out:        oldCfg,
+			template:   newCfg,
+		},
+		"enforce-startup-config-first-start": {
+			cfg: &types.NodeConfig{
+				StartupConfig:        "other",
+				EnforceStartupConfig: true,
+			},
+			err:        nil,
+			preExists:  false,
+			postExists: true,
+			out:        newCfg,
+			template:   newCfg,
+		},
+		"enforce-startup-config-existing-lab": {
+			cfg: &types.NodeConfig{
+				StartupConfig:        "other",
+				EnforceStartupConfig: true,
+			},
+			err:        nil,
+			preExists:  true,
+			postExists: true,
+			out:        newCfg,
+			template:   newCfg,
+		},
+		"enforce-startup-config-no-startup": {
+			cfg: &types.NodeConfig{
+				EnforceStartupConfig: true,
+			},
+			err: ErrNoStartupConfig,
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(tt *testing.T) {
+			node := &DefaultNode{Cfg: tc.cfg}
 			dstFolder := tt.TempDir()
 			dstFile := filepath.Join(dstFolder, "config")
-			err := tc.node.GenerateConfig(dstFile, "foo")
-			if err != tc.err {
-				t.Errorf("got %v, wanted %v", err, tc.err)
+
+			if tc.preExists {
+				err := os.WriteFile(dstFile, []byte(oldCfg), 0666)
+				if err != nil {
+					tt.Errorf("Could not write existing config: %v", err)
+				}
 			}
-			if tc.exists {
+
+			err := node.GenerateConfig(dstFile, tc.template)
+			if tc.err != nil {
+				if !errors.Is(err, tc.err) {
+					tt.Errorf("got %v, wanted %v", err, tc.err)
+				}
+			}
+			if tc.postExists {
 				cnt, err := os.ReadFile(dstFile)
 				if err != nil {
-					t.Fatal(err)
+					tt.Fatal(err)
 				}
 				if string(cnt) != tc.out {
-					t.Errorf("got %v, wanted %v", string(cnt), tc.out)
+					tt.Errorf("got %v, wanted %v", string(cnt), tc.out)
 				}
 			} else {
 				if _, err := os.Stat(dstFile); err == nil {
-					t.Errorf("config file created")
+					tt.Errorf("config file created")
 				}
 			}
 		})

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -118,9 +118,7 @@ func TestGenerateConfigs(t *testing.T) {
 				EnforceStartupConfig:  true,
 				SuppressStartupConfig: true,
 			},
-			err: ErrIncompatibleOptions{
-				Options: []string{"enforce-startup-config", "suppress-startup-config"},
-			},
+			err: ErrIncompatibleOptions,
 		},
 	}
 	for name, tc := range tests {
@@ -139,7 +137,7 @@ func TestGenerateConfigs(t *testing.T) {
 			err := node.GenerateConfig(dstFile, tc.template)
 			if tc.err != nil {
 				if !errors.Is(err, tc.err) {
-					tt.Errorf("got %v, wanted %v", err, tc.err)
+					tt.Errorf("got: %v, wanted: %v", err, tc.err)
 				}
 			}
 			if tc.postExists {

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -113,6 +113,15 @@ func TestGenerateConfigs(t *testing.T) {
 			},
 			err: ErrNoStartupConfig,
 		},
+		"enforce-and-suppress-startup-config": {
+			cfg: &types.NodeConfig{
+				EnforceStartupConfig:  true,
+				SuppressStartupConfig: true,
+			},
+			err: ErrIncompatibleOptions{
+				Options: []string{"enforce-startup-config", "suppress-startup-config"},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(tt *testing.T) {

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/srl-labs/containerlab/cert"
@@ -38,10 +39,31 @@ var (
 	ErrCommandExecError = errors.New("command execution error")
 	// ErrContainersNotFound indicated that for a given node no containers where found in the runtime.
 	ErrContainersNotFound = errors.New("containers not found")
-
-	// ErrNoStartupConfig
+	// ErrNoStartupConfig indicates that we are supposed to enforce a startup config but none are provided
 	ErrNoStartupConfig = errors.New("no startup-config provided")
 )
+
+// ErrIncompatibleOptions enforce-startup-config and suppress-startup-config are mutually exclusive
+type ErrIncompatibleOptions struct {
+	Options []string
+}
+
+func (e ErrIncompatibleOptions) Error() string {
+	var sb strings.Builder
+	l := len(e.Options)
+	if l > 2 {
+		for i := 0; i < l-1; i++ {
+			sb.WriteString(e.Options[i])
+			sb.WriteString(", ")
+		}
+	} else {
+		sb.WriteString(e.Options[0])
+		sb.WriteString(" ")
+	}
+	sb.WriteString("and ")
+	sb.WriteString(e.Options[l-1])
+	return fmt.Sprintf("the options %s are incompatible", sb.String())
+}
 
 // SetNonDefaultRuntimePerKind sets a non default runtime for kinds that requires that (see cvx).
 func SetNonDefaultRuntimePerKind(kindnames []string, runtime string) error {

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/srl-labs/containerlab/cert"
@@ -41,29 +40,9 @@ var (
 	ErrContainersNotFound = errors.New("containers not found")
 	// ErrNoStartupConfig indicates that we are supposed to enforce a startup config but none are provided
 	ErrNoStartupConfig = errors.New("no startup-config provided")
+	// ErrIncompatibleOptions for options that are mutually exclusive
+	ErrIncompatibleOptions = errors.New("incompatible options")
 )
-
-// ErrIncompatibleOptions enforce-startup-config and suppress-startup-config are mutually exclusive
-type ErrIncompatibleOptions struct {
-	Options []string
-}
-
-func (e ErrIncompatibleOptions) Error() string {
-	var sb strings.Builder
-	l := len(e.Options)
-	if l > 2 {
-		for i := 0; i < l-1; i++ {
-			sb.WriteString(e.Options[i])
-			sb.WriteString(", ")
-		}
-	} else {
-		sb.WriteString(e.Options[0])
-		sb.WriteString(" ")
-	}
-	sb.WriteString("and ")
-	sb.WriteString(e.Options[l-1])
-	return fmt.Sprintf("the options %s are incompatible", sb.String())
-}
 
 // SetNonDefaultRuntimePerKind sets a non default runtime for kinds that requires that (see cvx).
 func SetNonDefaultRuntimePerKind(kindnames []string, runtime string) error {

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -38,6 +38,9 @@ var (
 	ErrCommandExecError = errors.New("command execution error")
 	// ErrContainersNotFound indicated that for a given node no containers where found in the runtime.
 	ErrContainersNotFound = errors.New("containers not found")
+
+	// ErrNoStartupConfig
+	ErrNoStartupConfig = errors.New("no startup-config provided")
 )
 
 // SetNonDefaultRuntimePerKind sets a non default runtime for kinds that requires that (see cvx).


### PR DESCRIPTION
I too experienced the issue in #1685. The tests in the default_node_tests were limited to only testing the suppress option.

According to the docs it's implied if `startup-config` is defined, but `enforce-startup-config!=true` then the config saved by the node should be used unless `--cleanup` or `--reconfigure` is used. 

This makes sense because you could provide a lab with predefined configurations to nodes to share with others. But you may want to stop the lab and have any changes you've been experimenting with remain for when you next start it.

I added tests to test other options like the one above, and additionally the currently undefined option where you have `enforce-startup-config=true` but don't have a `startup-config` defined, which I think should result in an error.