### PR TITLE
cmd/destroy: Fix tools containers not being removed when using --all

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -246,26 +246,26 @@ func removeToolContainers(ctx context.Context, rt runtime.ContainerRuntime, labN
 	var errs []error
 	containers, err := rt.ListContainers(ctx, toolFilter)
 	if err != nil {
-		log.Errorf("Failed to list %s containers: %v", toolType, err)
+		log.Error("Failed to list tool containers", "tool", toolType, "error", err)
 		errs = append(errs, err)
 		return errs
 	}
 
 	if len(containers) == 0 {
-		log.Debugf("No %s containers found for lab %s", toolType, labName)
+		log.Debug("No tool containers found for lab", "tool", toolType, "lab", labName)
 		return nil
 	}
 
-	log.Infof("Found %d %s containers associated with lab %s", len(containers), toolType, labName)
+	log.Info("Found tool containers associated with a lab", "tool", toolType, "lab", labName, "count", len(containers))
 
 	for _, container := range containers {
 		containerName := strings.TrimPrefix(container.Names[0], "/")
-		log.Infof("Removing %s container: %s", toolType, containerName)
+		log.Info("Removing tool container", "tool", toolType, "container", containerName)
 		if err := rt.DeleteContainer(ctx, containerName); err != nil {
-			log.Warnf("Failed to remove %s container %s: %v", toolType, containerName, err)
+			log.Warn("Failed to remove tool container", "tool", toolType, "container", containerName, "error", err)
 			errs = append(errs, err)
 		} else {
-			log.Infof("%s container %s removed successfully", toolType, containerName)
+			log.Info("Tool container removed successfully", "tool", toolType, "container", containerName)
 		}
 	}
 

--- a/cmd/tool_gotty.go
+++ b/cmd/tool_gotty.go
@@ -24,6 +24,8 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
+const gotty string = "gotty"
+
 // Configuration variables for the GoTTY commands
 var (
 	gottyLabName       string
@@ -106,7 +108,7 @@ func init() {
 
 // gottyCmd represents the gotty command container
 var gottyCmd = &cobra.Command{
-	Use:   "gotty",
+	Use:   gotty,
 	Short: "GoTTY web terminal operations",
 	Long:  "Attach or detach GoTTY web terminal containers to labs",
 }
@@ -266,7 +268,7 @@ var gottyAttachCmd = &cobra.Command{
 		if owner == "" {
 			owner = utils.GetOwner()
 		}
-		labelsMap := common.CreateLabelsMap(labName, gottyContainerName, owner, "gotty")
+		labelsMap := common.CreateLabelsMap(labName, gottyContainerName, owner, gotty)
 
 		// Create and start GoTTY container
 		log.Infof("Creating GoTTY container %s on network '%s'", gottyContainerName, networkName)
@@ -386,7 +388,7 @@ var gottyListCmd = &cobra.Command{
 				FilterType: "label",
 				Field:      clabels.ToolType,
 				Operator:   "=",
-				Match:      "gotty",
+				Match:      gotty,
 			},
 		}
 
@@ -555,7 +557,7 @@ var gottyReattachCmd = &cobra.Command{
 		if owner == "" {
 			owner = utils.GetOwner()
 		}
-		labelsMap := common.CreateLabelsMap(labName, gottyContainerName, owner, "gotty")
+		labelsMap := common.CreateLabelsMap(labName, gottyContainerName, owner, gotty)
 
 		// Create and start GoTTY container
 		log.Infof("Creating new GoTTY container %s on network '%s'", gottyContainerName, networkName)

--- a/cmd/tool_sshx.go
+++ b/cmd/tool_sshx.go
@@ -27,6 +27,8 @@ import (
 	"github.com/srl-labs/containerlab/utils"
 )
 
+const sshx string = "sshx"
+
 // Configuration variables for the SSHX commands
 var (
 	sshxLabName       string
@@ -98,7 +100,7 @@ func init() {
 
 // sshxCmd represents the sshx command container
 var sshxCmd = &cobra.Command{
-	Use:   "sshx",
+	Use:   sshx,
 	Short: "SSHX terminal sharing operations",
 	Long:  "Attach or detach SSHX terminal sharing containers to labs",
 }
@@ -259,7 +261,7 @@ var sshxAttachCmd = &cobra.Command{
 		if owner == "" {
 			owner = utils.GetOwner()
 		}
-		labelsMap := common.CreateLabelsMap(labName, sshxContainerName, owner, "sshx")
+		labelsMap := common.CreateLabelsMap(labName, sshxContainerName, owner, sshx)
 
 		// Create and start SSHX container
 		log.Infof("Creating SSHX container %s on network '%s'", sshxContainerName, networkName)
@@ -380,7 +382,7 @@ var sshxListCmd = &cobra.Command{
 				FilterType: "label",
 				Field:      clabels.ToolType,
 				Operator:   "=",
-				Match:      "sshx",
+				Match:      sshx,
 			},
 		}
 
@@ -533,7 +535,7 @@ var sshxReattachCmd = &cobra.Command{
 		if owner == "" {
 			owner = utils.GetOwner()
 		}
-		labelsMap := common.CreateLabelsMap(labName, sshxContainerName, owner, "sshx")
+		labelsMap := common.CreateLabelsMap(labName, sshxContainerName, owner, sshx)
 
 		// Create and start SSHX container
 		log.Infof("Creating new SSHX container %s on network '%s'", sshxContainerName, networkName)


### PR DESCRIPTION
This PR fixes #2637 by removing the !all condition from the tool container removal part of destroy.