### PR TITLE
store backup files in temp dir

### DIFF
--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -177,6 +177,7 @@ func (*TopoPaths) ClabTmpDir() string {
 	if !utils.DirExists(clabTmpDir) {
 		utils.CreateDirectory(clabTmpDir, 0o755)
 	}
+
 	return clabTmpDir
 }
 
@@ -185,10 +186,9 @@ func (*TopoPaths) ClabTmpDir() string {
 func (t *TopoPaths) ClabBakDir() string {
 	d := filepath.Join(t.ClabTmpDir(), backupDirName)
 	if !utils.DirExists(d) {
-		if err := utils.CreateDirectory(d, 0o755); err != nil {
-			fmt.Printf("Error creating directory %s: %v\n", d, err)
-		}
+		utils.CreateDirectory(d, 0o755)
 	}
+
 	return d
 }
 

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -203,11 +203,14 @@ func (t *TopoPaths) TopologyFilenameBase() string {
 	return filepath.Base(t.topoFile)
 }
 
+// TopologyFileExt returns the file extension of the topology file, including the dot.
+func (t *TopoPaths) TopologyFileExt() string {
+	return filepath.Ext(t.TopologyFilenameBase())
+}
+
 // TopologyFilenameWithoutExt returns the topology file name without the file extension.
 func (t *TopoPaths) TopologyFilenameWithoutExt() string {
-	name := t.TopologyFilenameBase()
-
-	return name[:len(name)-len(filepath.Ext(name))]
+	return strings.TrimSuffix(t.TopologyFilenameBase(), t.TopologyFileExt())
 }
 
 func (t *TopoPaths) TopologyFileIsSet() bool {

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -219,7 +219,7 @@ func (t *TopoPaths) TopologyFileIsSet() bool {
 	return t.topoFile != ""
 }
 
-// TopologyBakFileAbsPath returns the backup topology file name in ~/.clab with a timestamp prefix.
+// TopologyBakFileAbsPath returns the backup topology file name in /tmp/.clab directory with a timestamp prefix.
 func (t *TopoPaths) TopologyBakFileAbsPath() string {
 	ts := time.Now().Format("060102_150405") // YYMMDD_HHMMSS
 	return filepath.Join(t.ClabBakDir(), ts+"_"+t.TopologyFilenameBase())

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -222,7 +222,7 @@ func (t *TopoPaths) TopologyFileIsSet() bool {
 // TopologyBakFileAbsPath returns the backup topology file name in ~/.clab with a timestamp prefix.
 func (t *TopoPaths) TopologyBakFileAbsPath() string {
 	ts := time.Now().Format("060102_150405") // YYMMDD_HHMMSS
-	return path.Join(t.ClabBakDir(), ts+"_"+t.TopologyFilenameBase())
+	return filepath.Join(t.ClabBakDir(), ts+"_"+t.TopologyFilenameBase())
 }
 
 // TopologyFileDir returns the abs path to the topology file directory.

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/srl-labs/containerlab/utils"
 )
@@ -19,8 +20,7 @@ const (
 	caDir                         = "ca"
 	graph                         = "graph"
 	labDirPrefix                  = "clab-"
-	backupFileSuffix              = ".bak"
-	backupFilePrefix              = "."
+	backupDirName                 = "bak"
 	CertFileSuffix                = ".pem"
 	KeyFileSuffix                 = ".key"
 	CSRFileSuffix                 = ".csr"
@@ -180,6 +180,16 @@ func (*TopoPaths) ClabTmpDir() string {
 	return clabTmpDir
 }
 
+// ClabBakDir returns the absolute path to the directory where clab stores backup files.
+// Creates the directory if it does not exist.
+func (t *TopoPaths) ClabBakDir() string {
+	d := filepath.Join(t.ClabTmpDir(), backupDirName)
+	if !utils.DirExists(d) {
+		utils.CreateDirectory(d, 0o755)
+	}
+	return d
+}
+
 // StartupConfigDownloadFileAbsPath returns the absolute path to the startup-config file
 // when it is downloaded from a remote location to the clab temp directory.
 func (t *TopoPaths) StartupConfigDownloadFileAbsPath(node, postfix string) string {
@@ -207,9 +217,10 @@ func (t *TopoPaths) TopologyFileIsSet() bool {
 	return t.topoFile != ""
 }
 
-// TopologyBakFileAbsPath returns the backup topology file name.
+// TopologyBakFileAbsPath returns the backup topology file name in ~/.clab with a timestamp prefix.
 func (t *TopoPaths) TopologyBakFileAbsPath() string {
-	return path.Join(t.TopologyFileDir(), backupFilePrefix+t.TopologyFilenameBase()+backupFileSuffix)
+	ts := time.Now().Format("060102_150405") // YYMMDD_HHMMSS
+	return path.Join(t.ClabBakDir(), ts+"_"+t.TopologyFilenameBase())
 }
 
 // TopologyFileDir returns the abs path to the topology file directory.

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -87,7 +86,7 @@ func (t *TopoPaths) SetLabDirByPrefix(topologyName string) (err error) {
 		baseDir = t.TopologyFileDir()
 	}
 	// construct the path
-	t.labDir = path.Join(baseDir, labDirPrefix+topologyName)
+	t.labDir = filepath.Join(baseDir, labDirPrefix+topologyName)
 	return nil
 }
 
@@ -118,22 +117,22 @@ func (t *TopoPaths) SSHConfigPath() string {
 
 // TLSBaseDir returns the path of the TLS directory structure.
 func (t *TopoPaths) TLSBaseDir() string {
-	return path.Join(t.labDir, tlsDir)
+	return filepath.Join(t.labDir, tlsDir)
 }
 
 // NodeTLSDir returns the directory that contains the certificat data for the given node.
 func (t *TopoPaths) NodeTLSDir(nodename string) string {
-	return path.Join(t.TLSBaseDir(), nodename)
+	return filepath.Join(t.TLSBaseDir(), nodename)
 }
 
 // AuthorizedKeysFilename returns the path for the generated AuthorizedKeysFile.
 func (t *TopoPaths) AuthorizedKeysFilename() string {
-	return path.Join(t.labDir, authzKeysFileName)
+	return filepath.Join(t.labDir, authzKeysFileName)
 }
 
 // GraphDir returns the directory that takes the graphs.
 func (t *TopoPaths) GraphDir() string {
-	return path.Join(t.labDir, graph)
+	return filepath.Join(t.labDir, graph)
 }
 
 // GraphFilename returns the filename for a given graph file with the provided extension.
@@ -143,27 +142,27 @@ func (t *TopoPaths) GraphFilename(ext string) string {
 		ext = "." + ext
 	}
 
-	return path.Join(t.GraphDir(), t.TopologyFilenameWithoutExt()+ext)
+	return filepath.Join(t.GraphDir(), t.TopologyFilenameWithoutExt()+ext)
 }
 
 // NodeDir returns the directory in the labDir for the provided node.
 func (t *TopoPaths) NodeDir(nodeName string) string {
-	return path.Join(t.labDir, nodeName)
+	return filepath.Join(t.labDir, nodeName)
 }
 
 // TopoExportFile returns the path for the topology-export file.
 func (t *TopoPaths) TopoExportFile() string {
-	return path.Join(t.labDir, topologyExportDatFileName)
+	return filepath.Join(t.labDir, topologyExportDatFileName)
 }
 
 // AnsibleInventoryFileAbsPath returns the absolute path to the ansible-inventory file.
 func (t *TopoPaths) AnsibleInventoryFileAbsPath() string {
-	return path.Join(t.labDir, ansibleInventoryFileName)
+	return filepath.Join(t.labDir, ansibleInventoryFileName)
 }
 
 // NornirSimpleInventoryFileAbsPath returns the absolute path to the ansible-inventory file.
 func (t *TopoPaths) NornirSimpleInventoryFileAbsPath() string {
-	return path.Join(t.labDir, nornirSimpleInventoryFileName)
+	return filepath.Join(t.labDir, nornirSimpleInventoryFileName)
 }
 
 // TopologyFilenameAbsPath returns the absolute path to the topology file.
@@ -237,17 +236,17 @@ func (t *TopoPaths) TopologyLabDir() string {
 
 // NodeCertKeyAbsFilename returns the path to a key file for the given identifier.
 func (t *TopoPaths) NodeCertKeyAbsFilename(nodeName string) string {
-	return path.Join(t.NodeTLSDir(nodeName), nodeName+KeyFileSuffix)
+	return filepath.Join(t.NodeTLSDir(nodeName), nodeName+KeyFileSuffix)
 }
 
 // NodeCertAbsFilename returns the path to a cert file for the given identifier.
 func (t *TopoPaths) NodeCertAbsFilename(nodeName string) string {
-	return path.Join(t.NodeTLSDir(nodeName), nodeName+CertFileSuffix)
+	return filepath.Join(t.NodeTLSDir(nodeName), nodeName+CertFileSuffix)
 }
 
 // NodeCertCSRAbsFilename returns the path to a csr file for the given identifier.
 func (t *TopoPaths) NodeCertCSRAbsFilename(nodeName string) string {
-	return path.Join(t.NodeTLSDir(nodeName), nodeName+CSRFileSuffix)
+	return filepath.Join(t.NodeTLSDir(nodeName), nodeName+CSRFileSuffix)
 }
 
 // CaCertAbsFilename returns the path to the CA cert file.

--- a/types/topo_paths.go
+++ b/types/topo_paths.go
@@ -185,7 +185,9 @@ func (*TopoPaths) ClabTmpDir() string {
 func (t *TopoPaths) ClabBakDir() string {
 	d := filepath.Join(t.ClabTmpDir(), backupDirName)
 	if !utils.DirExists(d) {
-		utils.CreateDirectory(d, 0o755)
+		if err := utils.CreateDirectory(d, 0o755); err != nil {
+			fmt.Printf("Error creating directory %s: %v\n", d, err)
+		}
 	}
 	return d
 }


### PR DESCRIPTION
fix #2592 

The bak files are now stored in `/tmp/.clab/bak` directory and timestamped:

```
❯ ls -l /tmp/.clab/bak 
total 4
-rw-r--r-- 1 roman roman 253 Jul 13 22:05 250713_220527_topo-1353611672.clab.yml
```