### PR TITLE
fixes #2523 support for --name flag with clab destroy command

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -139,6 +139,9 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 		if keepMgmtNet {
 			opts = append(opts, clab.WithKeepMgmtNet())
 		}
+		if common.Name != "" {
+			opts = append(opts, clab.WithLabName(common.Name))
+		}
 
 		log.Debugf("going through extracted topos for destroy, got a topo file %v and generated opts list %+v", topo, opts)
 		nc, err := clab.NewContainerLab(opts...)
@@ -172,7 +175,6 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-
 		labs = append(labs, nc)
 	}
 


### PR DESCRIPTION
fix #2523 
Added --name flag support for destroy subcommand