### PR TITLE
Prompt a user when destroy `--all` is used with the interactive terminal

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -118,7 +118,28 @@ func destroyFn(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	log.Debugf("We got the following topos struct for destroy: %+v", topos)
+	log.Debugf("We got the following topologies for destroy: %+v", topos)
+
+	// Interactive confirmation prompt if running in a terminal
+	if utils.IsTerminal(os.Stdin.Fd()) {
+		fmt.Println("The following labs will be removed:")
+		idx := 1
+		for topo, labdir := range topos {
+			fmt.Printf("  %d. Topology: %s\n     Lab Dir: %s\n", idx, topo, labdir)
+			idx++
+		}
+		fmt.Print("Are you sure you want to remove ALL labs? Type 'y', to confirm or 'n' to abort: ")
+		var answer string
+		_, err := fmt.Scanln(&answer)
+		if err != nil {
+			return fmt.Errorf("failed to read user input: %v", err)
+		}
+		if answer != "y" && answer != "Y" && answer != "yes" {
+			fmt.Println("Aborted by user.")
+			return nil
+		}
+	}
+
 	for topo, labdir := range topos {
 		opts := []clab.ClabOption{
 			clab.WithTimeout(common.Timeout),

--- a/utils/term.go
+++ b/utils/term.go
@@ -1,0 +1,8 @@
+package utils
+
+import "golang.org/x/term"
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	return term.IsTerminal(int(fd))
+}


### PR DESCRIPTION
```
❯ dclab des -a -c
The following labs will be removed:
  1. Topology: /tmp/.clab/topo-3555600796.clab.yml
     Lab Dir: /tmp/.clab/clab-srl2
Are you sure you want to remove ALL labs? Type 'y', to confirm or 'n' to abort: y
```

fix #2490