### PR TITLE
Fix panic if per-stage command execution fails

### DIFF
--- a/clab/dependency_manager/dependency_node.go
+++ b/clab/dependency_manager/dependency_node.go
@@ -131,8 +131,9 @@ func (d *DependencyNode) runExecs(ctx context.Context, execPhase types.ExecPhase
 		}
 		if err != nil {
 			log.Errorf("error on exec in node %s for stage %s: %v", d.GetShortName(), stage, err)
+		} else {
+			execResultCollection.Add(hostname, execResult)
 		}
-		execResultCollection.Add(hostname, execResult)
 	}
 	execResultCollection.Log()
 }

--- a/nodes/host/host.go
+++ b/nodes/host/host.go
@@ -7,6 +7,7 @@ package host
 import (
 	"bytes"
 	"context"
+	"errors"
 
 	osexec "os/exec"
 
@@ -105,7 +106,8 @@ func RunExec(ctx context.Context, e *cExec.ExecCmd) (*cExec.ExecResult, error) {
 
 	// execute the command synchronously
 	err := cmd.Run()
-	if err != nil {
+	exerr := &osexec.ExitError{}
+	if err != nil && !errors.As(err, &exerr) {
 		return nil, err
 	}
 

--- a/nodes/host/host_test.go
+++ b/nodes/host/host_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package host_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/srl-labs/containerlab/clab/exec"
+	"github.com/srl-labs/containerlab/nodes/host"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunExec(t *testing.T) {
+	// Run a command that does succeed
+	out, err := host.RunExec(context.TODO(), exec.NewExecCmdFromSlice([]string{"true"}))
+	assert.NoError(t, err, "Exec should not have failed")
+	if assert.NotNil(t, out, "The exec result should not be nil") {
+		assert.EqualValues(t, 0, out.ReturnCode, "The return code should be 0")
+	}
+
+	// Run a command that does not succeed
+	out, err = host.RunExec(context.TODO(), exec.NewExecCmdFromSlice([]string{"false"}))
+	assert.NoError(t, err, "Exec should not have failed")
+	if assert.NotNil(t, out, "The exec result should not be nil") {
+		assert.EqualValues(t, 1, out.ReturnCode, "The return code should be 0")
+	}
+
+	// Run a command that does not exist
+	out, err = host.RunExec(context.TODO(), exec.NewExecCmdFromSlice([]string{"unknown-command-foobar"}))
+	assert.Error(t, err, "Exec should have failed")
+	assert.Nil(t, out, "The exec result should be nil")
+}


### PR DESCRIPTION
Currently, containerlab panics if one of the per-stage commands exits with a non-zero code, due to the subsequent access to the uninitialized exec result. Let's get this fixed by always propagating the exec result regardless of the exit code, and avoiding accessing it in case of other errors.