### PR TITLE
allow to use existing config to boot srsim

### DIFF
--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -54,7 +54,7 @@ const (
 	configCf3                 = "config/cf3"
 	configCf2                 = "config/cf2"
 	configCf1                 = "config/cf1"
-	startupCfgFName           = "config.cfg"
+	startupCfgName            = "config.cfg"
 	envNokiaSrosSlot          = "NOKIA_SROS_SLOT"
 	envNokiaSrosChassis       = "NOKIA_SROS_CHASSIS"
 	envNokiaSrosSystemBaseMac = "NOKIA_SROS_SYSTEM_BASE_MAC"
@@ -240,12 +240,12 @@ func (n *sros) PreDeploy(_ context.Context, params *nodes.PreDeployParams) error
 				envNokiaSrosSlot, n.Cfg.Env[envNokiaSrosSlot])
 		}
 		// add the config specific mounts
-		cfgPath := filepath.Join(n.Cfg.LabDir, slot, configStartup)
+		cfgStartupPath := filepath.Join(n.Cfg.LabDir, slot, configStartup)
 		cf1Path := filepath.Join(n.Cfg.LabDir, slot, configCf1)
 		cf2Path := filepath.Join(n.Cfg.LabDir, slot, configCf2)
 		cf3Path := filepath.Join(n.Cfg.LabDir, slot, configCf3)
 		n.Cfg.Binds = append(n.Cfg.Binds,
-			fmt.Sprint(cfgPath, ":", cfgDir, ":rw"),
+			fmt.Sprint(cfgStartupPath, ":", cfgDir, ":rw"),
 			fmt.Sprint(cf1Path, ":", cf1Dir, "/:rw"),
 			fmt.Sprint(cf2Path, ":", cf2Dir, "/:rw"),
 			fmt.Sprint(cf3Path, ":", cf3Dir, "/:rw"),
@@ -660,6 +660,12 @@ func (n *sros) CheckDeploymentConditions(ctx context.Context) error {
 	return n.DefaultNode.CheckDeploymentConditions(ctx)
 }
 
+// nodeConfigExists returns true if a file at <labdir>/<node>/<slot>/config/cf3/config.cfg exists.
+func nodeConfigExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	return err == nil
+}
+
 // Func that creates the Dirs used for the kind SR-SIM and sets/merges the default Env vars.
 func (n *sros) createSROSFiles() error {
 	log.Debug("Creating directory structure for SR OS container", "node", n.Cfg.ShortName)
@@ -699,53 +705,65 @@ func (n *sros) createSROSFilesConfig() error {
 
 	var cfgTemplate string
 	var err error
+	// Path pointing to config file under cf3dir
+	cf3CfgFile := filepath.Join(n.Cfg.LabDir, n.Cfg.Env[envNokiaSrosSlot], configCf3, startupCfgName)
+	//Path pointing to config file under startup dir
+	cfgStartupFile := filepath.Join(n.Cfg.LabDir, n.Cfg.Env[envNokiaSrosSlot], configStartup, startupCfgName)
 
-	cfgPath := filepath.Join(n.Cfg.LabDir, n.Cfg.Env[envNokiaSrosSlot], configStartup, startupCfgFName)
 	isPartial := isPartialConfigFile(n.Cfg.StartupConfig)
-	if n.Cfg.StartupConfig != "" && !isPartial {
-		// User provides startup config
-		log.Debug("Reading startup-config", "node", n.Cfg.ShortName, "startup-config",
-			n.Cfg.StartupConfig, "isPartial", isPartial)
 
-		c, err := os.ReadFile(n.Cfg.StartupConfig)
-		if err != nil {
-			return err
+	if nodeConfigExists(cf3CfgFile) { // Found config on CF3, using that instead
+		log.Infof("Using existing config file (%s) instead of applying a new one", cf3CfgFile)
+		if err := utils.CopyFile(cf3CfgFile, cfgStartupFile, 0o644); err != nil {
+			return fmt.Errorf("startupCfg copying src %s -> dst %s failed: %v", cf3CfgFile, cfgStartupFile, err)
 		}
-
-		cBuf, err := utils.SubstituteEnvsAndTemplate(bytes.NewReader(c), n.Cfg)
-		if err != nil {
-			return err
-		}
-
-		cfgTemplate = cBuf.String()
 	} else {
-		// Use default clab config from the embedded template
-		log.Debug("Rendering SR OS default containerlab startup config", "node",
-			n.Cfg.ShortName, "type", n.Cfg.NodeType)
+		// Use startup folder to generate config and use that to boot node
+		if n.Cfg.StartupConfig != "" && !isPartial {
+			// User provides startup config
+			log.Debug("Reading startup-config", "node", n.Cfg.ShortName, "startup-config",
+				n.Cfg.StartupConfig, "isPartial", isPartial)
 
-		err = n.addDefaultConfig()
+			c, err := os.ReadFile(n.Cfg.StartupConfig)
+			if err != nil {
+				return err
+			}
+
+			cBuf, err := utils.SubstituteEnvsAndTemplate(bytes.NewReader(c), n.Cfg)
+			if err != nil {
+				return err
+			}
+
+			cfgTemplate = cBuf.String()
+
+		} else {
+			// Use default clab config from the embedded template
+			log.Debug("Rendering SR OS default containerlab startup config", "node",
+				n.Cfg.ShortName, "type", n.Cfg.NodeType)
+
+			err = n.addDefaultConfig()
+			if err != nil {
+				return err
+			}
+
+			log.Debug("Rendered default startup config", "node", n.Cfg.ShortName,
+				"startup-config", string(n.startupCliCfg))
+
+			if err := utils.CreateFile(cfgStartupFile, string(n.startupCliCfg)); err != nil {
+				return fmt.Errorf("failed to create startup-config file %s for node %s failed: %v", cfgStartupFile, n.Cfg.ShortName, err)
+			}
+		}
+
+		if cfgTemplate == "" {
+			log.Debug("configuration template is empty, skipping startup config file generation", "node", n.Cfg.ShortName)
+			return nil
+		}
+
+		err = n.GenerateConfig(cfgStartupFile, cfgTemplate)
 		if err != nil {
-			return err
-		}
-
-		log.Debug("Rendered default startup config", "node", n.Cfg.ShortName,
-			"startup-config", string(n.startupCliCfg))
-
-		if err := utils.CreateFile(cfgPath, string(n.startupCliCfg)); err != nil {
-			return fmt.Errorf("failed to create startup-config file %s for node %s failed: %v", cfgPath, n.Cfg.ShortName, err)
+			return fmt.Errorf("failed to generate config for node %q: %v", n.Cfg.ShortName, err)
 		}
 	}
-
-	if cfgTemplate == "" {
-		log.Debug("configuration template is empty, skipping startup config file generation", "node", n.Cfg.ShortName)
-		return nil
-	}
-
-	err = n.GenerateConfig(cfgPath, cfgTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to generate config for node %q: %v", n.Cfg.ShortName, err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
On the first release, the code to allow to use existing config wasn't present. 
Also did some minor renaming of variables to give better sense to the whole config generation functions