### PR TITLE
revert to 9.6.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,7 +18,7 @@ on:
 env:
   GO_VER: "1.24.5"
   CGO_ENABLED: 0
-  MKDOCS_INS_VER: 9.6.12-insiders-4.53.16-hellt
+  MKDOCS_INS_VER: 9.6.1-insiders-4.53.15-hellt
   GORELEASER_VER: v2.6.1
   PY_VER: "3.10"
   RUNTIME: ${{ inputs.runtime || 'docker' }}

--- a/.github/workflows/force-build.yml
+++ b/.github/workflows/force-build.yml
@@ -9,7 +9,7 @@ on:
 env:
   GO_VER: "1.24.5"
   CGO_ENABLED: 0
-  MKDOCS_INS_VER: 9.6.12-insiders-4.53.16-hellt
+  MKDOCS_INS_VER: 9.6.1-insiders-4.53.15-hellt
   GORELEASER_VER: v2.0.1
   PY_VER: "3.10"
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY = $(BIN_DIR)/containerlab
 MKDOCS_VER = 9.6.1
 # insiders version/tag https://github.com/srl-labs/mkdocs-material-insiders/pkgs/container/mkdocs-material-insiders
 # make sure to also change the mkdocs version in actions' cicd.yml and force-build.yml files
-MKDOCS_INS_VER = 9.6.12-insiders-4.53.16-hellt
+MKDOCS_INS_VER = 9.6.1-insiders-4.53.15-hellt
 
 DATE := $(shell date)
 COMMIT_HASH := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
code annotations were not rendering with 9.6.12-insiders-4.53.16-hellt

worth building the latest insiders to check whats' what. Reverting for now