### PR TITLE
Fix Distributed SR-SIM port mapping when using Grouped topology

### DIFF
--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -386,6 +386,8 @@ func (n *sros) setupComponentNodes() error {
 		componentConfig.Fqdn = n.calcComponentFqdn(c.Slot)
 		if idx != 0 {
 			componentConfig.DNS = nil
+			componentConfig.PortBindings = nil
+			componentConfig.PortSet = nil
 		}
 
 		// add the component env to the componentConfig env


### PR DESCRIPTION
In Distributed SR-SIM scenarios involving grouped topologies, port bindings should not be configured for line cards.