### PR TITLE
Update clab.schema.json to match types expected for iol

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -505,6 +505,24 @@
                             }
                         }
                     }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "kind": {
+                                "pattern": "(cisco_iol)"
+                            }
+                        },
+                        "required": ["kind"]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["iol","l2"]
+                            }
+                        }
+                    }
                 }
             ],
             "additionalProperties": false


### PR DESCRIPTION
Includes the "l2" and "iol" node types that are used by the iol.go node file.