### PR TITLE
SR-SIM components enhancement

### DIFF
--- a/docs/manual/kinds/sros.md
+++ b/docs/manual/kinds/sros.md
@@ -379,20 +379,20 @@ topology:
         - slot: A # containers will be attached to this Linux NS
         - slot: B
         - slot: 1
-          type: iom5-e # equivalent to override NOKIA_SROS_CARD
-          env:
-            NOKIA_SROS_SFM: m-sfm6-7/12
-            NOKIA_SROS_MDA_1: me6-100gb-qsfp28
-            NOKIA_SROS_MDA_2: me3-400gb-qsfpdd
+          type: iom5-e # maps to NOKIA_SROS_CARD
+          sfm: m-sfm6-7/12 # maps to NOKIA_SROS_SFM
+          mda:
+            - slot: 1
+              type: me6-100gb-qsfp28 # maps to NOKIA_SROS_MDA_1
+            - slot: 2
+              type: me3-400gb-qsfpdd # maps to NOKIA_SROS_MDA_2
         - slot: 2
-          env:
-            NOKIA_SROS_SFM: m-sfm6-7/12
-            NOKIA_SROS_CARD: iom5-e # (1)!
-            NOKIA_SROS_MDA_1: me6-100gb-qsfp28
-            NOKIA_SROS_MDA_2: me16-25gb-sfp28+2-100gb-qsfp28
+          type: iom5-e
+          sfm: m-sfm6-7/12
+          mda:
+            - slot: 2
+              type: me6-100gb-qsfp28
 ```
-
-1. As an example, the card type is set here as an env var, instead of the `type` field like we did for slot 1.
 
 ///
 /// tab | with links

--- a/docs/manual/kinds/sros.md
+++ b/docs/manual/kinds/sros.md
@@ -160,7 +160,6 @@ Data interfaces need to be configured with IP addressing manually using the SR O
 
 The SR-SIM can emulate different hardware platforms as explained in the [SR-SIM Installation, deployment and setup guide](https://documentation.nokia.com/sr/25-7/7750-sr/titles/sr-sim-installation-setup.html). These variants can be set using the `type` directive in the clab topology file, or by overriding the different available environment variables such as the ones for the chassis (`NOKIA_SROS_CHASSIS`) or card (`NOKIA_SROS_CARD`).  
 
-
 Users can then use environment variables to change the default behavior of a given container. If there is a conflict between the `type` field in the topology file and an environment variable in the topology file, the environment variable will take precedence.
 
 > When `type` is not provided in the topology file, SR-SIM will start as `SR-1` platform.
@@ -171,7 +170,7 @@ If the chosen platform is chassis-based, the SR-SIM deployment needs to be done 
 
 We call non-chassis-based systems like SR-1, SR-1s integrated variants. As these systems have a fixed form factor, they run as a single container and are represented as a single node in the topology file.
 
-Besides setting the `type` to drive the platform selection, users can then modify some of the default settings on a per-node basis using the `components` configuration on the node, or the environment variables. 
+Besides setting the `type` to drive the platform selection, users can then modify some of the default settings on a per-node basis using the `components` configuration on the node, or the environment variables.
 
 For example, to change the slot 1 MDA, refer to the example below:
 /// tab | Integrated SR-SIM
@@ -224,7 +223,7 @@ topology:
 
 When the emulated platform is chassis-based, like SR-7, SR-14s, etc., the SR-SIM node must be defined in a distributed mode in the topology file.
 
-A distributed SR-SIM node consists of two or more containers with a specific role: CPM or IOM. A node can boot in either mode depending on the settings of the `NOKIA_SROS_SLOT` environment variable and the SR-SIM node type. 
+A distributed SR-SIM node consists of two or more containers with a specific role: CPM or IOM. A node can boot in either mode depending on the settings of the `NOKIA_SROS_SLOT` environment variable and the SR-SIM node type.
 There are several other variables that will modify the default settings for a simulated chassis (e.g. SFM, XIOM, MDA, etc.), so please check the [SR-SIM Installation guide](https://documentation.nokia.com/sr/25-7/7750-sr/titles/sr-sim-installation-setup.html) for a full list of options.
 
 Containerlab provides two ways to define the distributed variant:
@@ -242,7 +241,7 @@ Distributed systems require certain settings given the nature of the SR-SIM simu
 
 #### Grouped topology
 
-Users can simplify the topology file with distributed SR-SIM nodes by using the `components` directive in the node definition. In this case, every member in the `components` section will result in a spawned container emulating the corresponding component type (CPM or IOM). 
+Users can simplify the topology file with distributed SR-SIM nodes by using the `components` directive in the node definition. In this case, every member in the `components` section will result in a spawned container emulating the corresponding component type (CPM or IOM).
 
 Each card in the chassis can have it's card type, SFM, XIOM and MDA configured either using the relevant directives, or via environment variables.
 

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -239,8 +239,8 @@ func (n *sros) setupStandaloneComponents() (map[string]string, error) {
 
 	vars := map[string]string{}
 
-	if len(n.Cfg.Components) != 1 {
-		return nil, fmt.Errorf("more than one component defined for standalone SR-SIM node: %q", n.Cfg.ShortName)
+	if len(n.Cfg.Components) == 0 {
+		return nil, nil
 	}
 
 	slotA := n.Cfg.Components[0]

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -234,9 +234,8 @@ func (n *sros) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 	return nil
 }
 
-// integrated -> pull component info from slot A components
+// integrated -> pull component info from slot A components.
 func (n *sros) setupStandaloneComponents() (map[string]string, error) {
-
 	vars := map[string]string{}
 
 	if len(n.Cfg.Components) == 0 {

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -172,6 +172,8 @@ func (n *sros) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 	n.HostRequirements.MinAvailMemoryGb = 4
 	n.HostRequirements.MinAvailMemoryGbFailAction = clabtypes.FailBehaviourLog
 
+	n.LicensePolicy = clabtypes.LicensePolicyRequired
+
 	n.Cfg = cfg
 
 	n.InterfaceHelp = InterfaceHelp

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -208,17 +208,23 @@ func (n *sros) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 	mac := genMac(n.Cfg)
 	srosEnv[envNokiaSrosSystemBaseMac] = mac
 
-	n.Cfg.Env = clabutils.MergeStringMaps(srosEnv, n.Cfg.Env)
-	log.Debug("Merged env file", "env", fmt.Sprintf("%+v", n.Cfg.Env), "node", n.Cfg.ShortName)
-
 	if n.isStandaloneNode() {
 		log.Debugf("%q is standalone node. %v", n.Cfg.ShortName, len(n.Cfg.Components))
-		err := n.setupStandaloneComponents()
+
+		vars, err := n.setupStandaloneComponents()
 		if err != nil {
 			return err
 		}
+
+		// n.Cfg.Env overrides component vars, overrides default srosEnv
+		n.Cfg.Env = clabutils.MergeStringMaps(srosEnv, vars, n.Cfg.Env)
+		log.Debug("Merged env file", "env", fmt.Sprintf("%+v", n.Cfg.Env), "node", n.Cfg.ShortName)
 	} else {
 		log.Debugf("%q is distributed node. %v", n.Cfg.ShortName, len(n.Cfg.Components))
+
+		n.Cfg.Env = clabutils.MergeStringMaps(srosEnv, n.Cfg.Env)
+		log.Debug("Merged env file", "env", fmt.Sprintf("%+v", n.Cfg.Env), "node", n.Cfg.ShortName)
+
 		err := n.setupComponentNodes()
 		if err != nil {
 			return err
@@ -229,10 +235,12 @@ func (n *sros) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 }
 
 // integrated -> pull component info from slot A components
-func (n *sros) setupStandaloneComponents() error {
+func (n *sros) setupStandaloneComponents() (map[string]string, error) {
+
+	vars := map[string]string{}
 
 	if len(n.Cfg.Components) != 1 {
-		return fmt.Errorf("more than one component defined for standalone SR-SIM node: %q", n.Cfg.ShortName)
+		return nil, fmt.Errorf("more than one component defined for standalone SR-SIM node: %q", n.Cfg.ShortName)
 	}
 
 	slotA := n.Cfg.Components[0]
@@ -244,33 +252,33 @@ func (n *sros) setupStandaloneComponents() error {
 	}
 
 	if slotName != standaloneSlotName {
-		return fmt.Errorf("expected no slot, or slot %q for components of standalone SR-SIM node: %q", standaloneSlotName, n.Cfg.ShortName)
-	}
-
-	for k, v := range slotA.Env {
-		n.Cfg.Env[k] = v
+		return nil, fmt.Errorf("expected no slot, or slot %q for components of standalone SR-SIM node: %q", standaloneSlotName, n.Cfg.ShortName)
 	}
 
 	if slotA.Type != "" {
-		n.Cfg.Env[envNokiaSrosCard] = slotA.Type
+		vars[envNokiaSrosCard] = slotA.Type
 	}
 
 	if slotA.SFM != "" {
-		n.Cfg.Env[envNokiaSrosSFM] = slotA.SFM
+		vars[envNokiaSrosSFM] = slotA.SFM
 	}
 
 	if slotA.XIOM != "" {
-		n.Cfg.Env[envNokiaSrosXIOM] = slotA.XIOM
+		vars[envNokiaSrosXIOM] = slotA.XIOM
 	}
 
 	if len(slotA.MDA) > 0 {
 		for _, m := range slotA.MDA {
 			key := fmt.Sprintf("%s_%d", envNokiaSrosMDA, m.Slot)
-			n.Cfg.Env[key] = m.Type
+			vars[key] = m.Type
 		}
 	}
 
-	return nil
+	for k, v := range slotA.Env {
+		vars[k] = v
+	}
+
+	return vars, nil
 }
 
 // Pre Deploy func for SR-SIM kind.

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -58,6 +58,9 @@ const (
 	envNokiaSrosChassis       = "NOKIA_SROS_CHASSIS"
 	envNokiaSrosSystemBaseMac = "NOKIA_SROS_SYSTEM_BASE_MAC"
 	envNokiaSrosCard          = "NOKIA_SROS_CARD"
+	envNokiaSrosSFM           = "NOKIA_SROS_SFM"
+	envNokiaSrosXIOM          = "NOKIA_SROS_XIOM"
+	envNokiaSrosMDA           = "NOKIA_SROS_MDA"
 )
 
 var (
@@ -401,6 +404,21 @@ func (n *sros) setupComponentNodes() error {
 		// set the type var if type is set
 		if c.Type != "" {
 			componentConfig.Env[envNokiaSrosCard] = c.Type
+		}
+
+		if c.SFM != "" {
+			componentConfig.Env[envNokiaSrosSFM] = c.SFM
+		}
+
+		if c.XIOM != "" {
+			componentConfig.Env[envNokiaSrosXIOM] = c.XIOM
+		}
+
+		if len(c.MDA) > 0 {
+			for _, m := range c.MDA {
+				key := fmt.Sprintf("%s_%d", envNokiaSrosMDA, m.Slot)
+				componentConfig.Env[key] = m.Type
+			}
 		}
 
 		componentConfig.Env[envNokiaSrosSlot] = c.Slot

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -299,20 +299,112 @@
                             "slot": {
                                 "description": "Set component physical position on a distributed chassis",
                                 "anyOf": [
-                                    { "type": "string", "pattern": "^[ABab]$" },
-                                    { "type": "integer", "minimum": 1}
+                                    {
+                                        "type": "string",
+                                        "pattern": "^[ABab]$"
+                                    },
+                                    {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    }
                                 ]
                             },
                             "type": {
-                                "type": "string",
                                 "description": "Set component type"
+                            },
+                            "sfm": {
+                                "description": "Set SFM type (SR-OS specific).",
+                                "$ref": "#/definitions/sros-sfm-types"
+                            },
+                            "xiom": {
+                                "description": "Set XIOM type (SR-OS specific).",
+                                "$ref": "#/definitions/sros-xiom-types"
+                            },
+                            "mda": {
+                                "type": "array",
+                                "description": "Define list of MDAs (SR-OS Specific). Each defined MDA must have values of 'slot' and 'type'",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "slot": {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        "type": {
+                                            "description": "Set MDA type (SR-OS specific)"
+                                        }
+                                    },
+                                    "required": [
+                                        "slot",
+                                        "type"
+                                    ],
+                                    "additionalProperties": false
+                                }
                             },
                             "env": {
                                 "type": "object",
                                 "$ref": "#/definitions/env"
                             }
                         },
-                        "additionalProperties": false
+                        "additionalProperties": false,
+                        "allOf": [
+                            {
+                                "if": {
+                                    "properties": {
+                                        "slot": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/sros-cpm-types"
+                                        }
+                                    }
+                                },
+                                "else": {
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/sros-card-types"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "if": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                },
+                                "then": {
+                                    "properties": {
+                                        "mda": {
+                                            "items": {
+                                                "properties": {
+                                                    "type": {
+                                                        "$ref": "#/definitions/sros-xiom-mda-types"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "else": {
+                                    "properties": {
+                                        "mda": {
+                                            "items": {
+                                                "properties": {
+                                                    "type": {
+                                                        "$ref": "#/definitions/sros-mda-types"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
                     },
                     "uniqueItems": true,
                     "description": "List of node components, used for multicontainer systems",
@@ -563,13 +655,18 @@
                                 "pattern": "(cisco_iol)"
                             }
                         },
-                        "required": ["kind"]
+                        "required": [
+                            "kind"
+                        ]
                     },
                     "then": {
                         "properties": {
                             "type": {
                                 "type": "string",
-                                "enum": ["iol","l2"]
+                                "enum": [
+                                    "iol",
+                                    "l2"
+                                ]
                             }
                         }
                     }
@@ -916,7 +1013,13 @@
             "type": "string",
             "description": "MACVLAN operating mode",
             "markdownDescription": "MACVLAN operating mode",
-            "enum": ["private", "vepa", "bridge", "passthru", "source"]
+            "enum": [
+                "private",
+                "vepa",
+                "bridge",
+                "passthru",
+                "source"
+            ]
         },
         "extras-config": {
             "type": "object",
@@ -1302,6 +1405,256 @@
             "markdownDescription": "IPv6 address",
             "type": "string",
             "pattern": "^((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{N}\\p{L}]+)?$"
+        },
+        "sros-card-types": {
+            "type": "string",
+            "description": "Card types for SR-OS",
+            "enum": [
+                "xcm-x20",
+                "imm40-10gb-sfp",
+                "iom4-e",
+                "iom-a",
+                "imm-2pac-fp3",
+                "iom4-e-hs",
+                "imm4-100gb-cfp4",
+                "iom-e",
+                "iom-v",
+                "iom4-e-b",
+                "iom-sar-hm",
+                "xcm2-x20",
+                "iom-1",
+                "xcm-14s",
+                "imm40-10gb-sfp-ptp",
+                "iom-ixr-r6",
+                "imm36-100g-qsfp28",
+                "imm48-sfp+2-qsfp28",
+                "iom5-e",
+                "xcm-7s",
+                "imm48-sfp++6-qsfp28",
+                "xcm-1s",
+                "xcm-2s",
+                "imm24-sfp++8-sfp28+2-qsfp28",
+                "iom-sar-hmc",
+                "imm14-10g-sfp++4-1g-tx",
+                "iom-ixr-r4",
+                "imm6-qsfpdd+48-sfp56",
+                "imm32-qsfp28+4-qsfpdd",
+                "i48-800g-qsfpdd-1x",
+                "imm36-qsfpdd",
+                "imm4-1g-tx+20-1g-sfp+6-10g-sfp+",
+                "iom-ixr-r6d",
+                "xcm2-7s",
+                "i24-800g-qsfpdd-1",
+                "imm36-800g-qsfpdd",
+                "xcm2-14s",
+                "i48-400g-qsfpdd-1",
+                "i80-200g-sfpdd+12-400g-qsfpdd-1",
+                "i40-200g-sfpdd+6-800g-qsfpdd-1",
+                "i80-200g-sfpdd+12-800g-qsfpdd-1x",
+                "xcm-2se",
+                "xcm-14s-b",
+                "xcm-7s-b",
+                "imm2-qsfpdd+2-qsfp28+24-sfp28",
+                "xcmc-2se",
+                "imm12-sfp28+2-qsfp28",
+                "dms24-800g-qsfpdd-1",
+                "iom-sar"
+            ]
+        },
+        "sros-cpm-types": {
+            "type": "string",
+            "description": "CPM card types for SR-OS",
+            "enum": [
+                "cpm-x20",
+                "cpm-v",
+                "cpm5",
+                "cpm-a",
+                "cpm-e",
+                "cpm-sar-hm",
+                "cpm-sar-hmc",
+                "cpm-ixr-e-gnss",
+                "cpm-s",
+                "cpiom-ixr-r6",
+                "cpm-ixr",
+                "cpm-1",
+                "cpm-ixr-s",
+                "cpm-1x",
+                "cpm-1s",
+                "cpm-2s",
+                "cpm-ixr-e",
+                "cpm2-s",
+                "cpm2-x20",
+                "cpm-ixr-r4",
+                "cpm-ixr-x",
+                "cpm-ixr-ec",
+                "cpiom-ixr-r6d",
+                "cpm-1se",
+                "cpm-2se",
+                "cpm-ixr-e2",
+                "cpm-ixr-e2c",
+                "cpm-sar"
+            ]
+        },
+        "sros-mda-types": {
+            "type": "string",
+            "description": "MDA types for SR-OS",
+            "enum": [
+                "x12-400g-qsfpdd",
+                "x6-200g-cfp2-dco",
+                "p10-10g-sfp",
+                "p1-100g-cfp",
+                "p6-10g-sfp",
+                "x40-10g-sfp",
+                "m40-10g-sfp",
+                "p20-1gb-sfp",
+                "s36-100gb-qsfp28-3.6t",
+                "p-isa2-ms",
+                "p-isa2-ms-e",
+                "isa2-aa",
+                "isa2-tunnel",
+                "isa2-bb",
+                "x4-100g-cfp2",
+                "maxp1-100gb-cfp",
+                "ma4-10gb-sfp+",
+                "maxp10-10gb-sfp+",
+                "me10-10gb-sfp+",
+                "ma2-10gb-sfp+12-1gb-sfp",
+                "ma44-1gb-csfp",
+                "ma20-1gb-tx",
+                "m20-10g-sfp+",
+                "me1-100gb-cfp2",
+                "m4-100g-cfp4",
+                "maxp1-100gb-cfp2",
+                "maxp1-100gb-cfp4",
+                "isa-ms-v",
+                "isa-aa-v",
+                "isa-tunnel-v",
+                "isa-bb-v",
+                "m20-v",
+                "me-isa2-ms",
+                "me-isa2-ms-e",
+                "me40-1gb-csfp",
+                "m4-1g-tx+20-1g-sfp+6-10g-sfp+",
+                "me6-10gb-sfp+",
+                "isa2-video",
+                "me2-100gb-qsfp28",
+                "i6-10/100eth-tx",
+                "i2-sdi",
+                "i2-cellular",
+                "me12-10/1gb-sfp+",
+                "me16-25gb-sfp28+2-100gb-qsfp28",
+                "me6-100gb-qsfp28",
+                "x6-400g-cfp8",
+                "me2-100gb-ms-qsfp28",
+                "s18-100gb-qsfp28",
+                "x40-10g-sfp-ptp",
+                "m40-10g-sfp-ptp",
+                "m36-100g-qsfp28",
+                "m48-sfp+2-qsfp28",
+                "m10-10g-sfp+",
+                "m20-1g-csfp",
+                "m6-10g-sfp++1-100g-qsfp28",
+                "me3-200gb-cfp2-dco",
+                "x24-100g-qsfp28",
+                "me12-100gb-qsfp28",
+                "i1-wlan",
+                "s36-400gb-qsfpdd",
+                "m24-sfp++8-sfp28+2-qsfp28",
+                "s36-100gb-qsfp28",
+                "a32-chds1v2",
+                "m48-sfp++6-qsfp28",
+                "maxp10-10/1gb-msec-sfp+",
+                "m4-10g-sfp++1-100g-cfp2",
+                "i3-10/100eth-tx",
+                "me3-400gb-qsfpdd",
+                "m18-25g-sfp28",
+                "m14-10g-sfp++4-1g-tx",
+                "m6-10g-sfp++4-25g-sfp28",
+                "me6-400gb-qsfpdd",
+                "me8-10/25gb-sfp28",
+                "m10-1g-sfp+2-10g-sfp+",
+                "m6-qsfpdd+48-sfp56",
+                "m32-qsfp28+4-qsfpdd",
+                "m36-qsfpdd",
+                "m1-400g-qsfpdd+1-100g-qsfp28",
+                "m5-100g-qsfp28",
+                "m48-800g-qsfpdd-1x",
+                "m24-800g-qsfpdd-1",
+                "ms36-800g-qsfpdd",
+                "x2-s36-800g-qsfpdd-18.0t",
+                "m48-400g-qsfpdd-1",
+                "m80-200g-sfpdd+12-800g-qsfpdd-1x",
+                "m40-200g-sfpdd+6-800g-qsfpdd-1",
+                "m80-200g-sfpdd+12-400g-qsfpdd-1",
+                "m46-10g-sfp+",
+                "m2-cfp2",
+                "m2-qsfpdd+2-qsfp28+24-sfp28",
+                "x2-s36-800g-qsfpdd-12.0t",
+                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                "m10-50g-sfp56",
+                "m32-1g-csfp",
+                "m80-1g-csfp",
+                "m12-sfp28+2-qsfp28",
+                "m2-100g-qsfp28+16-10g-sfp+",
+                "d24-800g-qsfpdd-1",
+                "m10-sfp++6-sfp",
+                "m5e2-100g-qsfp28+2-800g-qdd",
+                "m5e8-100g-sfp112+2-800g-qdd"
+            ]
+        },
+        "sros-xiom-types": {
+            "type": "string",
+            "description": "XIOM types for SR-OS",
+            "enum": [
+                "iom-s-3.0t",
+                "iom-s-1.5t",
+                "iom2-se-6.0t",
+                "iom2-se-3.0t",
+                "x2-s36-800g-qsfpdd-6.0t",
+                "x2-s36-400g-qsfp112-3.0t"
+            ]
+        },
+        "sros-xiom-mda-types": {
+            "type": "string",
+            "description": "XIOM MDA types for SR-OS",
+            "enum": [
+                "ms6-200gb-cfp2-dco",
+                "ms3-200gb-cfp2-dco",
+                "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                "ms18-100gb-qsfp28",
+                "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                "ms24-10/100gb-sfpdd",
+                "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                "ms16-sdd+4-qsfp28-b",
+                "ms8-sdd+2-qsfp28-b",
+                "mse24-200g-sfpdd",
+                "mse6-800g-cfp2-dco",
+                "mse14-800g+4-400g",
+                "m36-800g-qsfpdd",
+                "mse6-800g-qsfpdd",
+                "m36-400g-qsfp112",
+                "ms2-100g-qsfp28+2-800g-qsfpdd",
+                "ms8-100g-sfp112+2-800g-qsfpdd",
+                "ms4-400g-qsfpdd+4-100g-qsfp28"
+            ]
+        },
+        "sros-sfm-types": {
+            "type": "string",
+            "description": "SFM types for SR-OS",
+            "enum": [
+                "m-sfm5-12",
+                "m-sfm5-7",
+                "m-sfm6-7/12",
+                "sfm-2s",
+                "sfm-2se",
+                "sfm-s",
+                "sfm-x20",
+                "sfm-x20-b",
+                "sfm-x20s-b",
+                "sfm2-s",
+                "sfm2-x20s"
+            ]
         }
     },
     "type": "object",

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -297,8 +297,11 @@
                         "type": "object",
                         "properties": {
                             "slot": {
-                                "type": "string",
-                                "description": "Set component physical position on a distributed chassis"
+                                "description": "Set component physical position on a distributed chassis",
+                                "anyOf": [
+                                    { "type": "string", "pattern": "^[ABab]$" },
+                                    { "type": "integer", "minimum": 1}
+                                ]
                             },
                             "type": {
                                 "type": "string",

--- a/tests/13-srsim/05-sros-comp-to-linux.robot
+++ b/tests/13-srsim/05-sros-comp-to-linux.robot
@@ -51,6 +51,19 @@ Ensure l1 can ping sros over 1/1/c23/4 interface
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    0% packet loss
 
+Ensure MDA is overriden with explicit slot on sr1-01
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    echo "show mda" | sshpass -p "NokiaSros1!" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-sr1-01
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    me12-100gb-qsfp28
+
+Ensure MDA is overriden with implicit slot on sr1-02
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    echo "show mda" | sshpass -p "NokiaSros1!" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-sr1-02
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    me12-100gb-qsfp28
 
 *** Keywords ***
 Cleanup

--- a/tests/13-srsim/05-sros-comp-to-linux.robot
+++ b/tests/13-srsim/05-sros-comp-to-linux.robot
@@ -65,6 +65,20 @@ Ensure MDA is overriden with implicit slot on sr1-02
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    me12-100gb-qsfp28
 
+Ensure MDA is overriden with env var on component on sr1-03
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    echo "show mda" | sshpass -p "NokiaSros1!" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-sr1-03
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    me12-100gb-qsfp28
+
+Ensure MDA is overriden with env var on node on sr1-04
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    echo "show mda" | sshpass -p "NokiaSros1!" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-sr1-04
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    me12-100gb-qsfp28
+
 *** Keywords ***
 Cleanup
     Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup

--- a/tests/13-srsim/05-srsim-comp.clab.yml
+++ b/tests/13-srsim/05-srsim-comp.clab.yml
@@ -53,6 +53,33 @@ topology:
       startup-config: |
         /configure card 1 admin-state enable
         /configure card 1 card-type iom-1
+
+    sr1-03:
+      kind: nokia_srsim
+      type: sr-1
+      components: 
+         - env:
+              NOKIA_SROS_MDA_1: me12-100gb-qsfp28 # verify env MDA override on component
+           mda:
+               - slot: 1
+                 type: me6-100gb-qsfp28
+      startup-config: |
+        /configure card 1 admin-state enable
+        /configure card 1 card-type iom-1
+
+    sr1-04:
+      kind: nokia_srsim
+      type: sr-1
+      env: 
+        NOKIA_SROS_MDA_1: me12-100gb-qsfp28 # verify env MDA override on node config
+      components: 
+         - mda:
+            - slot: 1
+              type: me6-100gb-qsfp28
+      startup-config: |
+        /configure card 1 admin-state enable
+        /configure card 1 card-type iom-1
+        
         
   links:
     - endpoints: ["l1:eth1", "sros:1/1/c23/4"]

--- a/tests/13-srsim/05-srsim-comp.clab.yml
+++ b/tests/13-srsim/05-srsim-comp.clab.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/clab.schema.json
 name: sr05
 
 topology:
@@ -29,5 +30,29 @@ topology:
         /configure router "Base" interface "to-linux" port 1/1/c23/4:0
         /configure router "Base" interface "to-linux" ipv4 primary address 10.0.0.2
         /configure router "Base" interface "to-linux" ipv4 primary prefix-length 24
+
+    sr1-01:
+      kind: nokia_srsim
+      type: sr-1
+      components: 
+        - slot: A # override integrated MDA explicit slot
+          mda:
+            - slot: 1
+              type: me12-100gb-qsfp28
+      startup-config: |
+        /configure card 1 admin-state enable
+        /configure card 1 card-type iom-1
+
+    sr1-02:
+      kind: nokia_srsim
+      type: sr-1
+      components: 
+         - mda: # override integrated MDA implicit slot
+            - slot: 1
+              type: me12-100gb-qsfp28
+      startup-config: |
+        /configure card 1 admin-state enable
+        /configure card 1 card-type iom-1
+        
   links:
     - endpoints: ["l1:eth1", "sros:1/1/c23/4"]

--- a/tests/13-srsim/07-srsim-mix.clab.yml
+++ b/tests/13-srsim/07-srsim-mix.clab.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/clab.schema.json
 name: "sr07"
 mgmt:
   network: srsim_mgmt
@@ -60,11 +61,13 @@ topology:
         - slot: A
         - slot: B
         - slot: 1
-          env:
-            NOKIA_SROS_CARD: iom5-e
-            NOKIA_SROS_MDA_1: me6-100gb-qsfp28
-            NOKIA_SROS_MDA_2: me3-400gb-qsfpdd
-            NOKIA_SROS_SFM: m-sfm6-7/12
+          type: iom5-e
+          sfm: m-sfm6-7/12
+          mda:
+            - slot: 1
+              type: me6-100gb-qsfp28
+            - slot: 2
+              type: me3-400gb-qsfpdd
         - slot: 2
     srsim11-a:
       kind: nokia_srsim

--- a/types/component.go
+++ b/types/component.go
@@ -1,10 +1,22 @@
 package types
 
+import "fmt"
+
 type Component struct {
 	Slot string            `yaml:"slot,omitempty"`
 	Type string            `yaml:"type,omitempty"`
 	Env  map[string]string `yaml:"env,omitempty"`
+	SFM  string            `yaml:"sfm,omitempty"`
+	XIOM string            `yaml:"xiom,omitempty"`
+	MDA  MDAS              `yaml:"mda,omitempty"`
 }
+
+type MDA struct {
+	Slot int    `yaml:"slot,omitempty"`
+	Type string `yaml:"type,omitempty"`
+}
+
+type MDAS []MDA
 
 func (c *Component) Copy() *Component {
 	if c == nil {
@@ -24,5 +36,39 @@ func (c *Component) Copy() *Component {
 		Slot: c.Slot,
 		Type: c.Type,
 		Env:  envCopy,
+		SFM:  c.SFM,
+		XIOM: c.XIOM,
+		MDA:  c.MDA.Copy(),
 	}
+}
+
+func (l *MDAS) UnmarshalYAML(unmarshal func(any) error) error {
+
+	var entries []MDA
+	if err := unmarshal(&entries); err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		*l = nil
+		return nil
+	}
+
+	for _, e := range entries {
+		if e.Type == "" || e.Slot <= 0 {
+			return fmt.Errorf("invalid mda entry. slot and type are required, got slot %q, type%q", e.Slot, e.Type)
+		}
+	}
+
+	*l = MDAS(entries)
+	return nil
+}
+
+func (l MDAS) Copy() MDAS {
+	if l == nil {
+		return nil
+	}
+	out := make([]MDA, len(l))
+	copy(out, l)
+	return out
 }

--- a/types/component.go
+++ b/types/component.go
@@ -43,7 +43,6 @@ func (c *Component) Copy() *Component {
 }
 
 func (l *MDAS) UnmarshalYAML(unmarshal func(any) error) error {
-
 	var entries []MDA
 	if err := unmarshal(&entries); err != nil {
 		return err

--- a/types/component_test.go
+++ b/types/component_test.go
@@ -1,9 +1,8 @@
 package types
 
 import (
-	"testing"
-
 	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v2"

--- a/types/component_test.go
+++ b/types/component_test.go
@@ -1,0 +1,100 @@
+package types
+
+import (
+	"testing"
+
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+)
+
+func TestComponentMDAUnmarshal(t *testing.T) {
+	mdaYaml := `
+- slot: 1
+  type: a
+- slot: 2
+  type: b
+`
+	var m MDAS
+	if err := yaml.Unmarshal([]byte(mdaYaml), &m); err != nil {
+		t.Fatalf("err unmarshalling mdas: %v", err)
+	}
+
+	if len(m) != 2 {
+		t.Fatalf("got: %d mdas, want 2", len(m))
+	}
+
+	wantMDAS := MDAS{
+		{
+			Slot: 1,
+			Type: "a",
+		},
+		{
+			Slot: 2,
+			Type: "b",
+		},
+	}
+
+	if diff := cmp.Diff(wantMDAS, m); diff != "" {
+		t.Fatalf("MDAS mismatch:\n%s", diff)
+	}
+}
+
+func TestComponentMDAUnmarshalInvalidSlotZero(t *testing.T) {
+	mdaYaml := `
+- slot: 0
+  type: foo
+`
+	var m MDAS
+	if err := yaml.Unmarshal([]byte(mdaYaml), &m); err == nil {
+		t.Fatalf("expected error, got nil")
+	} else {
+		if want := "invalid mda entry"; !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want contains %q", err.Error(), want)
+		}
+	}
+}
+
+func TestComponentMDAUnmarshalInvalidSlotNonNumeric(t *testing.T) {
+	mdaYaml := `
+- slot: z
+  type: foo
+`
+	var m MDAS
+	if err := yaml.Unmarshal([]byte(mdaYaml), &m); err == nil {
+		t.Fatalf("expected error, got nil")
+	} else {
+		if want := "cannot unmarshal"; !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want contains %q", err.Error(), want)
+		}
+	}
+}
+
+func TestComponentMDAUnmarshalMissingType(t *testing.T) {
+	mdaYaml := `
+- slot: 1
+`
+	var m MDAS
+	if err := yaml.Unmarshal([]byte(mdaYaml), &m); err == nil {
+		t.Fatalf("expected error, got nil")
+	} else {
+		if want := "invalid mda entry"; !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want contains %q", err.Error(), want)
+		}
+	}
+}
+
+func TestComponentMDAUnmarshalMissingSlot(t *testing.T) {
+	mdaYaml := `
+- type: abc
+`
+	var m MDAS
+	if err := yaml.Unmarshal([]byte(mdaYaml), &m); err == nil {
+		t.Fatalf("expected error, got nil")
+	} else {
+		if want := "invalid mda entry"; !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want contains %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
We want to add some nice SR-SIM integration into the vscode extension. 

The current env var based configuration of the SR-SIM nodes aren't so clean, and schema validation isn't easy either.

I propose some new fields under the `components` for `xiom`, `sfm` and `mda`. These still map to env vars, but being dedicated fields we can make some nice enhancements to the schema (which are also added in this PR; I have pulled all the types from the public 7x50 YANG models).

I have also updated the license policy to prevent a case where if no license is provided, the containers exit and the deploy cmd hangs.

Please give your thoughts. Docs & tests will come soon.

https://github.com/user-attachments/assets/77454f8b-64b5-47e8-a153-1f378290ec5d

cc: @FloSch62 @asadarafat 