### PR TITLE
Fix sudo curl breaking if HTTP(S)_PROXY is in play

### DIFF
--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -51,7 +51,7 @@ function install-docker-debian {
     sudo apt-get update -y
     sudo apt-get install -y ca-certificates curl
     sudo install -m 0755 -d /etc/apt/keyrings
-    sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    sudo -E curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     sudo chmod a+r /etc/apt/keyrings/docker.asc
 
     # Add the repository to Apt sources:
@@ -75,7 +75,7 @@ function install-docker-ubuntu {
     sudo apt-get update -y
     sudo apt-get install -y ca-certificates curl
     sudo install -m 0755 -d /etc/apt/keyrings
-    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo -E curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
     sudo chmod a+r /etc/apt/keyrings/docker.asc
 
     # Add the repository to Apt sources:


### PR DESCRIPTION
`sudo curl ...` does not allow curl to use any proxy environment variables, breaking the installation script if run in an environment where such a proxy is necessary for outside traffic. Passing the environment variables on with `sudo -E` fixes this issue.