### PR TITLE
Add short and json version output options

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -99,6 +99,10 @@ func GetOptions() *Options {
 				Port:           defaultVxlanPort,
 				DeletionPrefix: "vx-",
 			},
+			Version: &VersionOptions{
+				Short: false,
+				JSON:  false,
+			},
 		}
 	}
 
@@ -122,6 +126,7 @@ type Options struct {
 	ToolsSSHX      *ToolsSSHXOptions
 	ToolsVeth      *ToolsVethOptions
 	ToolsVxlan     *ToolsVxlanOptions
+	Version        *VersionOptions
 }
 
 func (o *Options) ToClabOptions() []clabcore.ClabOption {
@@ -420,4 +425,9 @@ type ToolsVxlanOptions struct {
 	Remote         string
 	ParentDevice   string
 	DeletionPrefix string
+}
+
+type VersionOptions struct {
+	Short bool
+	JSON  bool
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -126,7 +126,9 @@ func printVersionInfo(c *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
+
 		fmt.Println(string(j))
+
 		return nil
 	}
 
@@ -136,6 +138,7 @@ func printVersionInfo(c *cobra.Command, _ []string) error {
 	fmt.Printf("       date: %s\n", date)
 	fmt.Printf("     source: %s\n", repoUrl)
 	fmt.Printf(" rel. notes: %s\n", versionData.ReleaseNotes)
+
 	return nil
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -101,7 +101,7 @@ func docsLinkFromVer(ver string) string {
 	return relSlug
 }
 
-func printVersionInfoFn(c *cobra.Command, o *Options) error {
+func printVersionInfoFn(_ *cobra.Command, o *Options) error {
 	versionData := struct {
 		Version      string `json:"version"`
 		Commit       string `json:"commit"`

--- a/docs/cmd/version/index.md
+++ b/docs/cmd/version/index.md
@@ -2,18 +2,36 @@
 
 ## Description
 
-The `version` command displays the version of containerlab installed.
+The `version` command displays containerlab's version information.
 
 ## Usage
 
 ```
 containerlab version
+  ____ ___  _   _ _____  _    ___ _   _ _____ ____  _       _     
+ / ___/ _ \| \ | |_   _|/ \  |_ _| \ | | ____|  _ \| | __ _| |__  
+| |  | | | |  \| | | | / _ \  | ||  \| |  _| | |_) | |/ _` | '_ \ 
+| |__| |_| | |\  | | |/ ___ \ | || |\  | |___|  _ <| | (_| | |_) |
+ \____\___/|_| \_| |_/_/   \_\___|_| \_|_____|_| \_\_|\__,_|_.__/ 
+
+    version: 0.69.3
+     commit: 49ee599b
+       date: 2025-08-06T21:02:24Z
+     source: https://github.com/srl-labs/containerlab
+ rel. notes: https://containerlab.dev/rn/0.69/#0693
 ```
 
-The version command contains:
+## Flags
 
-* version in the semantic versioning format
-* commit hash of the project repository
-* build date
-* a link to the github repo
-* a link to the release notes of the current version
+### short
+
+With `--short | -s` flag, only the version number is displayed.
+
+### json
+
+With `--json | -j` flag, the version information is displayed in JSON format.
+
+```
+clab version -j
+{"version":"0.0.0","commit":"none","date":"unknown","repository":"https://github.com/srl-labs/containerlab","releaseNotes":"https://containerlab.dev/rn/0.0/"}
+```


### PR DESCRIPTION
To make version checks easier in scripting, this adds an option to output just the version or a json with the same data as in the default output.

Otherwise it just outputs the same format as before.


Example
```
$ bin/containerlab version --short
0.0.0
$ bin/containerlab version --json
{"version":"0.0.0","commit":"none","date":"unknown","repository":"https://github.com/srl-labs/containerlab","releaseNotes":"https://containerlab.dev/rn/0.0/"}
```