### PR TITLE
tools/vxlan: Add source port option to VXLAN tool command

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -96,7 +96,8 @@ func GetOptions() *Options {
 			},
 			ToolsVxlan: &ToolsVxlanOptions{
 				ID:             defaultVxlanID,
-				Port:           defaultVxlanPort,
+				DstPort:        defaultVxlanPort,
+				SrcPort:        0,
 				DeletionPrefix: "vx-",
 			},
 			Version: &VersionOptions{
@@ -421,7 +422,8 @@ type ToolsVxlanOptions struct {
 	Link           string
 	ID             uint
 	MTU            uint
-	Port           uint
+	DstPort        uint
+	SrcPort        uint
 	Remote         string
 	ParentDevice   string
 	DeletionPrefix string

--- a/cmd/tools_vxlan.go
+++ b/cmd/tools_vxlan.go
@@ -67,12 +67,26 @@ func vxlanCmd(o *Options) (*cobra.Command, error) {
 		o.ToolsVxlan.MTU,
 		"VxLAN MTU",
 	)
-	vxlanCreateCmd.Flags().UintVarP(
-		&o.ToolsVxlan.Port,
+	vxlanCreateCmd.Flags().UintVar(
+		&o.ToolsVxlan.DstPort,
 		"port",
-		"p",
-		o.ToolsVxlan.Port,
+		o.ToolsVxlan.DstPort,
 		"VxLAN Destination UDP Port",
+	)
+	vxlanCreateCmd.Flags().MarkDeprecated("port", "use dst-port instead")
+	vxlanCreateCmd.Flags().UintVarP(
+		&o.ToolsVxlan.DstPort,
+		"dst-port",
+		"p",
+		o.ToolsVxlan.DstPort,
+		"VxLAN Destination UDP Port",
+	)
+	vxlanCreateCmd.Flags().UintVarP(
+		&o.ToolsVxlan.SrcPort,
+		"src-port",
+		"s",
+		o.ToolsVxlan.SrcPort,
+		"VxLAN Source UDP Port",
 	)
 
 	err := vxlanCreateCmd.MarkFlagRequired("remote")
@@ -135,7 +149,8 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 		LinkCommonParams: clablinks.LinkCommonParams{
 			MTU: int(o.ToolsVxlan.MTU),
 		},
-		UDPPort:  int(o.ToolsVxlan.Port),
+		DstPort:  int(o.ToolsVxlan.DstPort),
+		SrcPort:  int(o.ToolsVxlan.SrcPort),
 		LinkType: clablinks.LinkTypeVxlanStitch,
 		Endpoint: *clablinks.NewEndpointRaw(
 			"host",

--- a/docs/cmd/tools/vxlan/create.md
+++ b/docs/cmd/tools/vxlan/create.md
@@ -18,9 +18,13 @@ VxLAN interface name will be a catenation of a prefix `vx-` and the interface na
 
 VxLAN tunnels set up with this command are unidirectional in nature. To set the remote endpoint address the `--remote` flag should be used.
 
-### port
+### dst-port
 
-Port number that the VxLAN tunnel will use is set with `--port | -p` flag. Defaults to `14789`[^1].
+Destination port number that the VxLAN tunnel will use is set with `--dst-port | -p` flag. Defaults to `14789`[^1].
+
+### src-port
+
+Source port number that the VxLAN tunnel will use is set with `--src-port | -d` flag. Defaults to no source port set (ephemeral source ports). Recommended to be set when NAT is expected to be applied on the tunnel.
 
 ### id
 

--- a/docs/manual/topo-def-file.md
+++ b/docs/manual/topo-def-file.md
@@ -332,7 +332,8 @@ The vxlan type results in a vxlan tunnel interface that is created in the host n
         mac: <Node-Interface-Mac>            # optional
       remote: <Remote-VTEP-IP>               # mandatory
       vni: <VNI>                             # mandatory
-      udp-port: <VTEP-UDP-Port>              # mandatory
+      dst-port: <VTEP-UDP-Port>              # mandatory
+      src-port: <Source-UDP-Port>            # optional
       mtu: <link-mtu>                        # optional
       vars: <link-variables>                 # optional (used in templating)
       labels: <link-labels>                  # optional (used in templating)
@@ -352,7 +353,8 @@ In addition to these interfaces, tc rules are being provisioned to stitch the vx
         mac: <Node-Interface-Mac>            # optional
       remote: <Remote-VTEP-IP>               # mandatory
       vni: <VNI>                             # mandatory
-      udp-port: <VTEP-UDP-Port>              # mandatory
+      dst-port: <VTEP-UDP-Port>              # mandatory
+      src-port: <Source-UDP-Port>            # optional
       mtu: <link-mtu>                        # optional
       vars: <link-variables>                 # optional (used in templating)
       labels: <link-labels>                  # optional (used in templating)

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -8,7 +8,8 @@ import (
 
 type EndpointVxlan struct {
 	EndpointGeneric
-	udpPort     int
+	dstPort     int
+	srcPort     int
 	remote      net.IP
 	parentIface string
 	vni         int
@@ -26,7 +27,7 @@ func NewEndpointVxlan(node Node, link Link) *EndpointVxlan {
 }
 
 func (e *EndpointVxlan) String() string {
-	return fmt.Sprintf("vxlan remote: %q, udp-port: %d, vni: %d", e.remote, e.udpPort, e.vni)
+	return fmt.Sprintf("vxlan remote: %q, dst-port: %d, vni: %d", e.remote, e.dstPort, e.vni)
 }
 
 // Verify verifies that the endpoint is valid and can be deployed.

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -846,8 +846,11 @@
                 "vni": {
                     "$ref": "#/definitions/link-vxlan-vni"
                 },
-                "udp-port": {
-                    "$ref": "#/definitions/link-vxlan-udpport"
+                "dst-port": {
+                    "$ref": "#/definitions/link-vxlan-dstport"
+                },
+                "src-port": {
+                    "$ref": "#/definitions/link-vxlan-srcport"
                 },
                 "mtu": {
                     "$ref": "#/definitions/mtu"
@@ -864,7 +867,7 @@
                 "endpoint",
                 "remote",
                 "vni",
-                "udp-port"
+                "dst-port"
             ],
             "additionalProperties": false
         },
@@ -885,8 +888,11 @@
                 "vni": {
                     "$ref": "#/definitions/link-vxlan-vni"
                 },
-                "udp-port": {
-                    "$ref": "#/definitions/link-vxlan-udpport"
+                "dst-port": {
+                    "$ref": "#/definitions/link-vxlan-dstport"
+                },
+                "src-port": {
+                    "$ref": "#/definitions/link-vxlan-srcport"
                 },
                 "mtu": {
                     "$ref": "#/definitions/mtu"
@@ -903,7 +909,7 @@
                 "endpoint",
                 "remote",
                 "vni",
-                "udp-port"
+                "dst-port"
             ],
             "additionalProperties": false
         },
@@ -974,9 +980,15 @@
             "minimum": 1,
             "maximum": 16777215
         },
-        "link-vxlan-udpport": {
+        "link-vxlan-dstport": {
             "type": "integer",
-            "description": "Remote UDP port",
+            "description": "Destination UDP port",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "link-vxlan-srcport": {
+            "type": "integer",
+            "description": "Source UDP port",
             "minimum": 1,
             "maximum": 65535
         },

--- a/tests/08-vxlan/01-vxlan.clab.yml
+++ b/tests/08-vxlan/01-vxlan.clab.yml
@@ -32,4 +32,4 @@ topology:
         mac: 02:00:00:00:00:04
       remote: 172.20.25.22
       vni: 100
-      udp-port: 14788
+      dst-port: 14788

--- a/tests/08-vxlan/02-vxlan-stitch.clab.yml
+++ b/tests/08-vxlan/02-vxlan-stitch.clab.yml
@@ -44,7 +44,7 @@ topology:
         mac: 02:00:00:00:00:04
       remote: 172.20.25.22
       vni: 100
-      udp-port: 14788
+      dst-port: 14788
 
     - type: vxlan-stitch
       endpoint:
@@ -52,4 +52,4 @@ topology:
         interface: e1-1
       remote: 172.20.25.23
       vni: 101
-      udp-port: 14789
+      dst-port: 14789


### PR DESCRIPTION
This PR adds a 'source port' option for the VXLAN tool's create command. This is useful when going through NAT, limiting the VXLAN tunnel to a single port allows the other side to connect back even if port 4789 is not explicitly port-forwarded, and helps maintain the NAT session for the VXLAN tunnel. 

The port (destination port) option has been renamed to be consistent with the other option in both the CLI flags and the topology description.

The --port option/udp-port field is still functional, but has been marked as deprecated.