### PR TITLE
fix: add component sorting to SR-SIM

### DIFF
--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -16,10 +16,12 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 
 	"github.com/beevik/etree"
 	"github.com/brunoga/deep"
@@ -460,10 +462,36 @@ func (n *sros) DeleteNetnsSymlink() error {
 	return n.DefaultNode.DeleteNetnsSymlink()
 }
 
+// sortComponents ensure components are in order of
+// CPM then regular IOM/XCMs
+func (n *sros) sortComponents() {
+	slices.SortFunc(n.Cfg.Components, func(a, b *clabtypes.Component) int {
+		s1 := strings.ToUpper(strings.TrimSpace(a.Slot))
+		s2 := strings.ToUpper(strings.TrimSpace(b.Slot))
+
+		p1 := n.getSortOrder(s1)
+		p2 := n.getSortOrder(s2)
+
+		return p1 - p2
+	})
+}
+
+func (n *sros) getSortOrder(slot string) int {
+	r := rune(slot[0])
+	if unicode.IsLetter(r) {
+		return int(r) // A=65, B=66
+	} else {
+		num, _ := strconv.Atoi(slot)
+		return 1000 + num // 1001, 1002... always bigger than slot A/B
+	}
+}
+
 func (n *sros) setupComponentNodes() error {
 	if !n.isDistributedBaseNode() {
 		return nil
 	}
+
+	n.sortComponents()
 
 	// Registry, because it is not a package Var
 	nr := clabnodes.NewNodeRegistry()

--- a/nodes/sros/sros_test.go
+++ b/nodes/sros/sros_test.go
@@ -1,3 +1,67 @@
 package sros
 
-/* TO DO */
+import (
+	"testing"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+func TestComponentSorting(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*clabtypes.Component
+		expected []string // expected slot order
+	}{
+		{
+			name: "random mix",
+			input: []*clabtypes.Component{
+				{Slot: "3"},
+				{Slot: "b"},
+				{Slot: "1"},
+				{Slot: "A"},
+				{Slot: "2"},
+			},
+			expected: []string{"A", "b", "1", "2", "3"},
+		},
+		{
+			name: "iom/xcm only",
+			input: []*clabtypes.Component{
+				{Slot: "3"},
+				{Slot: "1"},
+				{Slot: "2"},
+				{Slot: "10"},
+			},
+			expected: []string{"1", "2", "3", "10"},
+		},
+		{
+			name: "cpm only",
+			input: []*clabtypes.Component{
+				{Slot: "b"},
+				{Slot: "A"},
+			},
+			expected: []string{"A", "b"},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			n := &sros{}
+			n.Cfg = &clabtypes.NodeConfig{
+				Components: c.input,
+			}
+
+			n.sortComponents()
+
+			if len(n.Cfg.Components) != len(c.expected) {
+				t.Fatalf("expected %d components, got %d", len(c.expected), len(n.Cfg.Components))
+			}
+
+			for i, expectedSlot := range c.expected {
+				actualSlot := n.Cfg.Components[i].Slot
+				if actualSlot != expectedSlot {
+					t.Errorf("expected slot %q, got %q", expectedSlot, actualSlot)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
If I have a topology like below. It will never complete deploying, because the IP address is getting handed to the slot 1 , which is not CPM. Since the CPM doens't have an IP, the deploy keeps waiting for the CPM to get an IP (which never happens).

This PR is sorting the components so that slot A should always get the IP/host config and all component nodes attach to it's namespace.

```yaml
    sr1:
        kind: nokia_srsim
        image: nokia_srsim:25.7.r1
        license: srsim.txt
        type: sr-2s
        components:
            - slot: 1
              type: xcm-2s
              xiom:
              - mda:
                - slot: 1
                  type: ms18-100gb-qsfp28
                - slot: 2
                  type: ms18-100gb-qsfp28
                slot: 1
                type: iom-s-3.0t
            - slot: 2
              type: xcm-2s
              xiom:
              - slot: 2
                type: iom-s-3.0t
            - slot: A
              type: cpm-2s
            - slot: B
              type: cpm-2s
```
@hellt I would appreciate the 0.70.2 patch rel on this as well.