### PR TITLE
Improve subnet overlap error message for Docker mgmt network

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -340,7 +340,27 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 
 	netCreateResponse, err := d.Client.NetworkCreate(nctx, d.mgmt.Network, opts)
 	if err != nil {
-		return "", err
+		// Handle subnet overlap error
+    if strings.Contains(err.Error(), "Pool overlaps") || strings.Contains(err.Error(), "subnet") {
+        nets, _ := d.Client.NetworkList(nctx, networkapi.ListOptions{})
+        for _, n := range nets {
+            for _, cfg := range n.IPAM.Config {
+                if cfg.Subnet == d.mgmt.IPv4Subnet {
+                    return "", fmt.Errorf(
+                        "subnet %s already in use by Docker network %q. See https://containerlab.dev/manual/network/",
+                        cfg.Subnet, n.Name,
+                    )
+                }
+            }
+        }
+        // fallback: no exact match, but clarify
+        return "", fmt.Errorf(
+            "requested subnet %s overlaps an existing Docker network. Original error: %v. See https://containerlab.dev/manual/network/",
+            d.mgmt.IPv4Subnet, err,
+        )
+    }
+
+    return "", err
 	}
 
 	if len(netCreateResponse.ID) < 12 {
@@ -355,8 +375,7 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 }
 
 // getMgmtBridgeIPs gets the management bridge v4/6 addresses.
-func getMgmtBridgeIPs(
-	bridgeName string,
+func getMgmtBridgeIPs(	bridgeName string,
 	netResource *networkapi.Inspect,
 ) (v4, v6 string, err error) {
 	if v4, v6, err = clabutils.FirstLinkIPs(bridgeName); err != nil {


### PR DESCRIPTION
### Context
Fixes #2786

### Changes
- Intercept "Pool overlaps" error from Docker.
- List existing Docker networks and match by subnet.
- Return a clear, actionable error message with a link to the docs.

### Example
Before:
    Error response from daemon: invalid pool request: Pool overlaps with other one on this address space.

After:
    Subnet 172.20.0.0/16 already in use by Docker network "testnet".
    See https://containerlab.dev/manual/network/

---
This is my first contribution to containerlab.