### PR TITLE
Rename 'ceos' to 'vyos' in network configuration

### DIFF
--- a/docs/manual/kinds/vyosnetworks_vyos.md
+++ b/docs/manual/kinds/vyosnetworks_vyos.md
@@ -132,7 +132,7 @@ You may specify a customer startup configuration using the `startup-config` prop
 name: vyos_lab
 topology:
   nodes:
-    ceos:
+    vyos:
       kind: -{{ kind_code_name }}-
       startup-config: myconfig.conf
 ```


### PR DESCRIPTION
It seems a copypaste mistake