### PR TITLE
Add generic interface struct in NodeCfg & IP link var support for XRd

### DIFF
--- a/nodes/xrd/xrd.cfg
+++ b/nodes/xrd/xrd.cfg
@@ -42,6 +42,20 @@ router static
   !
 {{- end}}
 !
+{{- range .TemplateInterfaces }}
+interface {{ .Name }}
+{{- if .MTU }}
+ mtu {{ .MTU }}
+{{- end }}
+{{- if .IPv4Addr }}
+ ipv4 address {{ .IPv4Addr }}
+{{- end }}
+{{- if .IPv6Addr }}
+ ipv6 address {{ .IPv6Addr }}
+{{- end }}
+ no shutdown
+!
+{{- end }}
 ssh server v2
 {{- if .Env.CLAB_MGMT_VRF }}
 ssh server vrf {{ .Env.CLAB_MGMT_VRF }}

--- a/types/types.go
+++ b/types/types.go
@@ -182,6 +182,8 @@ type NodeConfig struct {
 	TLSCert              string `json:"tls-cert,omitempty"`
 	TLSKey               string `json:"-"` // Do not marshal into JSON - highly sensitive data
 	TLSAnchor            string `json:"tls-anchor,omitempty"`
+	// TemplateInterfaces contains interface data for use in configuration templates
+	TemplateInterfaces []TemplateInterface `json:"template-interfaces,omitempty"`
 	// TLS Certificate configuration
 	Certificate *CertificateConfig
 	// Healthcheck configuration parameters
@@ -441,4 +443,17 @@ type ImpairmentData struct {
 	PacketLoss float64 `json:"packet_loss"`
 	Rate       int     `json:"rate"`
 	Corruption float64 `json:"corruption"`
+}
+
+// TemplateInterface represents a generic interface for use in config templates.
+type TemplateInterface struct {
+	// interface name as accepted in the NOS config
+	Name string
+	// interface name as defined in endpoints (could be ethX, gi0-0-0-0...)
+	RawName string
+	// ipv4 addr link var (inc cidr mask)
+	IPv4Addr string
+	// ipv6 addr link var (inc cidr mask)
+	IPv6Addr string
+	MTU      int
 }


### PR DESCRIPTION
I added a generic template interface struct to make integration for new NOSes easier for the IPv4/v6 link vars.

XRd is now also the first NOS using this, and by extension now supports the IPv4/v6 link vars, as well as setting the MTU to match the link.

