### PR TITLE
feat: add SR-OS console log messages to deploy logger

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Containerlab provides a CLI for orchestrating and managing container-based netwo
 Containerlab focuses on the containerized Network Operating Systems which are typically used to test network features and designs, such as:
 
 * [Nokia SR Linux](manual/kinds/srl.md)
-* [Nokia SR-OS (SR-SIM)](manual/kinds/sros.md)
+* [Nokia SR OS (SR-SIM)](manual/kinds/sros.md)
 * [Arista cEOS](manual/kinds/ceos.md)
 * [Cisco XRd](manual/kinds/xrd.md)
 * [SONiC](manual/kinds/sonic-vs.md)

--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -9,7 +9,7 @@ kind_display_name: Nokia SR OS
 <small>VM-based</small>
 
 /// warning
-There is a newer and more flexible fully containerized simulator for SR-OS called [SR-SIM](sros.md), which is the preferred way to emulate Nokia SR OS network OS.
+There is a newer and more flexible fully containerized simulator for SR OS called [SR-SIM](sros.md), which is the preferred way to emulate Nokia SR OS network OS.
 ///
 
 [Nokia SR OS](https://www.nokia.com/networks/products/service-router-operating-system/) vSIM router is identified with `-{{ kind_code_name }}-` kind in the [topology file](../topo-def-file.md). It is built using [vrnetlab](../vrnetlab.md) project and essentially is a QEMU VM packaged in a docker container format. Do not mistake with the fully containeraized version of SR OS named [SR-SIM](sros.md).

--- a/mocks/mockruntime/runtime.go
+++ b/mocks/mockruntime/runtime.go
@@ -11,6 +11,7 @@ package mockruntime
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	exec "github.com/srl-labs/containerlab/exec"
@@ -362,6 +363,21 @@ func (m *MockContainerRuntime) StopContainer(arg0 context.Context, arg1 string) 
 func (mr *MockContainerRuntimeMockRecorder) StopContainer(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainer", reflect.TypeOf((*MockContainerRuntime)(nil).StopContainer), arg0, arg1)
+}
+
+// StreamLogs mocks base method.
+func (m *MockContainerRuntime) StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamLogs", ctx, containerName)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StreamLogs indicates an expected call of StreamLogs.
+func (mr *MockContainerRuntimeMockRecorder) StreamLogs(ctx, containerName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLogs", reflect.TypeOf((*MockContainerRuntime)(nil).StreamLogs), ctx, containerName)
 }
 
 // UnpauseContainer mocks base method.

--- a/nodes/sros/banner.go
+++ b/nodes/sros/banner.go
@@ -1,6 +1,6 @@
 package sros
 
-const banner = `................................................................\n:                  Welcome to Nokia SR-OS!                     :\n:                                                              :\n:                                                              :\n: YANG:          https://yang.labctl.net/                      :\n: Community:     https://containerlab.dev/community/           :\n: Discord:       https://containerlab.dev/discord/             :\n................................................................\n`
+const banner = `................................................................\n:                  Welcome to Nokia SR OS!                     :\n:                                                              :\n:                                                              :\n: YANG:          https://yang.labctl.net/                      :\n: Community:     https://containerlab.dev/community/           :\n: Discord:       https://containerlab.dev/discord/             :\n................................................................\n`
 
 // banner returns a banner string with a docs version filled in based on the version information
 // queried from the node.

--- a/nodes/sros/macaddr.go
+++ b/nodes/sros/macaddr.go
@@ -8,10 +8,10 @@ import (
 	clabtypes "github.com/srl-labs/containerlab/types"
 )
 
-// genMac returns a struct with a generated MAC address string to use in SR-OS Node.
+// genMac returns a struct with a generated MAC address string to use in SR OS Node.
 func genMac(cfg *clabtypes.NodeConfig) string {
 	// Generated MAC address conforms to the following addressing scheme
-	// first byte  - `1c` - fixed for easy identification of SR-OS Mac addresses
+	// first byte  - `1c` - fixed for easy identification of SR OS Mac addresses
 	// second byte - random, to distinguish projects
 	// third byte  - index of the topology node
 

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1770,8 +1770,13 @@ func (n *sros) GetContainerName() string {
 	return n.DefaultNode.GetContainerName()
 }
 
-// MonitorLogs reads from the passed io reader to check if we get
-// any unexpected errors in PostDeploy phase of SRSIM (ie. rejected config).
+// MonitorLogs monitors log output from the provided reader during the PostDeploy phase of SRSIM.
+// It scans each line for SR-OS error messages (minor or critical) and logs them as warnings or errors.
+// The method checks for context cancellation on each line and returns immediately if the context is cancelled.
+// Parameters:
+//   - ctx: context for cancellation; if cancelled, the method returns.
+//   - reader: io.ReadCloser providing log lines to scan.
+// The method returns when the context is cancelled or the reader is exhausted.
 func (n *sros) MonitorLogs(ctx context.Context, reader io.ReadCloser) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1802,7 +1802,7 @@ func (n *sros) MonitorLogs(ctx context.Context, reader io.ReadCloser, exitChan c
 		if strings.Contains(line, srosMinorError) ||
 			strings.Contains(line, srosCriticalError) {
 			log.Warn(
-				"Got SR OS log message. Deployment may hang",
+				"Got SR OS log message",
 				"node",
 				n.Cfg.ShortName,
 				"message",

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1792,7 +1792,7 @@ func (n *sros) GetContainerName() string {
 //   - exitChan: channel which will signal an error for postdeploy to skip.
 //
 // The method returns when the context is cancelled, when the reader is exhausted or if
-// it detects that SR-OS rejected the config as per the const srosRejectedCfgMsg
+// it detects that SR OS rejected the config as per the const srosRejectedCfgMsg.
 func (n *sros) MonitorLogs(ctx context.Context, reader io.ReadCloser, exitChan chan<- error) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
@@ -1811,7 +1811,7 @@ func (n *sros) MonitorLogs(ctx context.Context, reader io.ReadCloser, exitChan c
 		}
 
 		if strings.Contains(line, srosRejectedCfgMsg) {
-			exitChan <- errors.New("configuration rejected by SR-OS")
+			exitChan <- errors.New("configuration rejected by SR OS")
 			return
 		}
 

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1771,7 +1771,7 @@ func (n *sros) GetContainerName() string {
 }
 
 // MonitorLogs reads from the passed io reader to check if we get
-// any unexpected errors in PostDeploy phase of SRSIM (ie. rejected config)
+// any unexpected errors in PostDeploy phase of SRSIM (ie. rejected config).
 func (n *sros) MonitorLogs(ctx context.Context, reader io.ReadCloser) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/nodes/sros/sros_default_config.go.tpl
+++ b/nodes/sros/sros_default_config.go.tpl
@@ -1,5 +1,5 @@
 {{ .SNMPConfig }}
-{{ .LoggingConfig }} 
+{{ .LoggingConfig }}
 {{ .GRPCConfig }}
 {{ .SNMPConfig }}
 {{ .NetconfConfig }}

--- a/nodes/sros/version.go
+++ b/nodes/sros/version.go
@@ -42,7 +42,7 @@ var (
 	sshConfig string
 )
 
-// SrosVersion represents an SR-OS version as a set of fields.
+// SrosVersion represents an SR OS version as a set of fields.
 type SrosVersion struct {
 	Major string
 	Minor string

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -1347,5 +1347,4 @@ func (d *DockerRuntime) StreamLogs(ctx context.Context, containerName string) (i
 	}
 
 	return logStream, nil
-
 }

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -1329,4 +1330,22 @@ func (*DockerRuntime) GetCooCBindMounts() clabtypes.Binds {
 		clabtypes.NewBind("/var/lib/docker/containers", "/var/lib/docker/containers", ""),
 		clabtypes.NewBind("/run/netns", "/run/netns", ""),
 	}
+}
+
+func (d *DockerRuntime) StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error) {
+	logOptions := container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		Timestamps: false,
+		Since:      time.Now().Format(time.RFC3339),
+	}
+
+	logStream, err := d.Client.ContainerLogs(ctx, containerName, logOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container logs: %v", err)
+	}
+
+	return logStream, nil
+
 }

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -1332,7 +1332,10 @@ func (*DockerRuntime) GetCooCBindMounts() clabtypes.Binds {
 	}
 }
 
-func (d *DockerRuntime) StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error) {
+func (d *DockerRuntime) StreamLogs(
+	ctx context.Context,
+	containerName string,
+) (io.ReadCloser, error) {
 	logOptions := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,

--- a/runtime/ignite/ignite.go
+++ b/runtime/ignite/ignite.go
@@ -3,6 +3,7 @@ package ignite
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -517,4 +518,8 @@ func (*IgniteRuntime) GetRuntimeSocket() (string, error) {
 
 func (*IgniteRuntime) GetCooCBindMounts() clabtypes.Binds {
 	return nil
+}
+
+func (*IgniteRuntime) StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("StreamLogs not implemented for Ignite runtime")
 }

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -6,6 +6,7 @@ package podman
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"time"
@@ -488,4 +489,8 @@ func (r *PodmanRuntime) GetRuntimeSocket() (string, error) {
 		}
 	}
 	return socket, nil
+}
+
+func (*PodmanRuntime) StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("StreamLogs not implemented for Podman runtime")
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -74,6 +75,9 @@ type ContainerRuntime interface {
 	// Container-outside-of-Container (CooC - General case – container uses host container
 	// runtime) does need to function properly
 	GetCooCBindMounts() clabtypes.Binds
+	// StreamLogs returns a reader for the container's logs
+	// The caller needs to close the returned ReadCloser.
+	StreamLogs(ctx context.Context, containerName string) (io.ReadCloser, error)
 }
 
 type ContainerStatus string

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -323,12 +323,12 @@
                                 "description": "Set component type"
                             },
                             "sfm": {
-                                "description": "Set SFM type (SR-OS specific).",
+                                "description": "Set SFM type (SR OS specific).",
                                 "$ref": "#/definitions/sros-sfm-types"
                             },
                             "xiom": {
                                 "type": "array",
-                                "description": "Define list of XIOMs (SR-OS Specific). Each XIOM must have values of 'slot' and 'type'. MDAs must be defined under the XIOM.",
+                                "description": "Define list of XIOMs (SR OS Specific). Each XIOM must have values of 'slot' and 'type'. MDAs must be defined under the XIOM.",
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -371,7 +371,7 @@
                             },
                             "mda": {
                                 "type": "array",
-                                "description": "Define list of MDAs (SR-OS Specific). Each defined MDA must have values of 'slot' and 'type'",
+                                "description": "Define list of MDAs (SR OS Specific). Each defined MDA must have values of 'slot' and 'type'",
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -380,7 +380,7 @@
                                             "minimum": 1
                                         },
                                         "type": {
-                                            "description": "Set MDA type (SR-OS specific)",
+                                            "description": "Set MDA type (SR OS specific)",
                                             "$ref": "#/definitions/sros-mda-types"
                                         }
                                     },
@@ -1484,7 +1484,7 @@
         },
         "sros-card-types": {
             "type": "string",
-            "description": "Card types for SR-OS",
+            "description": "Card types for SR OS",
             "enum": [
                 "xcm-x20",
                 "imm40-10gb-sfp",
@@ -1539,7 +1539,7 @@
         },
         "sros-cpm-types": {
             "type": "string",
-            "description": "CPM card types for SR-OS",
+            "description": "CPM card types for SR OS",
             "enum": [
                 "cpm-x20",
                 "cpm-v",
@@ -1573,7 +1573,7 @@
         },
         "sros-mda-types": {
             "type": "string",
-            "description": "MDA types for SR-OS",
+            "description": "MDA types for SR OS",
             "enum": [
                 "x12-400g-qsfpdd",
                 "x6-200g-cfp2-dco",
@@ -1680,7 +1680,7 @@
         },
         "sros-xiom-types": {
             "type": "string",
-            "description": "XIOM types for SR-OS",
+            "description": "XIOM types for SR OS",
             "enum": [
                 "iom-s-3.0t",
                 "iom-s-1.5t",
@@ -1692,7 +1692,7 @@
         },
         "sros-xiom-mda-types": {
             "type": "string",
-            "description": "XIOM MDA types for SR-OS",
+            "description": "XIOM MDA types for SR OS",
             "enum": [
                 "ms6-200gb-cfp2-dco",
                 "ms3-200gb-cfp2-dco",
@@ -1717,7 +1717,7 @@
         },
         "sros-sfm-types": {
             "type": "string",
-            "description": "SFM types for SR-OS",
+            "description": "SFM types for SR OS",
             "enum": [
                 "m-sfm5-12",
                 "m-sfm5-7",

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// StripNonPrintChars removes non-printable characters from the string.
+func StripNonPrintChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if !unicode.IsPrint(r) {
+			return -1
+		}
+		return r
+	}, s)
+}


### PR DESCRIPTION
Sometimes when a srsim node is deployed and the startup config is rejected, the deploy will hang with no meaningful message.. but if you check the ctr logs you will see some log messages about invalid config and that the fallback default config is now being used.

This change will start monitoring the logs during PostDeploy and catch if these messages come about, and show them to the user in the `clab deploy` logs.

Of course it will still hang currently, but the user at least knows what to do.. If we want to go a step further, we could maybe match on the `Configuration load failed - using default configuration` and just let the postdeploy finish so at least the deploy finishes and the user can login to the node.

I don't know if you want to keep the log severities as I have done currently, maybe everything should be a warn instead? let me know.

https://github.com/user-attachments/assets/cdb6389d-e51c-4b68-ad6b-57c2f06d48e5

