### PR TITLE
Revert "sudoless for inspect cmd (#2862)"

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -32,9 +32,6 @@ func inspectCmd(o *Options) (*cobra.Command, error) {
 		Long: "show details about a particular lab or all running labs\n" +
 			"reference: https://containerlab.dev/cmd/inspect/",
 		Aliases: []string{"ins", "i"},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			return clabutils.CheckAndGetRootPrivs()
-		},
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			return inspectFn(cobraCmd, o)
 		},


### PR DESCRIPTION
This reverts commit 1771415aead6c94583efcd3cee2608cb54e3a4ee.

I have realized that it is intended (as per the doc) to not require root for inspect command. My problem was that my user was not part of docker group.