### PR TITLE
Adds support for Cisco SD-WAN controllers and C8000v controller mode.

### DIFF
--- a/core/register.go
+++ b/core/register.go
@@ -11,6 +11,7 @@ import (
 	clabnodesc8000 "github.com/srl-labs/containerlab/nodes/c8000"
 	clabnodesceos "github.com/srl-labs/containerlab/nodes/ceos"
 	clabnodescheckpoint_cloudguard "github.com/srl-labs/containerlab/nodes/checkpoint_cloudguard"
+	clabnodesvrCiscoSdwan "github.com/srl-labs/containerlab/nodes/vr_cisco_sdwan"
 	clabnodescjunosevolved "github.com/srl-labs/containerlab/nodes/cjunosevolved"
 	clabnodescrpd "github.com/srl-labs/containerlab/nodes/crpd"
 	clabnodescvx "github.com/srl-labs/containerlab/nodes/cvx"
@@ -62,6 +63,7 @@ func (c *CLab) RegisterNodes() {
 	clabnodesbridge.Register(c.Reg)
 	clabnodesceos.Register(c.Reg)
 	clabnodescheckpoint_cloudguard.Register(c.Reg)
+	clabnodesvrCiscoSdwan.Register(c.Reg)
 	clabnodescrpd.Register(c.Reg)
 	clabnodescvx.Register(c.Reg)
 	clabnodesext_container.Register(c.Reg)

--- a/docs/manual/kinds/vr-c8000v.md
+++ b/docs/manual/kinds/vr-c8000v.md
@@ -79,15 +79,28 @@ GigabitEthernet2       unassigned      YES unset  administratively down down
 
 ## Features and options
 
-### Default node configuration
+### Operating Modes
 
-It is possible to launch nodes of `cisco_c8000v` kind with a basic config or to provide a custom config file that will be used as a startup config instead.
+The c8000v supports two modes via the `type` parameter:
 
-When a node is defined without `startup-config` statement present, the node will boot with a factory config
+- **`autonomous`** (default): Traditional IOS-XE routing
+- **`controller`**: SD-WAN controller-managed mode
+
+```yaml
+topology:
+  nodes:
+    edge:
+      kind: cisco_c8000v
+      type: controller  # For SD-WAN managed devices
+      image: vrnetlab/vr-c8000v:17.11.01a
+```
+
+When using `controller` mode, the device can either take a full SD-WAN bootstrap config or a regular device-config.
+If no config is provided the management interface will be in vrf 513 as a temporary management vrf. This is required as vpn 512 cannot be created without being in vManage mode in newer IOS-XE releases.
 
 ### User defined config
 
-With a [`startup-config`](../nodes.md#startup-config) property a user sets the path to the config file that will be mounted to a container and used as a startup-config:
+Use [`startup-config`](../nodes.md#startup-config) to provide a custom configuration file:
 
 ```yaml
 name: c8000v

--- a/docs/manual/kinds/vr_cisco_sdwan.md
+++ b/docs/manual/kinds/vr_cisco_sdwan.md
@@ -1,0 +1,256 @@
+---
+search:
+  boost: 4
+kind_code_name: vr_cisco_sdwan
+kind_display_name: Cisco SD-WAN Controllers
+---
+# Cisco SD-WAN
+
+Cisco SD-WAN controller components are identified with `{{ kind_code_name }}` kind in the [topology file](../topo-def-file.md).
+
+This kind supports all three Cisco SD-WAN controller components:
+
+- **vManage**: Orchestration and management
+- **vSmart**: Control plane controller
+- **vBond**: Orchestrator/validator
+
+## Hardware resource requirements
+
+| Component | vCPU | RAM   | Disk       |
+|-----------|------|-------|------------|
+| vManage   | 1    | 16 GB | 30 GB + 50 GB data |
+| vSmart    | 1    | 4 GB  | 30 GB      |
+| vBond     | 1    | 2 GB  | 30 GB      |
+
+## Managing cisco_sdwan nodes
+
+/// note
+SD-WAN components boot in 5-10 minutes. Monitor progress with:
+
+```bash
+docker logs -f <container-name>
+```
+
+Wait for `System Ready` or `All daemons up` message.
+///
+
+/// tab | SSH
+
+`ssh admin@<node-name>`
+Password: `admin`
+///
+/// tab | bash
+To connect to a `bash` shell:
+
+```bash
+docker exec -it <container-name/id> bash
+```
+
+///
+
+/// note
+Default credentials: `admin:admin`
+///
+
+## Component Types
+
+Specify the component type using the `type` parameter:
+
+- `manager` - vManage orchestrator
+- `controller` - vSmart control plane
+- `validator` - vBond orchestrator
+
+```yaml
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      image: vrnetlab/cisco_sdwan-manager:20.16.1
+
+    sdwan-controller:
+      kind: vr_cisco_sdwan
+      type: controller
+      image: vrnetlab/cisco_sdwan-controller:20.16.1
+
+    sdwan-validator:
+      kind: vr_cisco_sdwan
+      type: validator
+      image: vrnetlab/cisco_sdwan-validator:20.16.1
+```
+
+## Interface naming
+
+You can use [interfaces names](../topo-def-file.md#interface-naming) in the topology file like they appear in the device.
+
+The interface naming convention is: `ethX`, where `X` starts at 1.
+
+- `eth0` - Management interface (VPN 512)
+- `eth1` - First transport interface (VPN 0)
+- `eth2+` - Additional transport interfaces
+
+```yaml
+links:
+  - endpoints: ["sdwan-manager:eth1", "sdwan-validator:eth1"]
+```
+
+## Features and options
+
+### Startup Configuration
+
+The cisco_sdwan kind supports two configuration file formats:
+
+#### zCloud XML Configuration
+
+```yaml
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      startup-config: sdwan-manager-config.xml
+```
+
+Example zCloud XML (`sdwan-manager-config.xml`):
+
+```xml
+<config xmlns="http://tail-f.com/ns/config/1.0">
+  <system xmlns="http://viptela.com/system">
+    <personality>vmanage</personality>
+    <device-model>vmanage</device-model>
+    <host-name>my-vmanage</host-name>
+    <aaa>
+      <user>
+        <name>admin</name>
+        <password>MyPassword</password>
+        <group>netadmin</group>
+      </user>
+    </aaa>
+  </system>
+  <vpn xmlns="http://viptela.com/vpn">
+    <vpn-instance>
+      <vpn-id>512</vpn-id>
+      <interface>
+        <if-name>eth0</if-name>
+        <ip>
+          <dhcp-client>true</dhcp-client>
+        </ip>
+      </interface>
+    </vpn-instance>
+  </vpn>
+</config>
+```
+
+#### Full Cloud-Init Configuration
+
+```yaml
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      startup-config: sdwan-manager-cloud-init.yaml
+```
+
+Example cloud-init (`sdwan-manager-cloud-init.yaml`):
+
+```yaml
+#cloud-config
+write_files:
+- path: /etc/default/personality
+  content: "vmanage\n"
+- path: /etc/confd/init/zcloud.xml
+  content: |
+    <config xmlns="http://tail-f.com/ns/config/1.0">
+      <!-- zCloud XML content here -->
+    </config>
+```
+
+If no `startup-config` is provided, the component will boot with auto-generated default configuration.
+
+## Lab examples
+
+### Basic SD-WAN Controllers
+
+```yaml
+name: sdwan-controllers
+
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      image: vrnetlab/cisco_sdwan-manager:20.16.1
+
+    sdwan-controller:
+      kind: vr_cisco_sdwan
+      type: controller
+      image: vrnetlab/cisco_sdwan-controller:20.16.1
+
+    sdwan-validator:
+      kind: vr_cisco_sdwan
+      type: validator
+      image: vrnetlab/cisco_sdwan-validator:20.16.1
+
+  links:
+    - endpoints: ["sdwan-manager:eth1", "sdwan-validator:eth1"]
+    - endpoints: ["sdwan-controller:eth1", "sdwan-validator:eth1"]
+```
+
+### SD-WAN with Edge Devices
+
+```yaml
+name: sdwan-fabric
+
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      image: vrnetlab/cisco_sdwan-manager:20.16.1
+
+    sdwan-controller:
+      kind: vr_cisco_sdwan
+      type: controller
+      image: vrnetlab/cisco_sdwan-controller:20.16.1
+
+    sdwan-validator:
+      kind: vr_cisco_sdwan
+      type: validator
+      image: vrnetlab/cisco_sdwan-validator:20.16.1
+
+    edge1:
+      kind: cisco_c8000v
+      type: controller  # SD-WAN managed mode
+      image: vrnetlab/vr-c8000v:17.11.01a
+
+  links:
+    - endpoints: ["sdwan-manager:eth1", "sdwan-validator:eth1"]
+    - endpoints: ["sdwan-controller:eth1", "sdwan-validator:eth1"]
+    - endpoints: ["edge1:Gi2", "sdwan-validator:eth1"]
+```
+
+### With Custom Configuration
+
+```yaml
+name: sdwan-custom
+
+topology:
+  nodes:
+    sdwan-manager:
+      kind: vr_cisco_sdwan
+      type: manager
+      startup-config: configs/sdwan-manager-zcloud.xml
+      image: vrnetlab/cisco_sdwan-manager:20.16.1
+
+    sdwan-controller:
+      kind: vr_cisco_sdwan
+      type: controller
+      startup-config: configs/sdwan-controller-cloud-init.yaml
+      image: vrnetlab/cisco_sdwan-controller:20.16.1
+
+    sdwan-validator:
+      kind: vr_cisco_sdwan
+      type: validator
+      image: vrnetlab/cisco_sdwan-validator:20.16.1
+```

--- a/nodes/vr_cisco_sdwan/cisco_sdwan.go
+++ b/nodes/vr_cisco_sdwan/cisco_sdwan.go
@@ -1,0 +1,226 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cisco_sdwan
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	clabutils "github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindNames          = []string{"vr_cisco_sdwan"}
+	defaultCredentials = clabnodes.NewCredentials("admin", "admin")
+
+	InterfaceRegexp = regexp.MustCompile(`eth(?P<port>\d+)$`)
+	InterfaceOffset = 1
+	InterfaceHelp   = "ethX (where X >= 1)"
+)
+
+const (
+	scrapliPlatformName = "cisco_iosxe"
+
+	generateable     = true
+	generateIfFormat = "eth%d"
+
+	// Component types
+	componentTypeManager    = "manager"
+	componentTypeController = "controller"
+	componentTypeValidator  = "validator"
+
+	// Default component type if not specified
+	defaultComponentType = componentTypeManager
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *clabnodes.NodeRegistry) {
+	generateNodeAttributes := clabnodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	platformAttrs := &clabnodes.PlatformAttrs{
+		ScrapliPlatformName: scrapliPlatformName,
+	}
+
+	nrea := clabnodes.NewNodeRegistryEntryAttributes(
+		defaultCredentials,
+		generateNodeAttributes,
+		platformAttrs,
+	)
+
+	r.Register(kindNames, func() clabnodes.Node {
+		return new(ciscoSdwan)
+	}, nrea)
+}
+
+type ciscoSdwan struct {
+	clabnodes.VRNode
+	componentType string
+}
+
+func (n *ciscoSdwan) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) error {
+	// Init VRNode
+	n.VRNode = *clabnodes.NewVRNode(n, defaultCredentials, scrapliPlatformName)
+	// set virtualization requirement
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+
+	// Determine component type from NodeType field
+	// NodeType should be one of: manager, controller, validator
+	n.componentType = n.Cfg.NodeType
+	if n.componentType == "" {
+		n.componentType = defaultComponentType
+	}
+
+	// Validate component type
+	if !isValidComponentType(n.componentType) {
+		return fmt.Errorf(
+			"invalid component type %q for vr_cisco_sdwan node %q. Must be one of: manager, controller, validator",
+			n.componentType,
+			n.Cfg.ShortName,
+		)
+	}
+
+	// env vars are used to set launch.py arguments in vrnetlab container
+	defEnv := map[string]string{
+		"CONNECTION_MODE":    clabnodes.VrDefConnMode,
+		"USERNAME":           defaultCredentials.GetUsername(),
+		"PASSWORD":           defaultCredentials.GetPassword(),
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+	}
+	n.Cfg.Env = clabutils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	// mount config dir to support cloud-init configuration
+	n.Cfg.Binds = append(
+		n.Cfg.Binds,
+		fmt.Sprint(path.Join(n.Cfg.LabDir, n.ConfigDirName), ":/config"),
+	)
+
+	if n.Cfg.Env["CONNECTION_MODE"] == "macvtap" {
+		// mount dev dir to enable macvtap
+		n.Cfg.Binds = append(n.Cfg.Binds, "/dev:/dev")
+	}
+
+	// Build launch.py command with component-specific parameters
+	n.Cfg.Cmd = fmt.Sprintf(
+		"--username %s --password %s --hostname %s --connection-mode %s --component-type %s --trace",
+		n.Cfg.Env["USERNAME"],
+		n.Cfg.Env["PASSWORD"],
+		n.Cfg.ShortName,
+		n.Cfg.Env["CONNECTION_MODE"],
+		n.componentType,
+	)
+
+	n.InterfaceRegexp = InterfaceRegexp
+	n.InterfaceOffset = InterfaceOffset
+	n.InterfaceHelp = InterfaceHelp
+
+	return nil
+}
+
+func (n *ciscoSdwan) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) error {
+	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
+	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
+	if err != nil {
+		return err
+	}
+
+	return createCiscoSdwanFiles(n)
+}
+
+func (n *ciscoSdwan) GetImages(_ context.Context) map[string]string {
+	images := make(map[string]string)
+
+	// Determine image name based on component type
+	// vrnetlab builds images as: vrnetlab/cisco_sdwan-{manager,controller,validator}:version
+	imageName := n.Cfg.Image
+	if imageName == "" {
+		// If no image specified, construct default image name
+		// User will need to specify the version tag
+		imageName = fmt.Sprintf("vrnetlab/cisco_sdwan-%s", n.componentType)
+	}
+
+	images[clabnodes.ImageKey] = imageName
+
+	return images
+}
+
+// isValidComponentType checks if the component type is valid.
+func isValidComponentType(componentType string) bool {
+	switch componentType {
+	case componentTypeManager, componentTypeController, componentTypeValidator:
+		return true
+	default:
+		return false
+	}
+}
+
+// createCiscoSdwanFiles handles startup configuration files for Cisco SD-WAN nodes.
+// It supports both cloud-init.yaml (full) and zcloud.xml (partial) configuration files.
+func createCiscoSdwanFiles(node *ciscoSdwan) error {
+	nodeCfg := node.Config()
+
+	// Skip if no startup config is specified
+	if nodeCfg.StartupConfig == "" {
+		return nil
+	}
+
+	// Determine config file type and destination based on file extension
+	configDir := filepath.Join(nodeCfg.LabDir, node.ConfigDirName)
+
+	// Ensure config directory exists
+	clabutils.CreateDirectory(configDir, clabconstants.PermissionsOpen)
+
+	var dstFilename string
+	ext := strings.ToLower(filepath.Ext(nodeCfg.StartupConfig))
+
+	switch {
+	case ext == ".yaml" || ext == ".yml":
+		// Full cloud-init file
+		dstFilename = "cloud-init.yaml"
+		log.Debugf("Using cloud-init configuration file for node %s", nodeCfg.ShortName)
+	case ext == ".xml":
+		// zCloud XML configuration
+		dstFilename = "zcloud.xml"
+		log.Debugf("Using zCloud XML configuration file for node %s", nodeCfg.ShortName)
+	default:
+		return fmt.Errorf(
+			"unsupported startup config file format for node %s: %s. Supported formats: .yaml/.yml (cloud-init) or .xml (zcloud)",
+			nodeCfg.ShortName,
+			nodeCfg.StartupConfig,
+		)
+	}
+
+	dst := filepath.Join(configDir, dstFilename)
+
+	// Check if config already exists
+	if _, err := os.Stat(dst); err == nil {
+		log.Infof("Config file already exists for node %s at %s", nodeCfg.ShortName, dst)
+		return nil
+	}
+
+	// Copy the startup config to the destination
+	if err := clabutils.CopyFile(context.Background(), nodeCfg.StartupConfig, dst,
+		clabconstants.PermissionsFileDefault); err != nil {
+		return fmt.Errorf("failed to copy startup config [src: %s -> dst: %s]: %v",
+			nodeCfg.StartupConfig, dst, err)
+	}
+
+	log.Debugf("Copied startup config: %s -> %s", nodeCfg.StartupConfig, dst)
+
+	return nil
+}


### PR DESCRIPTION
 Changes:
  - vr_cisco_sdwan node kind: Supports manager, controller, and validator components with zCloud XML and cloud-init configs
  - C8000v modes: Added autonomous/controller mode support via type parameter

Related to the following vrnetlab PR: https://github.com/srl-labs/vrnetlab/pull/396
