### PR TITLE
Add QEMU_CPU configuration to vr-pan.go

### DIFF
--- a/nodes/vr_pan/vr-pan.go
+++ b/nodes/vr_pan/vr-pan.go
@@ -63,6 +63,7 @@ func (n *vrPan) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) er
 		"RAM":                "6144",
 		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
 		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+		"QEMU_CPU": "qemu64",
 	}
 	n.Cfg.Env = clabutils.MergeStringMaps(defEnv, n.Cfg.Env)
 


### PR DESCRIPTION
The PAN VM requires this env var to be set for the image to boot on the hardware I've tested with. This holds true across all supported images on the wiki, but I am using 11.2.3-h3 as it's the one I have access to.

Broken Topology:

```
name: palo-alto-test 

topology:
  nodes:
    palo-1:
      kind: paloalto_panos
      image: vrnetlab/paloalto_pa-vm:11.2.3-h3
    rtr-a:
      kind: cisco_iol
      image: vrnetlab/cisco_iol:17.16.01
    rtr-b:
      kind: cisco_iol
      image: vrnetlab/cisco_iol:17.16.01

  links:
    # inter-switch link
    - endpoints: [ "rtr-b:e0/1", "palo-1:eth1" ]
    - endpoints: [ "palo-1:eth2", "rtr-a:e0/1" ]
```

Logs:

```[*]─[xxx]─[~/clab]
└──> docker logs -f f850be3c72ac
2025-10-31 16:19:39,095: launch         DEBUG Environment variables: environ({'CLAB_INTFS': '2', 'CLAB_LABEL_CLAB_NODE_GROUP': '', 'CLAB_LABEL_CLAB_NODE_KIND': 'paloalto_panos', 'CLAB_LABEL_CLAB_NODE_LAB_DIR': '/home/xxx/clab/palo-alto-test/clab-palo-alto-test/palo-1', 'CLAB_LABEL_CLAB_NODE_LONGNAME': 'clab-palo-alto-test-palo-1', 'CLAB_LABEL_CLAB_NODE_NAME': 'palo-1', 'CLAB_LABEL_CLAB_NODE_TYPE': '', 'CLAB_LABEL_CLAB_OWNER': 'xxx', 'CLAB_LABEL_CLAB_TOPO_FILE': '/home/xxx/clab/palo-alto-test/palo-alto-test.clab.yml', 'CLAB_LABEL_CONTAINERLAB': 'palo-alto-test', 'CONNECTION_MODE': 'tc', 'DOCKER_NET_V4_ADDR': '172.20.20.0/24', 'DOCKER_NET_V6_ADDR': '3fff:172:20:20::/64', 'HOME': '/root', 'HOSTNAME': 'palo-1', 'NO_PROXY': 'localhost,127.0.0.1,::1,*.local,172.20.20.0/24,3fff:172:20:20::/64,palo-1,rtr-a,rtr-b', 'PASSWORD': 'Admin@123', 'PATH': '/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'RAM': '6144', 'TERM': 'xterm', 'USERNAME': 'admin', 'VCPU': '2', 'VIRTUAL_ENV': '/.venv', 'no_proxy': 'localhost,127.0.0.1,::1,*.local,172.20.20.0/24,3fff:172:20:20::/64,palo-1,rtr-a,rtr-b', 'LC_CTYPE': 'C.UTF-8'})
2025-10-31 16:19:39,096: vrnetlab       DEBUG class: PAN_vm, disk_image: /PA-VM-KVM-11.2.3-h3.qcow2, overlay: /PA-VM-KVM-11.2.3-h3-overlay.qcow2
2025-10-31 16:19:39,096: vrnetlab       DEBUG Creating overlay disk image
2025-10-31 16:19:39,111: vrnetlab       DEBUG Starting vrnetlab PAN
2025-10-31 16:19:39,112: vrnetlab       DEBUG VMs: [<__main__.PAN_vm object at 0x7f1ad38c18e0>]
2025-10-31 16:19:39,112: vrnetlab       DEBUG VM not started; starting!
2025-10-31 16:19:39,112: vrnetlab       INFO ----------------START ENVIRONMENT VARIABLES-----------------
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_INTFS: 2
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_GROUP: 
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_KIND: paloalto_panos
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_LAB_DIR: /home/t3040846/clab/palo-alto-test/clab-palo-alto-test/palo-1
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_LONGNAME: clab-palo-alto-test-palo-1
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_NAME: palo-1
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_NODE_TYPE: 
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_OWNER: t3040846
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CLAB_TOPO_FILE: /home/t3040846/clab/palo-alto-test/palo-alto-test.clab.yml
2025-10-31 16:19:39,112: vrnetlab       INFO CLAB_LABEL_CONTAINERLAB: palo-alto-test
2025-10-31 16:19:39,112: vrnetlab       INFO CONNECTION_MODE: tc
2025-10-31 16:19:39,112: vrnetlab       INFO DOCKER_NET_V4_ADDR: 172.20.20.0/24
2025-10-31 16:19:39,112: vrnetlab       INFO DOCKER_NET_V6_ADDR: 3fff:172:20:20::/64
2025-10-31 16:19:39,112: vrnetlab       INFO HOME: /root
2025-10-31 16:19:39,112: vrnetlab       INFO HOSTNAME: palo-1
2025-10-31 16:19:39,112: vrnetlab       INFO LC_CTYPE: C.UTF-8
2025-10-31 16:19:39,112: vrnetlab       INFO NO_PROXY: localhost,127.0.0.1,::1,*.local,172.20.20.0/24,3fff:172:20:20::/64,palo-1,rtr-a,rtr-b
2025-10-31 16:19:39,112: vrnetlab       INFO PASSWORD: Admin@123
2025-10-31 16:19:39,112: vrnetlab       INFO PATH: /.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
2025-10-31 16:19:39,112: vrnetlab       INFO RAM: 6144
2025-10-31 16:19:39,112: vrnetlab       INFO TERM: xterm
2025-10-31 16:19:39,112: vrnetlab       INFO USERNAME: admin
2025-10-31 16:19:39,112: vrnetlab       INFO VCPU: 2
2025-10-31 16:19:39,112: vrnetlab       INFO VIRTUAL_ENV: /.venv
2025-10-31 16:19:39,112: vrnetlab       INFO no_proxy: localhost,127.0.0.1,::1,*.local,172.20.20.0/24,3fff:172:20:20::/64,palo-1,rtr-a,rtr-b
2025-10-31 16:19:39,112: vrnetlab       INFO -----------------END ENVIRONMENT VARIABLES------------------
2025-10-31 16:19:39,112: vrnetlab       INFO Launching PAN_vm with 4,sockets=2,cores=2 SMP/VCPU and 6144 M of RAM
2025-10-31 16:19:39,112: vrnetlab       INFO Scrapli: Disabled
2025-10-31 16:19:39,112: vrnetlab       INFO Transparent mgmt interface: Disabled
2025-10-31 16:19:39,113: vrnetlab       DEBUG number of provisioned data plane interfaces is 2
2025-10-31 16:19:39,113: vrnetlab       DEBUG waiting for provisioned interfaces to appear...
2025-10-31 16:19:39,113: vrnetlab       DEBUG highest allocated interface id determined to be: 2...
2025-10-31 16:19:39,113: vrnetlab       DEBUG interfaces provisioned, continuing...
2025-10-31 16:19:39,114: vrnetlab       DEBUG qemu cmd: qemu-system-x86_64 -enable-kvm -display none -machine pc -monitor tcp:0.0.0.0:4000,server,nowait -serial telnet:0.0.0.0:5000,server,nowait -m 6144 -cpu host,level=9 -smp 4,sockets=2,cores=2 -drive if=ide,file=/PA-VM-KVM-11.2.3-h3-overlay.qcow2 -uuid aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa -device pci-bridge,chassis_nr=1,id=pci.1 -device virtio-net-pci,netdev=p00,mac=0C:00:08:46:92:00 -netdev user,id=p00,net=10.0.0.0/24,host=10.0.0.2,dns=10.0.0.3,dhcpstart=10.0.0.15,hostfwd=tcp:0.0.0.0:22-10.0.0.15:22,hostfwd=udp:0.0.0.0:161-10.0.0.15:161,hostfwd=tcp:0.0.0.0:80-10.0.0.15:80,hostfwd=tcp:0.0.0.0:443-10.0.0.15:443,hostfwd=tcp:0.0.0.0:830-10.0.0.15:830,hostfwd=tcp:0.0.0.0:6030-10.0.0.15:6030,hostfwd=tcp:0.0.0.0:8080-10.0.0.15:8080,hostfwd=tcp:0.0.0.0:9339-10.0.0.15:9339,hostfwd=tcp:0.0.0.0:32767-10.0.0.15:32767,hostfwd=tcp:0.0.0.0:50051-10.0.0.15:50051,hostfwd=tcp:0.0.0.0:57400-10.0.0.15:57400,tftp=/tftpboot -device virtio-net-pci,netdev=p01,mac=0C:00:cb:31:9a:01,bus=pci.1,addr=0x2 -netdev tap,id=p01,ifname=tap1,script=/etc/tc-tap-ifup,downscript=no -device virtio-net-pci,netdev=p02,mac=0C:00:57:c8:ae:02,bus=pci.1,addr=0x3 -netdev tap,id=p02,ifname=tap2,script=/etc/tc-tap-ifup,downscript=no
2025-10-31 16:19:40,399: vrnetlab       INFO STDOUT: 
2025-10-31 16:19:40,399: vrnetlab       INFO STDERR: qemu-system-x86_64: error: failed to set MSR 0x345 to 0x2000
qemu-system-x86_64: ../../target/i386/kvm/kvm.c:3183: kvm_buf_set_msrs: Assertion `ret == cpu->kvm_msr_buf->nmsrs' failed.

2025-10-31 16:19:40,409: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 1)
2025-10-31 16:19:41,409: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 2)
2025-10-31 16:19:42,410: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 3)
2025-10-31 16:19:43,411: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 4)
2025-10-31 16:19:44,411: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 5)
2025-10-31 16:19:45,412: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 6)
2025-10-31 16:19:46,412: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 7)
2025-10-31 16:19:47,412: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 8)
2025-10-31 16:19:48,413: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 9)
2025-10-31 16:19:49,414: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 10)
2025-10-31 16:19:50,414: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 11)
2025-10-31 16:19:51,415: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 12)
2025-10-31 16:19:52,415: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 13)
2025-10-31 16:19:53,416: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 14)
2025-10-31 16:19:54,416: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 15)
2025-10-31 16:19:55,417: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 16)
2025-10-31 16:19:56,417: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 17)
2025-10-31 16:19:57,418: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 18)
2025-10-31 16:19:58,418: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 19)
2025-10-31 16:19:59,419: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 20)
2025-10-31 16:20:00,420: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 21)
2025-10-31 16:20:01,420: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 22)
2025-10-31 16:20:02,420: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 23)
2025-10-31 16:20:03,421: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 24)
2025-10-31 16:20:04,421: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 25)
2025-10-31 16:20:05,422: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 26)
2025-10-31 16:20:06,422: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 27)
2025-10-31 16:20:07,423: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 28)
2025-10-31 16:20:08,424: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 29)
2025-10-31 16:20:09,424: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 30)
2025-10-31 16:20:10,425: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 31)
2025-10-31 16:20:11,425: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 32)
2025-10-31 16:20:12,426: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 33)
2025-10-31 16:20:13,427: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 34)
2025-10-31 16:20:14,427: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 35)
2025-10-31 16:20:15,428: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 36)
2025-10-31 16:20:16,429: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 37)
2025-10-31 16:20:17,429: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 38)
2025-10-31 16:20:18,430: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 39)
2025-10-31 16:20:19,430: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 40)
2025-10-31 16:20:20,431: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 41)
2025-10-31 16:20:21,431: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 42)
2025-10-31 16:20:22,432: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 43)
2025-10-31 16:20:23,433: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 44)
2025-10-31 16:20:24,433: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 45)
2025-10-31 16:20:25,434: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 46)
2025-10-31 16:20:26,434: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 47)
2025-10-31 16:20:27,435: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 48)
2025-10-31 16:20:28,435: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 49)
2025-10-31 16:20:29,436: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 50)
2025-10-31 16:20:30,437: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 51)
2025-10-31 16:20:31,437: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 52)
2025-10-31 16:20:32,438: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 53)
2025-10-31 16:20:33,438: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 54)
2025-10-31 16:20:34,439: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 55)
2025-10-31 16:20:35,439: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 56)
2025-10-31 16:20:36,440: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 57)
2025-10-31 16:20:37,440: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 58)
2025-10-31 16:20:38,441: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 59)
2025-10-31 16:20:39,441: vrnetlab       ERROR Unable to connect to qemu monitor (port 4000), retrying in a second (attempt 60)
Traceback (most recent call last):
  File "/launch.py", line 242, in <module>
    vr.start()
  File "/vrnetlab.py", line 1050, in start
    vm.work()
  File "/vrnetlab.py", line 924, in work
    self.check_qemu()
  File "/vrnetlab.py", line 938, in check_qemu
    self.start()
  File "/vrnetlab.py", line 400, in start
    raise QemuBroken(
vrnetlab.QemuBroken: Unable to connect to qemu monitor on port 4000
```