### PR TITLE
VPP version pinning

### DIFF
--- a/tests/11-fdio-vpp/e2e-lab/vpp.clab.yml
+++ b/tests/11-fdio-vpp/e2e-lab/vpp.clab.yml
@@ -3,7 +3,7 @@ name: e2e-vpp
 topology:
   kinds:
     fdio_vpp:
-      image: git.ipng.ch/ipng/vpp-containerlab:v25.10-release
+      image: git.ipng.ch/ipng/vpp-containerlab:v25.02-release
       startup-config: config/__clabNodeName__/vppcfg.yaml
       binds:
         - config/__clabNodeName__/bird-local.conf:/etc/bird/bird-local.conf:ro


### PR DESCRIPTION
@pimvanpelt it seems the datapath tests started to fail with `latest` tag in the e2e test

This PR pins the version to something available as a tag in your repo, and if these fails I will temporarily remove the vpp test to unblock the pipeline