### PR TITLE
Disable TX checksum offload on host-side veth for SRSIM mgmt intf

### DIFF
--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -379,15 +379,15 @@ func (n *sros) PostDeploy(ctx context.Context, params *clabnodes.PostDeployParam
 		return err
 	}
 
-	// Disable TX checksum offload on host NS veth for mgmt intf.
-	var peerIntfindex int
-	err := n.ExecFunction(ctx, clabutils.GetVethPeerIndex("eth0", &peerIntfindex))
+	// Disable TX checksum offload on the host NS veth for the mgmt interface.
+	var peerIfIndex int
+	err := n.ExecFunction(ctx, clabutils.VethPeerIndex("eth0", &peerIfIndex))
 	if err != nil {
 		log.Warn("Failed to get veth peer index for SR-SIM mgmt interface",
 			"node", n.Cfg.ShortName,
 			"error", err)
 	} else {
-		if err := clabutils.DisableTxOffloadByIndex(peerIntfindex); err != nil {
+		if err := clabutils.DisableTxOffloadByIndex(peerIfIndex); err != nil {
 			log.Warn("Failed to disable TX checksum offload on SR-SIM mgmt host veth",
 				"node", n.Cfg.ShortName,
 				"error", err)

--- a/utils/ethtool.go
+++ b/utils/ethtool.go
@@ -85,9 +85,9 @@ func EthtoolTXOff(name string) error {
 	return ioctlEthtool(socket, uintptr(unsafe.Pointer(&request))) // skipcq: GSC-G103
 }
 
-// GetVethPeerIndex will get the intfindex of the veth peer for
-// the given interface name on the container.
-func GetVethPeerIndex(ifaceName string, peerIndex *int) func(ns.NetNS) error {
+// VethPeerIndex gets the interface index of the veth peer for
+// the given interface name in the container.
+func VethPeerIndex(ifaceName string, peerIndex *int) func(ns.NetNS) error {
 	return func(_ ns.NetNS) error {
 		link, err := netlink.LinkByName(ifaceName)
 		if err != nil {
@@ -109,21 +109,21 @@ func GetVethPeerIndex(ifaceName string, peerIndex *int) func(ns.NetNS) error {
 	}
 }
 
-// DisableTxOffloadByIndex disables TX checksum offload on an interface by intf index
+// DisableTxOffloadByIndex disables TX checksum offload on an interface by its index.
 func DisableTxOffloadByIndex(index int) error {
 	link, err := netlink.LinkByIndex(index)
 	if err != nil {
-		return fmt.Errorf("failed to find interface with ifindex %d: %v", index, err)
+		return fmt.Errorf("failed to find interface with index %d: %w", index, err)
 	}
 
 	ifaceName := link.Attrs().Name
 	log.Debugf("Disabling TX offload on interface %s (index %d)", ifaceName, index)
 
 	if err := EthtoolTXOff(ifaceName); err != nil {
-		return fmt.Errorf("failed to disable TX offload on %s: %v", ifaceName, err)
+		return fmt.Errorf("failed to disable TX offload on %s: %w", ifaceName, err)
 	}
 
-	log.Debug("Successfully disabled TX offload on host ns interface", "interface", ifaceName)
+	log.Debug("Successfully disabled TX offload on the host ns interface", "interface", ifaceName)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #2894 

We needed to disable the checksum offload on the veth pair for the mgmt interface of the SR-SIM node. is not as simple as disabling it for the eth0 interface.

I will add some tests soon. @sacckth please confirm this works if you can :)