### PR TITLE
Add check for exited containers in emitContainerSnapshots function

### DIFF
--- a/core/events/stream.go
+++ b/core/events/stream.go
@@ -315,7 +315,7 @@ func emitContainerSnapshots(
 ) {
 	for idx := range containers {
 		container := containers[idx]
-		if !isRunningContainer(&container) {
+		if !isRunningContainer(&container) && !strings.EqualFold(container.State, "exited") {
 			continue
 		}
 


### PR DESCRIPTION
Report exited clab containers during intial report ( "-i" ) 