### PR TITLE
schemas: Add container runtime network driver options field to the topology JSON schema

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -1836,6 +1836,26 @@
                     "type": "boolean",
                     "description": "controls whether the management network has external access or not",
                     "markdownDescription": "controls whether the [management network has external access](https://containerlab.dev/manual/network/#external-access) or not"
+                },
+                "driver-opts": {
+                    "type": "object",
+                    "description": "overrides for container runtime network driver options",
+                    "markdownDescription": "[driver-opts](https://containerlab.dev/manual/network/#bridge-network-driver-options) lets you set overrides for the network driver of the container runtime",
+                    "patternProperties": {
+                        ".+": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
+                    }
                 }
             },
             "minProperties": 1,


### PR DESCRIPTION
This adds the missing field. Thanks @BYT3M3 for pointing this out in #2648 !