### PR TITLE
Replace `github.com/pkg/errors` by stdlib packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/pmorjan/kmod v1.1.1
 	github.com/scrapli/scrapligo v1.3.3
 	github.com/scrapli/scrapligocfg v1.0.0
@@ -130,6 +129,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.7 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
 	clabcert "github.com/srl-labs/containerlab/cert"
@@ -606,7 +605,7 @@ func generateSRLTopologyFile(cfg *clabtypes.NodeConfig) error {
 
 	tpl, err := template.ParseFS(topologies, "topology/"+srlTypes[cfg.NodeType])
 	if err != nil {
-		return errors.Wrap(err, "failed to get srl topology file")
+		return fmt.Errorf("failed to get srl topology file: %w", err)
 	}
 
 	mac := genMac(cfg)


### PR DESCRIPTION
None of the extra features of the 3rd party `github.com/pkg/errors` package are needed, so use the standard library `errors.New` and `fmt.Errorf` available since Go 1.13, like already done in lots of places elsewhere in the code base.