### PR TITLE
srsim: add container labels for component parent node

### DIFF
--- a/constants/labels.go
+++ b/constants/labels.go
@@ -1,15 +1,17 @@
 package constants
 
 const (
-	Containerlab  = "containerlab"
-	NodeName      = "clab-node-name"
-	LongName      = "clab-node-longname"
-	NodeKind      = "clab-node-kind"
-	NodeType      = "clab-node-type"
-	NodeGroup     = "clab-node-group"
-	NodeLabDir    = "clab-node-lab-dir"
-	TopoFile      = "clab-topo-file"
-	NodeMgmtNetBr = "clab-mgmt-net-bridge"
-	Owner         = "clab-owner"
-	ToolType      = "tool-type"
+	Containerlab     = "containerlab"
+	NodeName         = "clab-node-name"
+	LongName         = "clab-node-longname"
+	NodeKind         = "clab-node-kind"
+	NodeType         = "clab-node-type"
+	NodeGroup        = "clab-node-group"
+	NodeLabDir       = "clab-node-lab-dir"
+	TopoFile         = "clab-topo-file"
+	NodeMgmtNetBr    = "clab-mgmt-net-bridge"
+	Owner            = "clab-owner"
+	ToolType         = "tool-type"
+	RootNodeName     = "clab-root-node-name"
+	RootNodeLongName = "clab-root-node-longname"
 )

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -621,6 +621,8 @@ func (n *sros) setupComponentNodes() error {
 		// adjust labels
 		componentConfig.Labels[clabconstants.NodeName] = componentConfig.ShortName
 		componentConfig.Labels[clabconstants.LongName] = componentConfig.LongName
+		componentConfig.Labels[clabconstants.RootNodeName] = n.Cfg.ShortName
+		componentConfig.Labels[clabconstants.RootNodeLongName] = n.Cfg.LongName
 
 		// init the component
 		err = componentNode.Init(componentConfig)

--- a/tests/13-srsim/05-sros-comp-to-linux.robot
+++ b/tests/13-srsim/05-sros-comp-to-linux.robot
@@ -36,6 +36,34 @@ Ensure sros is reachable over ssh
     ...    password=NokiaSros1!
     ...    try_for=10
 
+Confirm sros CPM component container has clab-root-node-name label
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    docker inspect -f '{{index .Config.Labels "clab-root-node-name"}}' clab-${lab-name}-sros-a
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Strings    ${output}    sros
+
+Confirm sros CPM component component container has clab-root-node-longname label
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    docker inspect -f '{{index .Config.Labels "clab-root-node-longname"}}' clab-${lab-name}-sros-a
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Strings    ${output}    clab-${lab-name}-sros
+
+Confirm sros LC component container has clab-root-node-name label
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    docker inspect -f '{{index .Config.Labels "clab-root-node-name"}}' clab-${lab-name}-sros-1
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Strings    ${output}    sros
+
+Confirm sros LC component component container has clab-root-node-longname label
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    docker inspect -f '{{index .Config.Labels "clab-root-node-longname"}}' clab-${lab-name}-sros-1
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Strings    ${output}    clab-${lab-name}-sros
+
 Verify links in node l1
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${CLAB_BIN} --runtime ${runtime} exec -t ${CURDIR}/${lab-file-name} --label clab-node-name\=l1 --cmd "ip link show eth1"


### PR DESCRIPTION
For distributed SR-SIM nodes, this adds a label to the component containers which help to identify the name of the root node. Helps to group SR-SIM nodes when inspecting containers (ie. for vsc ext)

For example

```yaml
name: test
topology:
  nodes:
    sros: # this is the 'root' node.. clab-test-sros
      kind: nokia_srsim
      type: sr-7s
      license: ./lic.txt
      image: registry.nlkc.dev/pub/nokia_srsim:25.7.R1
      components:
        - slot: A # this is the component node.. clab-test-sros-a
        - slot: 1 # this is the component node.. clab-test-sros-1
```