### PR TITLE
add correct labels to sr-sim image (upcoming feature)

### DIFF
--- a/nodes/sros/version.go
+++ b/nodes/sros/version.go
@@ -127,13 +127,12 @@ func (n *sros) srosVersionFromImage(ctx context.Context) (*SrosVersion, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect image %s: %w", n.Cfg.Image, err)
 	}
-	// log.Infof("ImageInspect is %+v", imageInspect)
 	vendor, okVendor := imageInspect.Config.Labels[srosImageVendorLabel]
 	image, okTitle := imageInspect.Config.Labels[srosImageTitleLabel]
 	version, okVersion := imageInspect.Config.Labels[srosImageVersionLabel]
 
 	if okVendor && okTitle && okVersion && vendor == srosImageVendor && image == srosImageTitle {
-		return n.parseVersionString(version), err
+		return n.parseVersionString(version), nil
 	}
 
 	// Fallback: read directly from image layers via graph driver


### PR DESCRIPTION
This will enable faster version retrieval of the SR-SIM container images on versions greater than 25.10.R1
