### PR TITLE
Inline single use of `utils.IsTerminal`

### DIFF
--- a/core/destroy.go
+++ b/core/destroy.go
@@ -19,6 +19,7 @@ import (
 	clabruntimeignite "github.com/srl-labs/containerlab/runtime/ignite"
 	clabtypes "github.com/srl-labs/containerlab/types"
 	clabutils "github.com/srl-labs/containerlab/utils"
+	"golang.org/x/term"
 )
 
 func (c *CLab) Destroy(ctx context.Context, options ...DestroyOption) (err error) {
@@ -77,7 +78,7 @@ func (c *CLab) Destroy(ctx context.Context, options ...DestroyOption) (err error
 	log.Debugf("got the following topologies for destroy: %+v", topos)
 
 	// if all, and cli doesnt have --yes flag, and in a terminal -- prompt user confirmation
-	if opts.all && opts.terminalPrompt && clabutils.IsTerminal(os.Stdin.Fd()) {
+	if opts.all && opts.terminalPrompt && term.IsTerminal(int(os.Stdin.Fd())) {
 		err := cliPromptToDestroyAll(topos)
 		if err != nil {
 			return err

--- a/utils/term.go
+++ b/utils/term.go
@@ -1,8 +1,0 @@
-package utils
-
-import "golang.org/x/term"
-
-// IsTerminal returns true if the given file descriptor is a terminal.
-func IsTerminal(fd uintptr) bool {
-	return term.IsTerminal(int(fd))
-}


### PR DESCRIPTION
`utils.IsTerminal` is a simple wrapper around `golang.org/x/term.IsTerminal` that is already called directly elsewhere in core. Inline the remaining caller and drop `utils.IsTerminal`