### PR TITLE
Switch to Go 1.23+ stdlib `slices` package

### DIFF
--- a/core/clab.go
+++ b/core/clab.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +29,6 @@ import (
 	clabtypes "github.com/srl-labs/containerlab/types"
 	clabutils "github.com/srl-labs/containerlab/utils"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/exp/slices"
 )
 
 var ErrNodeNotFound = errors.New("node not found")

--- a/core/clab_test.go
+++ b/core/clab_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +19,6 @@ import (
 	_ "github.com/srl-labs/containerlab/runtime/all"
 	clabtypes "github.com/srl-labs/containerlab/types"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/slices"
 )
 
 // getNodeMap return a map of nodes for testing purpose.

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/weaveworks/ignite v0.10.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.43.0
-	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/sys v0.37.0
 	golang.org/x/term v0.36.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -155,6 +154,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250102185135-69823020774d // indirect
 	sigs.k8s.io/knftables v0.0.18 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/mermaid/graph.go
+++ b/internal/mermaid/graph.go
@@ -3,8 +3,7 @@ package mermaid
 import (
 	"fmt"
 	"io"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // A very minimalistic Mermaid flowchart generator

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -1,11 +1,11 @@
 package types
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	clabutils "github.com/srl-labs/containerlab/utils"
-	"golang.org/x/exp/slices"
 )
 
 var topologyTestSet = map[string]struct {

--- a/utils/resolve.go
+++ b/utils/resolve.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"io/fs"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/log"
-	"golang.org/x/exp/slices"
 )
 
 // ExtractDNSServersFromResolvConf extracts IP addresses


### PR DESCRIPTION
Use the `slices` package from the Go standard library instead of the `golang.org/x/exp/slices` package which merely wraps the stdlib package for the functions used here.