### PR TITLE
Ensure config directory exists for generic_vm before deploying it

### DIFF
--- a/nodes/generic_vm/generic_vm.go
+++ b/nodes/generic_vm/generic_vm.go
@@ -88,6 +88,8 @@ func (n *genericVM) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption
 
 func (n *genericVM) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) error {
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
+	// create config directory that will be bind mounted to vrnetlab container at /config path
+	clabutils.CreateDirectory(path.Join(n.Cfg.LabDir, configDirName), clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
 		return nil


### PR DESCRIPTION
The config directory isn't created by containerlab for generic_vm. Docker will create it automatically, but Podman fails:
```shell
clab --runtime=podman deploy 
21:28:39 INFO Containerlab started version=0.72.0
21:28:39 INFO Parsing & checking topology file=test.clab.yaml
21:28:39 INFO Creating lab directory path=/tmp/test/clab-test
21:28:39 ERRO failed deploy stage for node "ubuntu": statfs /tmp/test/clab-test/ubuntu/config: no such file or directory
          
   ERROR  
          
  Could not get container for node clab-test-ubuntu: Node: clab-test-ubuntu. containers not found.
```

For the Lab:
```yaml
name: test

topology:
  nodes:
    ubuntu:
      kind: generic_vm
      image: ubuntu
```