### PR TITLE
Docs: Enhance documentation for node exec property

### DIFF
--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -565,7 +565,10 @@ my-node:
   exec:
     - echo test123
     - bash /myscript.sh
+    - bash -c 'echo "foobar" > /root/wg-priv.key' #(1)!
 ```
+
+1. If you use shell tokens such as `>`, you need to wrap the command in the shell
 
 The `exec` is particularly helpful to provide some startup configuration for linux nodes such as IP addressing and routing instructions.
 


### PR DESCRIPTION
Explicitly document that if shell tokens are used, e.g. '>' to redirect output to a file, the entire command must be wrapped in the shell function

Thanks to @hellt  for pointing this out so quick in the Discord! Thought it's worth adding to the docs as an example.