### PR TITLE
node ceos: Add quotes for environment on startup

### DIFF
--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -106,7 +106,7 @@ func (n *ceos) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 	var envSb strings.Builder
 	envSb.WriteString("bash -c '" + ifWaitScriptContainerPath + " ; exec /sbin/init ")
 	for k, v := range n.Cfg.Env {
-		envSb.WriteString("systemd.setenv=" + k + "=" + v + " ")
+		envSb.WriteString("systemd.setenv=\"" + k + "=" + v + "\" ")
 	}
 	envSb.WriteString("'")
 


### PR DESCRIPTION
This patch adds support for using characters like space ' ' or pipe '|' to the environment of ceos nodes. This is required for clabs, that have bridges in a parent container namespace, as then the no_proxy environment is added for a node with the notation of br|container and the commandline will try to execute the part after the pipe.

fix: https://github.com/srl-labs/containerlab/issues/3004