### PR TITLE
Fix links and template references in inventory.md

### DIFF
--- a/docs/manual/inventory.md
+++ b/docs/manual/inventory.md
@@ -232,7 +232,7 @@ Containerlab internal data that is submitted for export via the template, has th
 --8<-- "core/export.go:37:44"
 ```
 
-To get the full list of fields available for export, you can export topology data with the [full template (`full.tmpl`)](https://github.com/srl-labs/containerlab/blob/main/core/export_templates/full.tmpl) using `--export-template /etc/containerlab/templates/export/full.tmpl` . Note, some fields exported via `full.tmpl` might contain sensitive information like TLS private keys. To customize export data, it is recommended to start with a copy of `auto.tmpl` and change it according to your needs.
+To get the full list of fields available for export, you can export topology data with the [full template (`full.tmpl`)](https://github.com/srl-labs/containerlab/blob/main/core/export_templates/full.tmpl) using `--export-template /etc/containerlab/templates/export/full.tmpl`. Note, some fields exported via `full.tmpl` might contain sensitive information like TLS private keys. To customize export data, it is recommended to start with a copy of `auto.tmpl` and change it according to your needs.
 
 Example of exported data when using default `auto.tmpl` template:
 


### PR DESCRIPTION
The links were broken since they got moved in July 2025:  https://github.com/srl-labs/containerlab/commits/main/core/export_templates/auto.tmpl