### PR TITLE
docs: Fix Open Graph image size

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,8 +19,8 @@
 <meta property="og:url" content="{{ page.canonical_url }}" />
 <meta property="og:image" content="{{ image }}" />
 <meta property="og:image:type" content="image/png" />
-<meta property="og:image:width" content="1092" />
-<meta property="og:image:height" content="954" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
 
 <!-- Twitter meta tags -->
 <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Unsquisssssssh.

<img width="345" height="377" alt="image" src="https://github.com/user-attachments/assets/bc9c2e61-4a65-4268-b0ad-213129830771" />
