### PR TITLE
Nokia SRSIM config generation simplification

### DIFF
--- a/.github/workflows/srsim-tests.yml
+++ b/.github/workflows/srsim-tests.yml
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull and re-tag srsim image
-        run: docker pull ghcr.io/srl-labs/containerlab/nokia_srsim:25.10.R1 && docker tag ghcr.io/srl-labs/containerlab/nokia_srsim:25.10.R1 registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+        run: docker pull ghcr.io/srl-labs/containerlab/nokia_srsim:25.10.R2 && docker tag ghcr.io/srl-labs/containerlab/nokia_srsim:25.10.R2 registry.srlinux.dev/pub/nokia_srsim:25.10.R2
 
       # - name: setup tmate session
       #   uses: mxschmitt/action-tmate@v3

--- a/nodes/sros/README.md
+++ b/nodes/sros/README.md
@@ -172,17 +172,18 @@ The configuration generation process follows a sophisticated pipeline that adapt
    │       ├─> Fallback to layer traversal
    │       └─> Store in n.swVersion
    │
-   ├─> Template Selection Phase
-   │   └─> getConfigTemplate()
-   │       ├─> Check for partial config
-   │       └─> Return appropriate template string
+   ├─> Startup config build phase
+   │   └─> buildStartupConfig()
+   │       ├─> If full user config: read file, substitute, return
+   │       └─> Else: addDefaultConfig() then addPartialConfig()
+   │           └─> addDefaultConfig()
+   │               ├─> prepareConfigTemplateData() (variant → snippet set)
+   │               ├─> selectConfigTemplate() (variant → template)
+   │               └─> Execute template → append to startup config
+   │       └─> Return full startup config string
    │
-   └─> Configuration Generation Phase
-       └─> GenerateConfig()
-           └─> addDefaultConfig()
-               ├─> prepareConfigTemplateData()
-               ├─> selectConfigTemplate()
-               └─> Execute template → final config
+   └─> Write config to node
+       └─> GenerateConfig(dst, startupConfig)
 
 2. Store the config file on the node filesystem
 2. PostDeploy Phase

--- a/nodes/sros/component_config.go
+++ b/nodes/sros/component_config.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package sros
+
+import (
+	"fmt"
+	"strings"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+// componentCfgLine represents one SR OS config line for a component (card, sfm, xiom, mda).
+// Adding a new component type = add a Kind and a case in String().
+type componentCfgLine struct {
+	Kind     string // "card", "sfm", "xiom", "xiomMda", "mda"
+	Slot     string
+	Type     string
+	XiomSlot int
+	MdaSlot  int
+}
+
+// String returns the SR OS CLI config line for this component.
+func (l componentCfgLine) String() string {
+	switch l.Kind {
+	case "card":
+		return fmt.Sprintf("/configure card %s card-type %s admin-state enable\n", l.Slot, l.Type)
+	case "sfm":
+		return fmt.Sprintf("/configure sfm %s sfm-type %s admin-state enable\n", l.Slot, l.Type)
+	case "xiom":
+		return fmt.Sprintf("/configure card %s xiom x%d xiom-type %s admin-state enable\n",
+			l.Slot, l.XiomSlot, l.Type)
+	case "xiomMda":
+		return fmt.Sprintf("/configure card %s xiom x%d mda %d mda-type %s admin-state enable\n",
+			l.Slot, l.XiomSlot, l.MdaSlot, l.Type)
+	case "mda":
+		return fmt.Sprintf("/configure card %s mda %d mda-type %s admin-state enable\n",
+			l.Slot, l.MdaSlot, l.Type)
+	default:
+		return ""
+	}
+}
+
+// buildComponentCfgLines turns root components into a slice of config lines (card, sfm, xiom, xiomMda, mda).
+// CPM slots (A, B) are skipped. Components without Type are skipped (caller may log).
+func buildComponentCfgLines(components []*clabtypes.Component) []componentCfgLine {
+	var lines []componentCfgLine
+	for _, component := range components {
+		slot := strings.ToUpper(strings.TrimSpace(component.Slot))
+		if slot == slotAName || slot == slotBName {
+			continue
+		}
+		if component.Type == "" {
+			continue
+		}
+		lines = append(lines, componentCfgLine{Kind: "card", Slot: slot, Type: component.Type})
+		if component.SFM != "" {
+			lines = append(lines, componentCfgLine{Kind: "sfm", Slot: slot, Type: component.SFM})
+		}
+		for _, xiom := range component.XIOM {
+			if xiom.Type != "" {
+				lines = append(lines, componentCfgLine{Kind: "xiom", Slot: slot, Type: xiom.Type, XiomSlot: xiom.Slot})
+			}
+			for _, mda := range xiom.MDA {
+				if mda.Type != "" {
+					lines = append(lines, componentCfgLine{
+						Kind: "xiomMda", Slot: slot, Type: mda.Type,
+						XiomSlot: xiom.Slot, MdaSlot: mda.Slot,
+					})
+				}
+			}
+		}
+		for _, mda := range component.MDA {
+			if mda.Type != "" {
+				lines = append(lines, componentCfgLine{Kind: "mda", Slot: slot, Type: mda.Type, MdaSlot: mda.Slot})
+			}
+		}
+	}
+	return lines
+}

--- a/nodes/sros/configs/sros_config_sros25.go.tpl
+++ b/nodes/sros/configs/sros_config_sros25.go.tpl
@@ -1,7 +1,6 @@
 {{ .SNMPConfig }}
 {{ .LoggingConfig }}
 {{ .GRPCConfig }}
-{{ .SNMPConfig }}
 {{ .NetconfConfig }}
 {{ .SystemConfig }}
 {{- if .Name }}

--- a/nodes/sros/configs_embed.go
+++ b/nodes/sros/configs_embed.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package sros
+
+import _ "embed"
+
+// Embedded service config snippets (base, IXR, SAR).
+// Used by config variant resolution to build startup config.
+var (
+	//go:embed configs/10_snmpv2.cfg
+	snmpv2Config string
+
+	//go:embed configs/11_logging.cfg
+	loggingConfig string
+
+	//go:embed configs/12_grpc.cfg
+	grpcConfig string
+
+	//go:embed configs/12_grpc_insecure.cfg
+	grpcConfigInsecure string
+
+	//go:embed configs/ixr/12_grpc.cfg
+	grpcConfigIXR string
+
+	//go:embed configs/ixr/12_grpc_insecure.cfg
+	grpcConfigIXRInsecure string
+
+	//go:embed configs/sar/12_grpc.cfg
+	grpcConfigSAR string
+
+	//go:embed configs/sar/12_grpc_insecure.cfg
+	grpcConfigSARInsecure string
+
+	//go:embed configs/13_netconf.cfg
+	netconfConfig string
+
+	//go:embed configs/14_system.cfg
+	systemCfg string
+
+	//go:embed configs/ixr/14_system.cfg
+	systemCfgIXR string
+
+	//go:embed configs/sar/14_system.cfg
+	systemCfgSAR string
+
+	//go:embed configs/15_ssh.cfg
+	sshConfig string
+)

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -996,7 +996,8 @@ func (n *sros) createSROSCertificates() error {
 	return nil
 }
 
-// createSROSConfigFiles handles the config generation for the SR-SIM kind.
+// createSROSConfigFiles handles config generation for the SR-SIM kind.
+// Flow: version detection → buildStartupConfig (default + partial) → GenerateConfig(dst, config).
 func (n *sros) createSROSConfigFiles() error {
 	// Get version from image before generating config
 	if n.swVersion == nil {
@@ -1026,25 +1027,27 @@ func (n *sros) createSROSConfigFiles() error {
 	log.Debug("Reading startup-config", "node", n.Cfg.ShortName, "startup-config",
 		n.Cfg.StartupConfig, "isPartial", isPartial)
 
-	cfgTemplate, err := n.getConfigTemplate(isPartial)
+	startupConfig, err := n.buildStartupConfig(isPartial)
 	if err != nil {
 		return err
 	}
 
-	if cfgTemplate == "" {
+	if startupConfig == "" {
 		log.Debug(
-			"configuration template is empty, skipping startup config file generation",
+			"startup config is empty, skipping startup config file generation",
 			"node",
 			n.Cfg.ShortName,
 		)
 		return nil
 	}
 
-	return n.GenerateConfig(cf3CfgFile, cfgTemplate)
+	return n.GenerateConfig(cf3CfgFile, startupConfig)
 }
 
-// getConfigTemplate retrieves the configuration template based on startup config settings.
-func (n *sros) getConfigTemplate(isPartial bool) (string, error) {
+// buildStartupConfig returns the full startup config string: either from user file (full config)
+// or from default + partial config generation. It does not return a template; the name is
+// historical.
+func (n *sros) buildStartupConfig(isPartial bool) (string, error) {
 	// User provides full startup config
 	if n.Cfg.StartupConfig != "" && !isPartial {
 		c, err := os.ReadFile(n.Cfg.StartupConfig)
@@ -1102,6 +1105,7 @@ func (n *sros) isCPM(cpm string) bool {
 }
 
 // prepareConfigTemplateData prepares all data needed for template selection and execution.
+// Service configs are filled from a single table-driven result: variant → getFullSnippetSet(v).
 func (n *sros) prepareConfigTemplateData() (*srosTemplateData, error) {
 	b, err := n.banner()
 	if err != nil {
@@ -1115,10 +1119,23 @@ func (n *sros) prepareConfigTemplateData() (*srosTemplateData, error) {
 		log.Debugf("SR-SIM node %q has non-partial startup-config defined, skipping component config gen", n.Cfg.LongName)
 	}
 
+	v := n.resolveConfigVariant()
+	snippets := getFullSnippetSet(v)
+	configMode := string(v.Mode)
+	if v.ForceClassic {
+		log.Warn(
+			"SAR-Hm nodes only support classic configuration mode. Overriding configuration mode to 'classic'",
+			"node", n.Cfg.LongName,
+			"node-type", strings.ToLower(n.Cfg.NodeType),
+		)
+		configMode = string(ConfigModeClassic)
+		n.Cfg.Env[envSrosConfigMode] = string(ConfigModeClassic)
+	}
+
 	tplData := &srosTemplateData{
 		// Selection criteria
 		NodeType:          strings.ToLower(n.Cfg.NodeType),
-		ConfigurationMode: strings.ToLower(n.Cfg.Env[envSrosConfigMode]),
+		ConfigurationMode: configMode,
 		SwVersion:         n.swVersion,
 		IsSecureGrpc:      *n.Cfg.Certificate.Issue,
 
@@ -1133,13 +1150,13 @@ func (n *sros) prepareConfigTemplateData() (*srosTemplateData, error) {
 		MgmtIPMTU:       n.Runtime.Mgmt().MTU,
 		ComponentConfig: componentConfig,
 
-		// Default service configs (will be overridden based on node type)
-		SystemConfig:  systemCfg,
-		SNMPConfig:    snmpv2Config,
-		GRPCConfig:    grpcConfig,
-		NetconfConfig: netconfConfig,
-		LoggingConfig: loggingConfig,
-		SSHConfig:     sshConfig,
+		// Service configs from variant (single source of truth)
+		SystemConfig:    snippets.SystemConfig,
+		GRPCConfig:      snippets.GRPCConfig,
+		SNMPConfig:      snippets.SNMPConfig,
+		NetconfConfig:   snippets.NetconfConfig,
+		LoggingConfig:   snippets.LoggingConfig,
+		SSHConfig:       snippets.SSHConfig,
 	}
 
 	if n.Config().DNS != nil {
@@ -1147,8 +1164,6 @@ func (n *sros) prepareConfigTemplateData() (*srosTemplateData, error) {
 	}
 
 	n.prepareSSHPubKeys(tplData)
-	n.applyNodeTypeSpecificConfig(tplData)
-
 	return tplData, nil
 }
 
@@ -1167,80 +1182,31 @@ func (n *sros) isSARHmNode() bool {
 	return sarHmRegexp.MatchString(n.Cfg.NodeType)
 }
 
-// applyNodeTypeSpecificConfig applies node-type and security specific overrides for Model-Driven
-// Config.
-func (n *sros) applyNodeTypeSpecificConfig(tplData *srosTemplateData) {
-	// SR OS nodes with insecure gRPC, non-IXR/SAR
-	if !tplData.IsSecureGrpc {
-		tplData.GRPCConfig = grpcConfigInsecure
+// getTemplateForVariant returns the template string and name for the given config variant.
+// swVersion is for future SR OS 26+ template selection (e.g. cfgTplSROS26 when Major >= "26").
+func getTemplateForVariant(v ConfigVariant, swVersion *SrosVersion) (tmpl string, tplName string) {
+	// Model-driven (or mixed treated as classic below when family is classic)
+	if v.Mode == ConfigModeModelDriven {
+		// Placeholder for version-specific template: if swVersion != nil && swVersion.Major >= "26" { return cfgTplSROS26, "clab-sros-config-sros26" }
+		return cfgTplSROS25, "clab-sros-config-sros25"
 	}
-	// Apply IXR-specific configs
-	if n.isIXRNode() {
-		tplData.SystemConfig = systemCfgIXR
-		tplData.GRPCConfig = grpcConfigIXR
-
-		// IXR with insecure gRPC
-		if !tplData.IsSecureGrpc {
-			tplData.GRPCConfig = grpcConfigIXRInsecure
-		}
-	}
-
-	if n.isSARNode() {
-		tplData.SystemConfig = systemCfgSAR
-		tplData.GRPCConfig = grpcConfigSAR
-		// SAR with insecure gRPC
-		if !tplData.IsSecureGrpc {
-			tplData.GRPCConfig = grpcConfigSARInsecure
-		}
-		if n.isSARHmNode() { // MD disabled on SAR-Hm nodes
-			if tplData.ConfigurationMode != "classic" {
-				log.Warn(
-					"SAR-Hm nodes only support classic configuration mode. Overriding configuration mode to 'classic'",
-					"node",
-					n.Cfg.LongName,
-					"node-type",
-					tplData.NodeType,
-				)
-				tplData.ConfigurationMode = "classic"
-				n.Cfg.Env[envSrosConfigMode] = "classic"
-			}
-		}
+	// Classic (or mixed)
+	tmpl = cfgTplClassic
+	tplName = "clab-sros-config-classic"
+	switch v.Family {
+	case ConfigFamilyIXR:
+		return cfgTplClassicIxr, "clab-sros-config-classic-ixr"
+	case ConfigFamilySAR:
+		return cfgTplClassicSar, "clab-sros-config-classic-sar"
+	default:
+		return tmpl, tplName
 	}
 }
 
-// selectConfigTemplate chooses the appropriate config template based on template data either MD or
-// classic.
+// selectConfigTemplate chooses the config template from the config variant (mode + family).
 func (n *sros) selectConfigTemplate(tplData *srosTemplateData) (*template.Template, error) {
-	var tmpl string
-	var tplName string
-	// Model-driven configuration mode (SROS25+)
-	// Future version-specific template selection:
-	// if tplData.SwVersion != nil && tplData.SwVersion.Major >= 26 {
-	//     tmpl = cfgTplSROS26
-	//     tplName = "clab-sros-config-sros26"
-	// } else {
-	//     tmpl = cfgTplSROS25
-	//     tplName = "clab-sros-config-sros25"
-	// }
-	tmpl = cfgTplSROS25
-	tplName = "clab-sros-config-sros25"
-
-	// Classic configuration mode
-	if tplData.ConfigurationMode == "classic" || tplData.ConfigurationMode == "mixed" {
-		// Default to classic template
-		tmpl = cfgTplClassic
-		tplName = "clab-sros-config-classic"
-
-		if n.isIXRNode() {
-			tmpl = cfgTplClassicIxr
-			tplName = "clab-sros-config-classic-ixr"
-		}
-		if n.isSARNode() {
-			tmpl = cfgTplClassicSar
-			tplName = "clab-sros-config-classic-sar"
-			// We choose not to support gRPC on classic mode at all
-		}
-	}
+	v := n.resolveConfigVariant()
+	tmpl, tplName := getTemplateForVariant(v, tplData.SwVersion)
 	return template.New(tplName).
 		Funcs(clabutils.CreateFuncs()).
 		Parse(tmpl)
@@ -1891,112 +1857,40 @@ func (n *sros) MgmtIPAddr() (string, error) {
 	)
 }
 
-// generateComponentConfig generates SR OS configuration
-// for explicitly defined components using components nodeConfig.
+// generateComponentConfig generates SR OS configuration for explicitly defined
+// components (cards, SFMs, XIOMs, MDAs) using a struct + loop; power config is appended.
 func (n *sros) generateComponentConfig() string {
 	if _, exists := n.Cfg.Env[envDisableComponentConfigGen]; exists {
 		return ""
 	}
-
-	// Skipping magic if using classic for NOW
 	if n.isConfigClassic() {
 		return ""
 	}
-
 	if n.isStandaloneNode() {
-		// skip integrated for now
 		return ""
 	}
-
 	components := n.rootComponents
-
 	if len(components) == 0 {
 		return ""
 	}
 
-	var config strings.Builder
-
-	for _, component := range components {
-		slot := strings.ToUpper(component.Slot)
-
-		if slot == "A" || slot == "B" {
-			// cpm -> skip
+	for _, c := range components {
+		slot := strings.ToUpper(strings.TrimSpace(c.Slot))
+		if slot == slotAName || slot == slotBName {
 			continue
 		}
-
-		if component.Type != "" {
-			config.WriteString(
-				fmt.Sprintf(
-					"/configure card %s card-type %s admin-state enable\n",
-					slot,
-					component.Type,
-				),
-			)
-		} else {
-			// not all types may have preprovisioned card
-			// so the following configs will fail if card
-			// doesn't have valid type explicitly set.
+		if c.Type == "" {
 			log.Warn("SR-SIM node has no type set for component in slot, skipping component SR OS config generation.",
-				"node",
-				n.Cfg.ShortName,
-				"slot",
-				slot)
-			continue
-		}
-
-		if component.SFM != "" {
-			config.WriteString(
-				fmt.Sprintf(
-					"/configure sfm %s sfm-type %s admin-state enable\n",
-					slot,
-					component.SFM,
-				),
-			)
-		}
-
-		for _, xiom := range component.XIOM {
-			if xiom.Type != "" {
-				config.WriteString(
-					fmt.Sprintf(
-						"/configure card %s xiom x%d xiom-type %s admin-state enable\n",
-						slot,
-						xiom.Slot,
-						xiom.Type,
-					),
-				)
-			}
-
-			for _, mda := range xiom.MDA {
-				if mda.Type != "" {
-					config.WriteString(
-						fmt.Sprintf(
-							"/configure card %s xiom x%d mda %d mda-type %s admin-state enable\n",
-							slot,
-							xiom.Slot,
-							mda.Slot,
-							mda.Type,
-						),
-					)
-				}
-			}
-		}
-
-		for _, mda := range component.MDA {
-			if mda.Type != "" {
-				config.WriteString(
-					fmt.Sprintf(
-						"/configure card %s mda %d mda-type %s admin-state enable\n",
-						slot,
-						mda.Slot,
-						mda.Type,
-					),
-				)
-			}
+				"node", n.Cfg.ShortName, "slot", slot)
 		}
 	}
 
+	lines := buildComponentCfgLines(components)
+	var config strings.Builder
+	for _, l := range lines {
+		config.WriteString(l.String())
+	}
 	config.WriteString(n.generatePowerConfig())
-
 	return config.String()
 }
 

--- a/nodes/sros/variant.go
+++ b/nodes/sros/variant.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package sros
+
+import "strings"
+
+// ConfigMode is the configuration mode (model-driven or classic).
+type ConfigMode string
+
+const (
+	ConfigModeModelDriven ConfigMode = "model-driven"
+	ConfigModeClassic     ConfigMode = "classic"
+	ConfigModeMixed       ConfigMode = "mixed"
+)
+
+// ConfigFamily is the node family (SR, IXR, SAR).
+type ConfigFamily string
+
+const (
+	ConfigFamilySR  ConfigFamily = "sr"
+	ConfigFamilyIXR ConfigFamily = "ixr"
+	ConfigFamilySAR ConfigFamily = "sar"
+)
+
+// ConfigVariant encodes mode, node family, and security for template and snippet selection.
+// Single source of truth for "what config do we use for this node."
+type ConfigVariant struct {
+	Mode         ConfigMode   // model-driven, classic, or mixed
+	Family       ConfigFamily // sr, ixr, sar
+	SecureGrpc   bool
+	ForceClassic bool // true when SAR-Hm forces classic (MD disabled)
+}
+
+// snippetSet holds the system and gRPC config snippets for a variant.
+// Other snippets (SNMP, logging, netconf, SSH) are shared across variants.
+type snippetSet struct {
+	SystemConfig string
+	GRPCConfig   string
+}
+
+// FullSnippetSet holds all config snippet strings for a variant (system, grpc, snmp, netconf, logging, ssh).
+// Single table-driven result for "which snippets apply to this variant."
+type FullSnippetSet struct {
+	SystemConfig    string
+	GRPCConfig      string
+	SNMPConfig      string
+	NetconfConfig   string
+	LoggingConfig   string
+	SSHConfig       string
+}
+
+// getFullSnippetSet returns the full set of snippet strings for the given variant.
+// Shared snippets (SNMP, logging, netconf, SSH) are the same for all variants.
+func getFullSnippetSet(v ConfigVariant) FullSnippetSet {
+	s := getSnippetSet(v)
+	return FullSnippetSet{
+		SystemConfig:  s.SystemConfig,
+		GRPCConfig:    s.GRPCConfig,
+		SNMPConfig:    snmpv2Config,
+		NetconfConfig: netconfConfig,
+		LoggingConfig: loggingConfig,
+		SSHConfig:     sshConfig,
+	}
+}
+
+// resolveConfigVariant returns the config variant for node n from NodeType,
+// Env[envSrosConfigMode], and Certificate.Issue. SAR-Hm forces classic mode;
+// the caller should apply that to tplData and n.Cfg.Env when ForceClassic is true.
+func (n *sros) resolveConfigVariant() ConfigVariant {
+	mode := ConfigMode(strings.ToLower(n.Cfg.Env[envSrosConfigMode]))
+	if mode == "" {
+		mode = ConfigModeModelDriven
+	}
+	secureGrpc := n.Cfg.Certificate.Issue != nil && *n.Cfg.Certificate.Issue
+
+	var family ConfigFamily
+	switch {
+	case n.isIXRNode():
+		family = ConfigFamilyIXR
+	case n.isSARNode():
+		family = ConfigFamilySAR
+	default:
+		family = ConfigFamilySR
+	}
+
+	forceClassic := false
+	if family == ConfigFamilySAR && n.isSARHmNode() {
+		forceClassic = true
+		if mode != ConfigModeClassic && mode != ConfigModeMixed {
+			mode = ConfigModeClassic
+		}
+	}
+
+	return ConfigVariant{
+		Mode:         mode,
+		Family:       family,
+		SecureGrpc:   secureGrpc,
+		ForceClassic: forceClassic,
+	}
+}
+
+// getSnippetSet returns the system and gRPC snippet set for the given variant.
+func getSnippetSet(v ConfigVariant) snippetSet {
+	sys := systemCfg
+	grpc := grpcConfig
+	if !v.SecureGrpc {
+		grpc = grpcConfigInsecure
+	}
+	switch v.Family {
+	case ConfigFamilyIXR:
+		sys = systemCfgIXR
+		grpc = grpcConfigIXR
+		if !v.SecureGrpc {
+			grpc = grpcConfigIXRInsecure
+		}
+	case ConfigFamilySAR:
+		sys = systemCfgSAR
+		grpc = grpcConfigSAR
+		if !v.SecureGrpc {
+			grpc = grpcConfigSARInsecure
+		}
+	}
+	return snippetSet{SystemConfig: sys, GRPCConfig: grpc}
+}

--- a/nodes/sros/version.go
+++ b/nodes/sros/version.go
@@ -2,7 +2,6 @@ package sros
 
 import (
 	"context"
-	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -22,47 +21,6 @@ const (
 	srosImageVendorLabel  = "org.opencontainers.image.vendor"
 	srosImageVendor       = "Nokia"
 	srosImageVersionLabel = "org.opencontainers.image.version"
-)
-
-var (
-	//go:embed configs/10_snmpv2.cfg
-	snmpv2Config string
-
-	//go:embed configs/11_logging.cfg
-	loggingConfig string
-
-	//go:embed configs/12_grpc.cfg
-	grpcConfig string
-
-	//go:embed configs/12_grpc_insecure.cfg
-	grpcConfigInsecure string
-
-	//go:embed configs/ixr/12_grpc.cfg
-	grpcConfigIXR string
-
-	//go:embed configs/ixr/12_grpc_insecure.cfg
-	grpcConfigIXRInsecure string
-
-	//go:embed configs/sar/12_grpc.cfg
-	grpcConfigSAR string
-
-	//go:embed configs/sar/12_grpc_insecure.cfg
-	grpcConfigSARInsecure string
-
-	//go:embed configs/13_netconf.cfg
-	netconfConfig string
-
-	//go:embed configs/14_system.cfg
-	systemCfg string
-
-	//go:embed configs/ixr/14_system.cfg
-	systemCfgIXR string
-
-	//go:embed configs/sar/14_system.cfg
-	systemCfgSAR string
-
-	//go:embed configs/15_ssh.cfg
-	sshConfig string
 )
 
 // SrosVersion represents an SR OS version as a set of fields.

--- a/tests/13-srsim/01-srsim.clab.yml
+++ b/tests/13-srsim/01-srsim.clab.yml
@@ -12,7 +12,7 @@ topology:
           ip addr add dev eth1 10.0.0.1/30'
     sros:
       kind: nokia_srsim
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
       type: sr-1
       license: /opt/nokia/sros/license-sros25.txt
       startup-config: |

--- a/tests/13-srsim/03-srsim-dist.clab.yml
+++ b/tests/13-srsim/03-srsim-dist.clab.yml
@@ -4,7 +4,7 @@ topology:
   kinds:
     nokia_srsim:
       license: /opt/nokia/sros/license-sros25.txt
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
   nodes:
     l1:
       kind: linux

--- a/tests/13-srsim/04-srsim-classic.clab.yml
+++ b/tests/13-srsim/04-srsim-classic.clab.yml
@@ -7,7 +7,7 @@ name: sr04
 topology:
   kinds:
     nokia_srsim:
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
       license: /opt/nokia/sros/license-sros25.txt
   nodes:
     srsim:

--- a/tests/13-srsim/05-srsim-comp.clab.yml
+++ b/tests/13-srsim/05-srsim-comp.clab.yml
@@ -5,7 +5,7 @@ topology:
   kinds:
     nokia_srsim:
       license: /opt/nokia/sros/license-sros25.txt
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
   nodes:
     l1:
       kind: linux

--- a/tests/13-srsim/06-srsim-sar.clab.yml
+++ b/tests/13-srsim/06-srsim-sar.clab.yml
@@ -2,19 +2,19 @@ name: sr06
 topology:
   nodes:
     sar1:
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
       license: /opt/nokia/sros/license-sros25.txt
       kind: nokia_srsim
       type: sar-1
       certificate:
         issue: true
     sar2:
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
       license: /opt/nokia/sros/license-sros25.txt
       kind: nokia_srsim
       type: sar-1
     sar3:
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
       license: /opt/nokia/sros/license-sros25.txt
       kind: nokia_srsim
       type: sar-hm

--- a/tests/13-srsim/07-srsim-mix.clab.yml
+++ b/tests/13-srsim/07-srsim-mix.clab.yml
@@ -8,7 +8,7 @@ topology:
   kinds:
     nokia_srsim:
       license: /opt/nokia/sros/license-sros25.txt
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
   nodes:
     srsim10:
       kind: nokia_srsim

--- a/tests/13-srsim/08-srsim-comp-cfg-test.clab.yml
+++ b/tests/13-srsim/08-srsim-comp-cfg-test.clab.yml
@@ -5,7 +5,7 @@ topology:
   kinds:
     nokia_srsim:
       license: /opt/nokia/sros/license-sros25.txt
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
 
   nodes:
     # only distributed nodes support the config gen for now

--- a/tests/13-srsim/09-srsim-comp-sort-mgmt.clab.yml
+++ b/tests/13-srsim/09-srsim-comp-sort-mgmt.clab.yml
@@ -5,7 +5,7 @@ topology:
   kinds:
     nokia_srsim:
       license: /opt/nokia/sros/license-sros25.txt
-      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R1
+      image: registry.srlinux.dev/pub/nokia_srsim:25.10.R2
 
   nodes:
 


### PR DESCRIPTION
- Fix duplicate {{ .SNMPConfig }} in sros_config_sros25.go.tpl
- Move embedded configs from version.go to configs_embed.go
- Introduce config variant (mode, family, secure gRPC) and single resolver
- Refactor applyNodeTypeSpecificConfig and selectConfigTemplate to use variant
- Rename getConfigTemplate to buildStartupConfig and document flow
- Add version placeholder in getTemplateForVariant for SR OS 26+
- Table-driven snippet resolution: getFullSnippetSet(v) in prepareConfigTemplateData
- generateComponentConfig: struct + loop (component_config.go, componentCfgLine)

Compatibility: no topology or runtime changes; same generated config.