### PR TITLE
Adding support for Ubuntu 25.10 to utils/quick-setup.sh

### DIFF
--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -19,7 +19,7 @@ function check_os {
             fi
         elif [ "$ID" = "ubuntu" ]; then
             DISTRO_TYPE="ubuntu"
-            if [ "$VERSION_ID" = "25.04" ]; then
+            if [ "$VERSION_ID" = "25.04" ] || [ "$VERSION_ID" = "25.10" ]; then
                 DOCKER_VERSION="28.5.2"
             fi
         elif [ "$ID" = "fedora" ]; then


### PR DESCRIPTION
# Summary
- To utils/quick-setup.sh adds an or statement to to the Ubuntu version check so that Ubuntu 25.10 picks up to install Docker version 28.5.2