### PR TITLE
Lowercase the slot in mgmt IP getter

### DIFF
--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1151,12 +1151,12 @@ func (n *sros) prepareConfigTemplateData() (*srosTemplateData, error) {
 		ComponentConfig: componentConfig,
 
 		// Service configs from variant (single source of truth)
-		SystemConfig:    snippets.SystemConfig,
-		GRPCConfig:      snippets.GRPCConfig,
-		SNMPConfig:      snippets.SNMPConfig,
-		NetconfConfig:   snippets.NetconfConfig,
-		LoggingConfig:   snippets.LoggingConfig,
-		SSHConfig:       snippets.SSHConfig,
+		SystemConfig:  snippets.SystemConfig,
+		GRPCConfig:    snippets.GRPCConfig,
+		SNMPConfig:    snippets.SNMPConfig,
+		NetconfConfig: snippets.NetconfConfig,
+		LoggingConfig: snippets.LoggingConfig,
+		SSHConfig:     snippets.SSHConfig,
 	}
 
 	if n.Config().DNS != nil {
@@ -1759,7 +1759,7 @@ func (n *sros) distNodeMgmtIPs() (MgmtIP, error) {
 	// 0th component container
 	if len(components) > 0 {
 		c := components[0]
-		slot := c.Slot
+		slot := strings.ToLower(c.Slot)
 
 		componentName := n.Cfg.LongName + "-" + slot
 


### PR DESCRIPTION
Fix bug whereby we wouldn't get the mgmt IP if only CPM card were defined because the mgmt IP getter was not lowercasing the slot number like the rest of the code did.