### PR TITLE
add missing sfm types to clab schema

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -1765,7 +1765,10 @@
                 "sfm-x20-b",
                 "sfm-x20s-b",
                 "sfm2-s",
-                "sfm2-x20s"
+                "sfm2-x20s",
+                "sfm-ixr-6",
+                "sfm-ixr-10",
+                "m-sfm6-12e"
             ]
         }
     },


### PR DESCRIPTION
SROS type was missing a couple of sfm types

https://documentation.nokia.com/sr/23-7-2/books/md-cli-command-reference/sfm-sfm_0.html#d57829