### PR TITLE
Adding support for Rocky 10 to utils/quick-setup.sh

### DIFF
--- a/utils/quick-setup.sh
+++ b/utils/quick-setup.sh
@@ -327,4 +327,3 @@ function all {
 }
 
 "$@"
-


### PR DESCRIPTION
# Summary
- To utils/quick-setup.sh adds an and statement to the RHEL check to check if Rocky 10 is the host OS, and if so then setting Docker version 28.5.2