### PR TITLE
fix: allow destroy by name without topology file

### DIFF
--- a/core/destroy.go
+++ b/core/destroy.go
@@ -118,6 +118,23 @@ func (c *CLab) makeCopyForDestroy(
 ) (*CLab, error) {
 	newOpts := []ClabOption{
 		WithTimeout(c.timeout),
+	}
+
+	// Try to load topology file if it exists, otherwise use lab name only.
+	// This allows destroying labs even when the topology file has been deleted.
+	// WithTopoPath / WithLabNameOnly must run before WithNodeFilter so filterClabNodes
+	// sees topology nodes (see filterClabNodes in clab.go).
+	if clabutils.FileOrDirExists(topo) {
+		newOpts = append(newOpts, WithTopoPath(topo, c.TopoPaths.VarsFilenameAbsPath()))
+	} else {
+		// Derive lab name from lab directory (format: clab-<labname>)
+		labName := filepath.Base(labDir)
+		labName = strings.TrimPrefix(labName, "clab-")
+		log.Debugf("topology file %q not found, using lab name %q for destroy", topo, labName)
+		newOpts = append(newOpts, WithLabNameOnly(labName))
+	}
+
+	newOpts = append(newOpts,
 		WithNodeFilter(opts.nodeFilter),
 		// during destroy we don't want to check bind paths
 		// as it is irrelevant for this command.
@@ -130,19 +147,7 @@ func (c *CLab) makeCopyForDestroy(
 				GracefulShutdown: opts.graceful,
 			},
 		),
-	}
-
-	// Try to load topology file if it exists, otherwise use lab name only.
-	// This allows destroying labs even when the topology file has been deleted.
-	if clabutils.FileOrDirExists(topo) {
-		newOpts = append(newOpts, WithTopoPath(topo, c.TopoPaths.VarsFilenameAbsPath()))
-	} else {
-		// Derive lab name from lab directory (format: clab-<labname>)
-		labName := filepath.Base(labDir)
-		labName = strings.TrimPrefix(labName, "clab-")
-		log.Debugf("topology file %q not found, using lab name %q for destroy", topo, labName)
-		newOpts = append(newOpts, WithLabNameOnly(labName))
-	}
+	)
 
 	if opts.keepMgmtNet {
 		newOpts = append(newOpts, WithKeepMgmtNet())
@@ -357,7 +362,10 @@ func (c *CLab) deleteNodes(ctx context.Context, workers uint) {
 
 // deleteContainersDirect deletes containers directly via the runtime API.
 // This is used when we don't have node objects (e.g., destroy-by-name-only case).
-func (c *CLab) deleteContainersDirect(ctx context.Context, containers []clabruntime.GenericContainer) {
+func (c *CLab) deleteContainersDirect(
+	ctx context.Context,
+	containers []clabruntime.GenericContainer,
+) {
 	for _, cont := range containers {
 		name := cont.Names[0]
 		log.Infof("Removing container: %s", name)

--- a/core/destroy_test.go
+++ b/core/destroy_test.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package core
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	claberrors "github.com/srl-labs/containerlab/errors"
+)
+
+// makeCopyForDestroy must apply WithTopoPath (or WithLabNameOnly) before WithNodeFilter so that
+// filterClabNodes runs against a loaded topology. This mirrors the option order used there.
+func TestDestroyMakeCopyOptionOrder_nodeFilterAfterTopo(t *testing.T) {
+	t.Parallel()
+
+	topo := filepath.Join("test_data", "topo1.yml")
+
+	c, err := NewContainerLab(
+		WithTopoPath(topo, ""),
+		WithNodeFilter([]string{"node1"}),
+		WithSkippedBindsPathsCheck(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := c.Config.Topology.Nodes["node1"]; !ok {
+		t.Fatal("expected node1 to remain after filter")
+	}
+
+	if _, ok := c.Config.Topology.Nodes["node2"]; ok {
+		t.Fatal("expected node2 to be removed by node filter")
+	}
+}
+
+func TestDestroyMakeCopyOptionOrder_nodeFilterBeforeTopoFails(t *testing.T) {
+	t.Parallel()
+
+	topo := filepath.Join("test_data", "topo1.yml")
+
+	_, err := NewContainerLab(
+		WithNodeFilter([]string{"node1"}),
+		WithTopoPath(topo, ""),
+		WithSkippedBindsPathsCheck(),
+	)
+	if err == nil {
+		t.Fatal("expected error when node filter is applied before topology is loaded")
+	}
+
+	if !errors.Is(err, claberrors.ErrIncorrectInput) {
+		t.Fatalf("expected ErrIncorrectInput, got %v", err)
+	}
+}
+
+func TestWithLabNameOnly_setsNameWithoutTopologyFile(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewContainerLab(WithLabNameOnly("my-lab"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Config.Name != "my-lab" {
+		t.Fatalf("Config.Name = %q, want my-lab", c.Config.Name)
+	}
+
+	if c.TopoPaths.TopologyFileIsSet() {
+		t.Fatal("topology file should not be set for lab-name-only init")
+	}
+}

--- a/core/options_clab.go
+++ b/core/options_clab.go
@@ -237,7 +237,11 @@ func WithTopologyFromLab(labName string) ClabOption {
 		// If topology file doesn't exist, fall back to using just the lab name.
 		// This allows operations like destroy to work even when the topo file is missing.
 		if !clabutils.FileOrDirExists(topoFile) {
-			log.Debugf("topology file %s not found for lab %s, using lab name only", topoFile, labName)
+			log.Debugf(
+				"topology file %s not found for lab %s, using lab name only",
+				topoFile,
+				labName,
+			)
 			return WithLabNameOnly(labName)(c)
 		}
 


### PR DESCRIPTION
Fixes #2524

When using 'clab destroy --name <lab>' without a topology file, the command now works by using only the lab name to find and remove containers, rather than requiring the topology file to exist.

This is useful when:
- The topology file was accidentally deleted
- Running in CI where the topo file isn't persisted
- Managing labs from a different directory

The fix adds a new WithLabNameOnly() option that sets only the lab name without attempting to load or verify the topology file.