### PR TITLE
Fix typos and curl command in manual installation docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -171,7 +171,7 @@ example:
 
 ```bash
 # manually install latest release with package managers
-LATEST=$(curl -s https://github.com/srl-labs/containerlab/releases/latest | sed -e 's/.*tag\/v\(.*\)\".*/\1/')
+LATEST=$(curl -sLo /dev/null -w '%{url_effective}' https://github.com/srl-labs/containerlab/releases/latest | sed 's|.*/v||')
 # with yum
 yum install "https://github.com/srl-labs/containerlab/releases/download/v${LATEST}/containerlab_${LATEST}_linux_amd64.rpm"
 # with dpkg
@@ -238,12 +238,12 @@ ghcr.io/srl-labs/clab deploy -t somelab.clab.yml
 
 ## Manual installation
 
-If the linux distributive can't install deb/rpm packages, containerlab can be installed from the archive:
+If the Linux distribution can't install deb/rpm packages, containerlab can be installed from the archive:
 
 ```bash
 # get the latest available tag
-LATEST=$(curl -s https://github.com/srl-labs/containerlab/releases/latest | \
-       sed -e 's/.*tag\/v\(.*\)\".*/\1/')
+LATEST=$(curl -sLo /dev/null -w '%{url_effective}' \
+       https://github.com/srl-labs/containerlab/releases/latest | sed 's|.*/v||')
 
 # download tar.gz archive
 curl -L -o /tmp/clab.tar.gz "https://github.com/srl-labs/containerlab/releases/download/v${LATEST}/containerlab_${LATEST}_Linux_amd64.tar.gz"


### PR DESCRIPTION
The manual installation section had two issues:

- "linux distributive" corrected to "Linux distribution"
- The `curl` command used to determine the latest release version was
  scraping GitHub's HTML page without following redirects (`-L`), causing
  `LATEST` to always be empty. Replaced both occurrences (manual package
  installation and manual installation sections) with a redirect-based
  approach that is simpler and more reliable:

  ```bash
  LATEST=$(curl -sLo /dev/null -w '%{url_effective}' \
         https://github.com/srl-labs/containerlab/releases/latest | sed 's|.*/v||')
  ```
