### PR TITLE
fix(schema): fix `nokia_sros` custom variant `type` regex

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -590,7 +590,7 @@
                                         ]
                                     },
                                     {
-                                        "pattern": "^((lc|cp):\\s)?((cpu|ram|max_nics)=\\d+|slot=[A-Z]|chassis=[^\\s]+|card=.*|\\s)+$"
+                                        "pattern": "^\\s*(?:(?:cp|lc):\\s+)?(?:(?:(?:min_)?(?:cpu|ram|max_nics)=\\d+|slot=[A-Za-z0-9]+|chassis=[^\\s_][^\\s]*|card=[^\\s_][^\\s]*|mda/\\d+=[^\\s]+)(?:\\s+|$))+(?:\\s*___\\s*(?:(?:cp|lc):\\s+)?(?:(?:(?:min_)?(?:cpu|ram|max_nics)=\\d+|slot=[A-Za-z0-9]+|chassis=[^\\s_][^\\s]*|card=[^\\s_][^\\s]*|mda/\\d+=[^\\s]+)(?:\\s+|$))+)*\\s*$"
                                     }
                                 ]
                             }


### PR DESCRIPTION

## What

The JSON schema regex pattern used to validate the `nokia_sros` custom `type` string is too restrictive and incorrectly rejects valid topology definitions documented in the [vr-sros kind page](https://containerlab.dev/manual/kinds/vr-sros/).

capture below with he example _distributed chassis with multiple line cards [from the documentation](https://containerlab.dev/manual/kinds/vr-sros/)
<img width="1111" height="342" alt="image" src="https://github.com/user-attachments/assets/0b544efb-0670-49e0-8d87-139a777e1276" />

For your information, the creation and initial testing of the regular expression were carried out using IA. We then performed manual testing.

## Why

The existing pattern in `clab.schema.json`:

```
^((lc|cp):\s)?((cpu|ram|max_nics)=\d+|slot=[A-Z]|chassis=[^\s]+|card=.*|\s)+$
```

has five distinct bugs:

| Bug | Effect |
|---|---|
| `\s` (single space) after `cp\|lc:` | Fails when YAML `>-` folds lines, collapsing newlines into multiple spaces |
| `slot=[A-Z]` (uppercase only) | Rejects `slot=1`, `slot=2` — valid numeric line card slots |
| No `min_` prefix support | Rejects `min_ram=4`, `min_cpu=2` used in distributed chassis examples |
| No `mda/N=...` token | Rejects MDA definitions like `mda/1=me40-1gb-csfp` |
| `card=.*` greedy match | Silently swallows `___ lc: ...` remainder, creating false positives on multi-block strings |

As a result, all of the custom variant examples shown in the documentation produce schema validation errors in VS Code and any editor using the schema.

## Fix

Replace the pattern with a structured `BLOCK (___ BLOCK)*` grammar where `___` is a separator between blocks, not a token inside one:

```
^\s*(?:(?:cp|lc):\s+)?(?:(?:(?:min_)?(?:cpu|ram|max_nics)=\d+|slot=[A-Za-z0-9]+|chassis=[^\s_][^\s]*|card=[^\s_][^\s]*|mda/\d+=[^\s]+)(?:\s+|$))+(?:\s*___\s*(?:(?:cp|lc):\s+)?(?:(?:(?:min_)?(?:cpu|ram|max_nics)=\d+|slot=[A-Za-z0-9]+|chassis=[^\s_][^\s]*|card=[^\s_][^\s]*|mda/\d+=[^\s]+)(?:\s+|$))+)*\s*$
```

## Test cases validated

All examples from the documentation and from our lab now pass:

I have test the new schema by inserting this to use our custom clab.schema.json
```yaml
# yaml-language-server: $schema=/home/sysadmin/clabs/labs_antoine/rbci/clab.schema.json
```

```yaml
# integrated variant — no cp/lc prefix
type: "cpu=2 ram=4 slot=A chassis=ixr-r6 card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28"

# distributed chassis — single line card
type: >-
  cp: cpu=2 ram=4 chassis=ixr-e slot=A card=cpm-ixr-e ___
  lc: cpu=2 ram=4 max_nics=34 chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28

# distributed chassis — multiple line cards with min_ram
type: >-
  cp: cpu=2 min_ram=4 chassis=sr-7 slot=A card=cpm5 ___
  lc: cpu=4 min_ram=4 max_nics=6 chassis=sr-7 slot=1 card=iom4-e mda/1=me6-10gb-sfp+ ___
  lc: cpu=4 min_ram=4 max_nics=6 chassis=sr-7 slot=2 card=iom4-e mda/1=me6-10gb-sfp+
```

Predefined enum values (`sr-1`, `sr-7s`, etc.) are unaffected — they are validated by the `anyOf` enum branch, not this pattern.

## Related

- [vr-sros custom variants documentation](https://containerlab.dev/manual/kinds/vr-sros/#custom-variants)