### PR TITLE
Do not disable tx offload on clab network

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -465,6 +465,7 @@ func (d *DockerRuntime) postCreateNetActions() (err error) {
 		log.Warnf("failed to enable LLDP on docker bridge: %v", err)
 	}
 
+	// TODO: consider if that is useful or not later.
 	// Enable nf_call_iptables and nf_call_ip6tables on the management bridge so that
 	// bridged traffic passes through netfilter/conntrack. Without this, per-bridge sysfs
 	// settings (which default to 0 on custom bridges) override the global
@@ -472,12 +473,12 @@ func (d *DockerRuntime) postCreateNetActions() (err error) {
 	// embedded DNS proxy: the masquerade conntrack mapping is not maintained for return
 	// packets, so DNS responses arriving at the container's eth0 are never delivered to
 	// the waiting socket even though they are visible to tcpdump.
-	for _, knob := range []string{"nf_call_iptables", "nf_call_ip6tables"} {
-		p := "/sys/class/net/" + d.mgmt.Bridge + "/bridge/" + knob
-		if werr := os.WriteFile(p, []byte("1"), 0o640); werr != nil { // skipcq: GO-S2306
-			log.Warnf("failed to set %s on bridge %s: %v", knob, d.mgmt.Bridge, werr)
-		}
-	}
+	// for _, knob := range []string{"nf_call_iptables", "nf_call_ip6tables"} {
+	// 	p := "/sys/class/net/" + d.mgmt.Bridge + "/bridge/" + knob
+	// 	if werr := os.WriteFile(p, []byte("1"), 0o640); werr != nil { // skipcq: GO-S2306
+	// 		log.Warnf("failed to set %s on bridge %s: %v", knob, d.mgmt.Bridge, werr)
+	// 	}
+	// }
 
 	// Note: we intentionally do NOT disable TX checksum offloading on the bridge interface
 	// itself. Doing so corrupts UDP/TCP checksums on NAT-forwarded packets (e.g. DNS replies


### PR DESCRIPTION
The disabled tx offload on clab network was causing checksum failure on VMs running under orbstack (and potentially in other cases).

It was disabled long time ago when the wrong checksums were preventing srl to accept the packets with incorrect checksums that linux networking stack was using to save on cpu cycles calculating the valid ones.

But disabling the checksum on the bridge/network was not really fixing anything, and therefore we ended up disabling checksums on the egressing veths instead, which solved it for us. Since then, SRL started to recompute the checksums, so the original fix was not really at play anymore, but the code stayed, and today I noticed that in a debian VM under Orbstack the DNS of the nodes started with clab was no working. The returning dns replies were dropped in the kernel's depths, but here is [the link](https://gist.github.com/hellt/41d36757d7325d4205749be2635b5b1a) to the verification/tshooting steps I used.

Besides removing the code that was disabling tx offload on the clab bridge, I added the code to default to 1500 mtu if we failed to glean the acting mtu of the existing docker networks.

And lastly, there is the nf_call_iptables  blob that is commented out. It might be needed in the newer kernels, but I will enable it when we see issues, not sooner.