### PR TITLE
Add ceos-copy-to-flash to .clab.yml schema

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -1118,20 +1118,6 @@
             "type": "object",
             "description": "node's extra configurations",
             "properties": {
-                "srl-agents": {
-                    "type": "array",
-                    "description": "list of SR Linux agent's config files to be copied to the NOS filesystem",
-                    "markdownDescription": "list of [SR Linux agent's config files](https://containerlab.dev/manual/kinds/srl/#user-defined-custom-agents-for-sr-linux-nodes) to be copied to the NOS filesystem",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "mysocket-proxy": {
-                    "type": "string",
-                    "description": "http/s proxy to be used by mysocketctl"
-                },
                 "ceos-copy-to-flash": {
                     "type": "array",
                     "description": "list of cEOS-specific configuration or override files to be copied to the flash directory and evaluated on startup",


### PR DESCRIPTION
Introduce a new schema entry for `ceos-copy-to-flash`, allowing users to specify a list of CEOS-specific configuration files to be copied to the flash directory on startup.

NOTE: Dont see srl-agents property in the latest documentation