### PR TITLE
Handle netlink transient errors when deploying links concurrently

### DIFF
--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -284,6 +284,8 @@ func (l *LinkVEth) Deploy(ctx context.Context, ep Endpoint) error {
 	var lastErr error
 
 	for attempt := range linkDeployRetries {
+		// The first node to trigger the link creation will call deployAEnd,
+		// subsequent (the second) call will end up in deployBEnd.
 		switch l.DeploymentState {
 		case LinkDeploymentStateHalfDeployed:
 			lastErr = l.deployBEnd(ctx, idx)


### PR DESCRIPTION
When deploying a dense topology, concurrent netlink operations race against each other, causing three types of transient kernel errors:

* "bad address" (EFAULT) - concurrent namespace operations corrupt netlink messages
* "no such device" (ENODEV) - interface not yet visible between concurrent operations
* "file exists" (EEXIST) - cascading failure: when deployAEnd fails after creating a veth pair but before setting DeploymentState, the orphaned veth pair blocks subsequent retry attempts

in deployAEnd: if netlink.LinkAdd succeeded but a later step (like AddLinkToContainer) failed, the veth pair was left orphaned in the root namespace. Since DeploymentState was never updated, the peer node would call deployAEnd again with the same random interface names, hitting "file exists".


Fix
`links/link_veth.go`:

Cleanup on partial failure in deployAEnd: After netlink.LinkAdd succeeds, any subsequent failure now deletes the veth pair before returning the error. This prevents orphaned interfaces.

Retry logic in Deploy: Up to 3 retries with exponential backoff (100ms, 200ms, 400ms) for transient netlink errors (EFAULT, ENODEV, ENOENT). Non-transient errors fail immediately.
