### PR TITLE
fix(podman): explicitly set health log destination to local

### DIFF
--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -151,10 +151,11 @@ func (r *PodmanRuntime) createContainerSpec(
 	}
 	// Defaults for health checks
 	specHCheckConfig := specgen.ContainerHealthCheckConfig{
-		HealthConfig: &manifest.Schema2HealthConfig{},
+		HealthLogDestination: "local",
 	}
 
 	if cfg.Healthcheck != nil {
+		specHCheckConfig.HealthConfig = &manifest.Schema2HealthConfig{}
 		specHCheckConfig.HealthConfig.Test = cfg.Healthcheck.Test
 		specHCheckConfig.HealthConfig.Retries = cfg.Healthcheck.Retries
 		specHCheckConfig.HealthConfig.Interval = cfg.Healthcheck.GetIntervalDuration()


### PR DESCRIPTION
### Summary
This PR fixes the `HealthCheck Log '' destination error: stat : no such file or directory` when using the Podman runtime with Podman 5.x engine.

### Root Cause
In Containerlab's Podman implementation (`runtime/podman/util.go`), the container specification was always initializing a `HealthConfig` object, even if no healthcheck was defined in the topology file. Podman 5.x interprets this non-nil configuration as a request to initialize a log file to capture healthcheck output. Because the `HealthLogDestination` was not explicitly set, Podman attempted to `stat` an empty string as a file path, resulting in the failure.

### Reproduction Steps
1. Use Podman engine 5.0 or later (verified on 5.8.0).
2. Create a minimal topology file (`repro.clab.yml`):
   ```yaml
   name: repro
   topology:
     nodes:
       node1:
         kind: linux
         image: alpine:latest
         runtime: podman
   ```
3. Deploy the lab: `containerlab deploy -t repro.clab.yml`
4. Observe the error: `running container create option: HealthCheck Log '' destination error: stat : no such file or directory`

### Fix
- Explicitly set `HealthLogDestination` to `"local"` in the `specgen.ContainerHealthCheckConfig`.
- Only initialize the `HealthConfig` pointer if `cfg.Healthcheck` is not nil.

Verified on Linux with Podman 5.8.0.