### PR TITLE
VyOS: allow to use eth greather than eth9

### DIFF
--- a/nodes/vyosnetworks_vyos/vyos.go
+++ b/nodes/vyosnetworks_vyos/vyos.go
@@ -201,9 +201,9 @@ func (n *vyos) PostDeploy(ctx context.Context, params *clabnodes.PostDeployParam
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (n *vyos) CheckInterfaceName() error {
-	// allow eth and et interfaces
-	// https://regex101.com/r/umQW5Z/2
-	ifRe := regexp.MustCompile(`eth[1-9]$`)
+	// allow eth interfaces - ethX, apart from eth0
+	// https://regex101.com/r/kqOPTc/1
+	ifRe := regexp.MustCompile(`eth[1-9][0-9]*$`)
 	for _, e := range n.Endpoints {
 		if !ifRe.MatchString(e.GetIfaceName()) {
 			return fmt.Errorf(


### PR DESCRIPTION
Fix #3118

Lab startup:

```
stefano@donkey:~/_clab_fix_vyos$ ./containerlab/bin/containerlab -t test.yml deploy
10:28:44 INFO Containerlab started version=0.0.0
10:28:44 INFO Parsing & checking topology file=test.yml
10:28:44 INFO Creating lab directory path=/home/stefano/_clab_fix_vyos/clab-vytest
10:28:44 INFO Creating container name=switch-1
10:28:45 INFO Creating container name=wan-1
10:28:45 INFO Created link: switch-1:eth18 ▪┄┄▪ wan-1:eth0
10:28:57 INFO Save successful node=switch-1
10:28:57 INFO PostDeploy complete node=switch-1
10:28:57 INFO Executed command node=wan-1 command="/sbin/ip address add 198.18.1.10/28 dev eth0" stdout=""
10:28:57 INFO Executed command node=wan-1 command="/sbin/ip route add default via 198.18.1.1" stdout=""
10:28:57 INFO Executed command node=wan-1 command="/sbin/ip link set mtu 1500 dev eth0" stdout=""
10:28:57 INFO Executed command node=wan-1 command="/sbin/ip link set up dev eth0" stdout=""
10:28:57 INFO Adding host entries path=/etc/hosts
10:28:57 INFO Adding SSH config for nodes path=/etc/ssh/ssh_config.d/clab-vytest.conf
10:28:57 INFO containerlab version
  🎉=
  │ A newer containerlab version (0.74.1) is available!
  │ Release notes: https://containerlab.dev/rn/0.74/#0741
  │ Run 'clab version upgrade' or see https://containerlab.dev/install/ for other installation options.
╭──────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────┬─────────┬────────────────╮
│         Name         │                                        Kind/Image                                        │  State  │ IPv4/6 Address │
├──────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┼─────────┼────────────────┤
│ clab-vytest-switch-1 │ vyosnetworks_vyos                                                                        │ running │ 172.20.99.10   │
│                      │ ghcr.io/sysoleg/vyos-container                                                           │         │ N/A            │
├──────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┼─────────┼────────────────┤
│ clab-vytest-wan-1    │ linux                                                                                    │ running │ N/A            │
│                      │ hol-wan-container:1.0.0                                                                  │         │ N/A            │
╰──────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┴─────────┴────────────────╯
```

Config + Usage test:

```
admin@switch-1:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address       MAC                VRF        MTU  S/L    Description
-----------  ---------------  -----------------  -------  -----  -----  -------------
eth0         172.20.99.10/24  ae:fe:71:4c:97:68  default   1500  u/u
eth18        198.18.1.1/28    aa:c1:ab:ae:b2:ec  default   1500  u/u
lo           127.0.0.1/8      00:00:00:00:00:00  default  65536  u/u
             ::1/128

admin@switch-1:~$ show ip route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 0.0.0.0/0 [0/0] via 172.20.99.1, eth0, weight 1, 00:01:56
C>* 172.20.99.0/24 is directly connected, eth0, weight 1, 00:01:56
L>* 172.20.99.10/32 is directly connected, eth0, weight 1, 00:01:56
C>* 198.18.1.0/28 is directly connected, eth18, weight 1, 00:00:57
K * 198.18.1.0/28 [0/0] is directly connected, eth18, weight 1, 00:00:57
L>* 198.18.1.1/32 is directly connected, eth18, weight 1, 00:00:57

admin@switch-1:~$ ping 198.18.1.10 count 4
PING 198.18.1.10 (198.18.1.10) 56(84) bytes of data.
64 bytes from 198.18.1.10: icmp_seq=1 ttl=64 time=0.021 ms
64 bytes from 198.18.1.10: icmp_seq=2 ttl=64 time=0.056 ms
64 bytes from 198.18.1.10: icmp_seq=3 ttl=64 time=0.062 ms
64 bytes from 198.18.1.10: icmp_seq=4 ttl=64 time=0.059 ms

--- 198.18.1.10 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3077ms
rtt min/avg/max/mdev = 0.021/0.049/0.062/0.016 ms
```