### PR TITLE
VyOS: add bind for /lib/modules:ro

### DIFF
--- a/nodes/vyosnetworks_vyos/vyos.go
+++ b/nodes/vyosnetworks_vyos/vyos.go
@@ -89,6 +89,9 @@ func (n *vyos) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) err
 	n.configDir = filepath.Join(n.Cfg.LabDir, "config")
 	n.Cfg.ResStartupConfig = filepath.Join(n.configDir, "config.boot")
 	n.Cfg.Binds = append(n.Cfg.Binds, fmt.Sprintf("%s:/opt/vyatta/etc/config", n.configDir))
+
+	// mount /lib/modules, required to allow VyOS to load required kernel modules (i.e., nft_nat)
+	n.Cfg.Binds = append(n.Cfg.Binds, "/lib/modules:/lib/modules:ro")
 	return nil
 }
 


### PR DESCRIPTION
With the current VyOS node "configuration", the VyOS container is not able to load required kernel modules on demand.

This is solved by mounting `/lib/modules` inside the container.

Before this patch - example (for NAT):

```
admin@switch-1# show
+outbound-interface {
+    name eth0
+}
+source {
+    address 10.20.30.0/24
+}
+translation {
+    address masquerade
+}
[edit nat source rule 10]
admin@switch-1# commit
[ nat ]
Loading Kernel module nft_nat failed
[[nat]] failed
Commit failed
```

After the patch:

```
stefano@donkey:~/_clab_fix_vyos$ docker exec -it clab-vytest-switch-1 su - admin
admin@switch-1:~$ ls /lib/modules
6.8.0-100-generic  6.8.0-106-generic  6.8.0-53-generic  6.8.0-56-generic  6.8.0-60-generic  6.8.0-64-generic  6.8.0-78-generic  6.8.0-85-generic  6.8.0-88-generic
6.8.0-101-generic  6.8.0-51-generic   6.8.0-55-generic  6.8.0-57-generic  6.8.0-62-generic  6.8.0-71-generic  6.8.0-79-generic  6.8.0-87-generic  6.8.0-94-generic
```