### PR TITLE
Fix cisco_8000 typo in schema node definitions

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -2031,7 +2031,7 @@
                         "cisco_iol": {
                             "$ref": "#/definitions/node-config"
                         },
-                        "cisco_8000": {
+                        "cisco_c8000": {
                             "$ref": "#/definitions/node-config"
                         },
                         "cisco_c8000v": {


### PR DESCRIPTION
## Summary
- Fixed a typo in `schemas/clab.schema.json` where the node property key was `cisco_8000` instead of `cisco_c8000`
- The correct kind name `cisco_c8000` is registered in `nodes/c8000/c8000.go` and already used in the kinds enum of the same schema file
- This was likely a leftover from the initial addition (v0.36) before the kind was renamed

## Test plan
- [ ] Verify schema validation works correctly with `cisco_c8000` kind in topology files

🤖 Generated with [Claude Code](https://claude.com/claude-code)