### PR TITLE
Add FiftyGigE (Fi) interface support for Cisco 8000

### DIFF
--- a/docs/manual/kinds/c8000.md
+++ b/docs/manual/kinds/c8000.md
@@ -23,7 +23,7 @@ docker image load -i 8201-32fh-clab_7.9.1.tar.gz
 ## Supported platforms
 
 - Fixed form platforms  
-  8101-32H, 8102-64H, 8201-32FH, 8201, 8202-32FH-M
+  8101-32H, 8102-64H, 8201-32FH, 8201, 8202-32FH-M, 8711-32FH-M, 8711-48Z-M
 - Modular chassis (8808 and 8804)  
   8800-LC-36FH, 8800-LC-48H, 8800-LC-36FH-M
 
@@ -85,6 +85,7 @@ Memory and cpu usage depends on XR features enabled and control/data plane traff
 c8000 container uses the following naming convention for its management and data interfaces:
 
 - `eth0` - management interface connected to the containerlab management network
+- `Fi0_0_0_X` - 50G data interface mapped to `FiftyGigE0/0/0/X` internal interface.
 - `Hu0_0_0_X` - 100G data interface mapped to `HundredGigE0/0/0/X` internal interface.
 - `FH0_0_0_X` - 400G data interface mapped to `FourHundredGigE0/0/0/X` internal interface.
 

--- a/nodes/c8000/c8000.go
+++ b/nodes/c8000/c8000.go
@@ -125,12 +125,12 @@ func (n *c8000) create8000Files(_ context.Context) error {
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (n *c8000) CheckInterfaceName() error {
-	ifRe := regexp.MustCompile(`^(Hu|FH)0_0_0_\d+$`)
+	ifRe := regexp.MustCompile(`^(Fi|Hu|FH)0_0_0_\d+$`)
 
 	for _, e := range n.Endpoints {
 		if !ifRe.MatchString(e.GetIfaceName()) {
 			return fmt.Errorf(
-				"cisco 8000 interface name %q doesn't match the required pattern. Cisco 8000 interfaces should be named as Hu0_0_0_X (100G interfaces) or FH0_0_0_X (400G interfaces) where X is the interface number",
+				"cisco 8000 interface name %q doesn't match the required pattern. Cisco 8000 interfaces should be named as Fi0_0_0_X (50G interfaces), Hu0_0_0_X (100G interfaces) or FH0_0_0_X (400G interfaces) where X is the interface number",
 				e.GetIfaceName(),
 			)
 		}


### PR DESCRIPTION
## Summary
- Add `Fi0_0_0_X` (50G FiftyGigE) to the allowed interface name pattern for `cisco_c8000` kind, alongside existing `Hu` (100G) and `FH` (400G)
- Add 8711-32FH-M and 8711-48Z-M to the supported platforms list in documentation
- Update interface naming convention docs to include FiftyGigE

## Background
Cisco 8711-48Z-M exposes FiftyGigE interfaces (`Fi0/0/0/X`), but the current `CheckInterfaceName()` regex only allows `Hu` and `FH` prefixes, causing interface validation to fail.

## Test
Verified on a Cisco 8711-48Z-M (IOS XR 25.4.1) with containerlab. FiftyGigE interfaces are correctly recognized and LLDP adjacencies form successfully.

**show version:**
```
RP/0/RP0/CPU0:PE1#show version 
Sun Mar 22 02:09:30.176 UTC
Cisco IOS XR Software, Version 25.4.1 LNT
Copyright (c) 2013-2025 by Cisco Systems, Inc.

Build Information:
 Built By     : cisco
 Built On     : Mon Dec 15 20:55:37 UTC 2025
 Build Host   : iox-lnx-005
 Workspace    : /auto/srcarchive12/prod/25.4.1/8000/ws/
 Version      : 25.4.1
 Label        : 25.4.1

cisco 8000 (VXR)
cisco 8711-48Z-M (VXR) processor with 16GB of memory
PE1 uptime is 11 minutes
Cisco 8711 1RU chassis with 48x 50G + 4x 200G + 6x 400G port
```

**show lldp neighbors:**
```
RP/0/RP0/CPU0:PE1#show lldp neighbors 
Sun Mar 22 02:09:53.212 UTC
Capability codes:
        (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
        (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other

Device ID       Local Intf                      Hold-time  Capability      Port ID
SR-PCE          FiftyGigE0/0/0/0                120        R               GigabitEthernet0/0/0/0
PE2             FourHundredGigE0/0/0/26         120        R               FourHundredGigE0/0/0/26
PE2             FourHundredGigE0/0/0/31         120        R               FourHundredGigE0/0/0/31

Total entries displayed: 3
```