### PR TITLE
feat(nokia_sros): Support for classic CLI scrapligo platform for vr-sros

### DIFF
--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -409,6 +409,21 @@ sudo CLAB_SKIP_SROS_SSH_KEY_CONFIG=true -E clab deploy -t <topo-file>
 
 ///
 
+### CLI mode
+
+Nokia SR OS supports both MD-CLI (model-driven) and classic CLI modes. By default, containerlab uses the MD-CLI scrapligo platform (`nokia_sros`) to interact with vr-sros nodes for operations such as partial config apply and `save-config`.
+
+If your node is running in classic or mixed CLI mode, set the `CLAB_SROS_CONFIG_MODE` environment variable so that containerlab uses the matching scrapligo platform (`nokia_sros_classic`) with the correct prompt regex:
+
+```yaml
+topology:
+  nodes:
+    sros1:
+      kind: nokia_sros
+      env:
+        CLAB_SROS_CONFIG_MODE: classic  # or "mixed"
+```
+
 ### License
 
 Path to a valid license must be provided for all Nokia SR OS nodes with a [`license`](../nodes.md#license) directive.

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -45,9 +45,14 @@ const (
 	generateable     = true
 	generateIfFormat = "1/1/%d"
 
-	vrsrosDefaultType   = "sr-1"
-	scrapliPlatformName = "nokia_sros"
-	configDirName       = "tftpboot"
+	vrsrosDefaultType          = "sr-1"
+	scrapliPlatformName        = "nokia_sros"
+	scrapliPlatformNameClassic = "nokia_sros_classic"
+	// envSrosConfigMode is the env var that controls the CLI mode used by SR OS.
+	// When set to "classic" or "mixed", the classic CLI scrapligo platform is used.
+	// Default (unset or "model-driven") uses the MD-CLI platform.
+	envSrosConfigMode = "CLAB_SROS_CONFIG_MODE"
+	configDirName     = "tftpboot"
 	startupCfgFName     = "config.txt"
 	licenseFName        = "license.txt"
 
@@ -231,7 +236,7 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams) 
 
 	// apply the aggregated config snippets
 	if b.Len() > 0 {
-		err := s.applyPartialConfig(ctx, s.Cfg.MgmtIPv4Address, scrapliPlatformName,
+		err := s.applyPartialConfig(ctx, s.Cfg.MgmtIPv4Address, s.scrapliPlatform(),
 			defaultCredentials.GetUsername(), defaultCredentials.GetPassword(),
 			b,
 		)
@@ -243,11 +248,22 @@ func (s *vrSROS) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams) 
 	return nil
 }
 
+// scrapliPlatform returns the scrapligo platform name based on the configured CLI mode.
+// When CLAB_SROS_CONFIG_MODE is "classic" or "mixed", the classic CLI platform is used.
+// The default (unset or "model-driven") uses the MD-CLI platform.
+func (s *vrSROS) scrapliPlatform() string {
+	cfgMode := strings.ToLower(s.Cfg.Env[envSrosConfigMode])
+	if cfgMode == "classic" || cfgMode == "mixed" {
+		return scrapliPlatformNameClassic
+	}
+	return scrapliPlatformName
+}
+
 func (s *vrSROS) SaveConfig(_ context.Context) (*clabnodes.SaveConfigResult, error) {
 	err := clabnetconf.SaveRunningConfig(s.Cfg.LongName,
 		defaultCredentials.GetUsername(),
 		defaultCredentials.GetPassword(),
-		scrapliPlatformName,
+		s.scrapliPlatform(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 Use classic CLI scrapligo platform for vr-sros when `CLAB_SROS_CONFIG_MODE ` is classic/mixed

The nokia_sros scrapligo platform uses an MD-CLI prompt regex that requires the `[/]\nA:user@node#` format. When a vr-sros node is configured in classic or mixed CLI mode, the prompt is `A:node#` which never matches, causing a channel timeout fetching prompt error on every connection attempt.

Honour the `CLAB_SROS_CONFIG_MODE ` env var in vr-sros (as already done in the native sros kind) to select the nokia_sros_classic scrapligo platform whose regex matches the classic CLI prompt format.

Default value stay the same.

Tested in our side, on a LAB with both mixed and MD-CLI

Without this we have the following errors logs and the CLAB never finished to start (my device is TRAKE101)

```
11:35:29 DEBU    DEBUG channel read "p"
11:35:29 DEBU    DEBUG channel read "tographic products does not imply third-party authority to \n "
11:35:29 DEBU    DEBUG channel read "import, export"
11:35:29 DEBU    DEBUG channel read ", distribu"
11:35:29 DEBU    DEBUG channel read "te or use en"
11:35:29 DEBU    DEBUG channel read "cryption.\n \n If you requ"
11:35:29 DEBU    DEBUG channel read "ire further assistance p"
11:35:29 DEBU    DEBUG channel read "lease contact us by sending an email\n to suppor"
11:35:29 DEBU    DEBUG channel read "t@nokia.com.\n\nA:"
11:35:29 DEBU    DEBUG channel read "TRAKE101# \nA:TRAKE101# "
11:35:33 DEBU CRITICAL channel timeout fetching prompt
11:35:33 DEBU CRITICAL error executing network driver OnOpen, error: errTimeoutError: channel timeout fetching prompt
11:35:33 DEBU     INFO channel closing...
11:35:33 DEBU    DEBUG force closing underlying
```