### PR TITLE
fix(cert): return errors instead of nil and guard nil PEM decode

### DIFF
--- a/cert/ca.go
+++ b/cert/ca.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"time"
@@ -32,6 +33,9 @@ func (ca *CA) SetCACert(cert *Certificate) error {
 
 	// PEM to DER
 	pbCert, _ := pem.Decode(cert.Cert)
+	if pbCert == nil {
+		return fmt.Errorf("failed to decode CA certificate PEM block")
+	}
 
 	// parse the Certificate
 	ca.cert, err = x509.ParseCertificate(pbCert.Bytes)
@@ -91,17 +95,21 @@ func (ca *CA) GenerateCACert(input *CACSRInput) (*Certificate, error) {
 
 	// convert Certificate into PEM format
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	if err := pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to PEM-encode CA certificate: %w", err)
+	}
 
 	// convert Private Key into PEM format
 	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
+	if err := pem.Encode(caPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to PEM-encode CA private key: %w", err)
+	}
 
 	// create the clab certificate struct
 	clabCert := &Certificate{
@@ -165,16 +173,20 @@ func (ca *CA) GenerateAndSignNodeCert(input *NodeCSRInput) (*Certificate, error)
 	}
 
 	certPEM := new(bytes.Buffer)
-	pem.Encode(certPEM, &pem.Block{
+	if err := pem.Encode(certPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: certBytes,
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to PEM-encode node certificate: %w", err)
+	}
 
 	certPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(certPrivKeyPEM, &pem.Block{
+	if err := pem.Encode(certPrivKeyPEM, &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(newPrivKey),
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to PEM-encode node private key: %w", err)
+	}
 
 	// create the clab certificate struct
 	clabCert := &Certificate{

--- a/core/cert.go
+++ b/core/cert.go
@@ -20,14 +20,14 @@ func (c *CLab) LoadOrGenerateCA(caCertInput *clabcert.CACSRInput) error {
 		// store the root CA
 		err = c.Cert.StoreCaCert(caCertificate)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 
 	// set CA cert that was either loaded or generated
 	err = c.Cert.SetCACert(caCertificate)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -94,7 +94,7 @@ func (*DefaultNode) PostDeploy(_ context.Context, _ *PostDeployParams) error { r
 func (d *DefaultNode) PreDeploy(_ context.Context, params *PreDeployParams) error {
 	_, err := d.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return fmt.Errorf("loading or generating certificate for node %q: %w", d.Cfg.ShortName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Three cert-related correctness bugs:

- `core/cert.go`: `StoreCaCert` and `SetCACert` errors returned `nil` (success) instead of `err`, silently reporting CA setup as successful when it failed. All subsequent cert operations on nodes would then fail with a nil CA.
- `cert/ca.go`: `pem.Decode` return value was dereferenced unconditionally — returns `nil` on malformed/empty input, causing a nil dereference panic in `SetCACert`.
- `cert/ca.go`: `pem.Encode` errors were discarded; a silent encode failure produces empty cert/key bytes stored to disk and causes cryptic TLS failures later.
- `nodes/default_node.go`: `PreDeploy` returned `nil` on certificate error, silently proceeding with deployment without a cert.

## Testing

- `go vet ./cert/... ./core/... ./nodes/...` — clean
- `go test -race ./cert/... ./core/... ./nodes/srl/... ./nodes/sros/...` — all pass
- Note: `cert/` has no unit tests in the project; the fixes are verified through `core/` tests which exercise the cert path, and by code inspection