### PR TITLE
fix(links): correct vxlan type in MarshalYAML and prevent DNS empty-slice panic

### DIFF
--- a/links/link.go
+++ b/links/link.go
@@ -301,7 +301,7 @@ func (r *LinkDefinition) MarshalYAML() (any, error) {
 			LinkVxlanRaw `yaml:",inline"`
 		}{
 			LinkVxlanRaw: *r.Link.(*LinkVxlanRaw),
-			Type:         string(LinkTypeMacVLan),
+			Type:         string(LinkTypeVxlan),
 		}
 		return x, nil
 	case LinkTypeDummy:

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -127,6 +127,11 @@ func (lr *LinkVxlanRaw) resolveVxlan(params *ResolveParams, stitched bool) (*Lin
 			return nil, err
 		}
 
+		// always use the first address
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("unable to resolve %s", lr.Remote)
+		}
+
 		// prepare log message
 		sb := strings.Builder{}
 		for _, ip := range ips {
@@ -134,11 +139,6 @@ func (lr *LinkVxlanRaw) resolveVxlan(params *ResolveParams, stitched bool) (*Lin
 			sb.WriteString(ip.String())
 		}
 		log.Debugf("looked up hostname %s, received IP addresses [%s]", lr.Remote, sb.String()[2:])
-
-		// always use the first address
-		if len(ips) == 0 {
-			return nil, fmt.Errorf("unable to resolve %s", lr.Remote)
-		}
 		ip = ips[0]
 	}
 


### PR DESCRIPTION
## Summary

Two link-related fixes:

- `links/link.go`: `MarshalYAML` serialized vxlan links with `type: macvlan` due to a copy-paste error from the MacVLan case directly above. Topologies saved with `clab generate` that contain vxlan links would be re-parsed as macvlan links, silently producing an incorrect topology.
- `links/link_vxlan.go`: `net.LookupIP` can return an empty non-nil slice without error on some resolver implementations. The code called `sb.String()[2:]` before the `len(ips) == 0` guard, causing an index out of range panic. Moved the empty check before the log line.

## Testing

- `go vet ./links/...` — clean
- `go test -race ./links/...` — all pass
- Verified the vxlan type constant change: `LinkTypeVxlan = "vxlan"` matches the expected serialized value