### PR TITLE
fix: close file handles to prevent resource leaks

### DIFF
--- a/core/deploy.go
+++ b/core/deploy.go
@@ -76,19 +76,21 @@ func (c *CLab) Deploy( //nolint: funlen
 	// we create it here first, so that bind mounts of ansible-inventory.yml file could work
 	ansibleInvFPath := c.TopoPaths.AnsibleInventoryFileAbsPath()
 
-	_, err = os.Create(ansibleInvFPath)
+	ansibleF, err := os.Create(ansibleInvFPath)
 	if err != nil {
 		return nil, err
 	}
+	ansibleF.Close()
 
 	// create an empty nornir simple inventory file that will get populated later
 	// we create it here first, so that bind mounts of nornir-simple-inventory.yml file could work
 	nornirSimpleInvFPath := c.TopoPaths.NornirSimpleInventoryFileAbsPath()
 
-	_, err = os.Create(nornirSimpleInvFPath)
+	nornirF, err := os.Create(nornirSimpleInvFPath)
 	if err != nil {
 		return nil, err
 	}
+	nornirF.Close()
 
 	// in an similar fashion, create an empty topology data file
 	topoDataFPath := c.TopoPaths.TopoExportFile()
@@ -97,6 +99,7 @@ func (c *CLab) Deploy( //nolint: funlen
 	if err != nil {
 		return nil, err
 	}
+	defer topoDataF.Close()
 
 	if err := c.certificateAuthoritySetup(); err != nil {
 		return nil, err

--- a/core/topology.go
+++ b/core/topology.go
@@ -62,6 +62,7 @@ func downloadTopoFile(url, tempDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer tmpFile.Close()
 
 	err = clabutils.CopyFile(context.Background(), url, tmpFile.Name(),
 		clabconstants.PermissionsFileDefault)
@@ -77,6 +78,7 @@ func readFromStdin(tempDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer tmpFile.Close()
 
 	_, err = tmpFile.ReadFrom(os.Stdin)
 	if err != nil {

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -609,6 +609,7 @@ func generateSRLTopologyFile(cfg *clabtypes.NodeConfig) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	if err := tpl.Execute(f, mac); err != nil {
 		return err

--- a/utils/file.go
+++ b/utils/file.go
@@ -323,6 +323,7 @@ func CreateFile(file, content string) (err error) {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	// add newline if missing
 	if !strings.HasSuffix(content, "\n") {
@@ -682,12 +683,16 @@ func FileToTarStream(dstFile string, filePath string) (*bytes.Buffer, error) {
 	}
 	header.Mode = 0o666
 	header.Name = filepath.Base(dstFile)
-	tarWriter.WriteHeader(header)
+	if err := tarWriter.WriteHeader(header); err != nil {
+		return nil, fmt.Errorf("cannot write tar header for %s: %w", filePath, err)
+	}
 
 	fileReader, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open %s: %w", filePath, err)
 	}
+	defer fileReader.Close()
+
 	_, err = io.Copy(tarWriter, fileReader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)


### PR DESCRIPTION
## Summary

Several file descriptor leaks across the codebase:

- `core/deploy.go`: `os.Create` return values for ansible/nornir inventory files were discarded with `_`, leaking the file descriptor. `topoDataF` was also missing a `defer Close()`, leaking on early return.
- `core/topology.go`: `readFromStdin` and `downloadTopoFile` opened temp files via `os.CreateTemp` but never closed the handle.
- `nodes/srl/srl.go`: `generateSRLTopologyFile` leaked the file handle when `tpl.Execute` returned an error.
- `utils/file.go`: `FileToTarStream` never closed the source file reader and silently discarded `tarWriter.WriteHeader` errors; `CreateFile` leaked the handle on write error.

Each of these leaks a file descriptor per lab operation. Under repeated deploys or long-running processes this exhausts the fd limit.

## Testing

- `go vet ./core/... ./nodes/srl/... ./utils/...` — clean
- `go test -race ./core/... ./nodes/srl/... ./utils/...` — all pass