### PR TITLE
fix: prevent nil dereference panics in destroy, netconf, and sros

### DIFF
--- a/core/destroy.go
+++ b/core/destroy.go
@@ -367,6 +367,10 @@ func (c *CLab) deleteContainersDirect(
 	containers []clabruntime.GenericContainer,
 ) {
 	for _, cont := range containers {
+		if len(cont.Names) == 0 {
+			log.Warnf("skipping container %s with no names", cont.ID)
+			continue
+		}
 		name := cont.Names[0]
 		log.Infof("Removing container: %s", name)
 

--- a/netconf/netconf.go
+++ b/netconf/netconf.go
@@ -134,14 +134,14 @@ func MultiExec(addr, username, password string, operations []Operation) error {
 
 	for _, operation := range operations {
 		r, e := operation(d)
+		if e != nil {
+			return fmt.Errorf("NETCONF operation failed for %q: %w", addr, e)
+		}
 		log.Debugf("NETCONF RPC sent to %q: %s", addr,
 			xmlfmt.FormatXML(string(r.Input), "\t", "    "))
 		if r.Failed != nil {
-			return fmt.Errorf("NETCONF RPC to %q failed received: %s",
+			return fmt.Errorf("NETCONF RPC to %q failed: %s",
 				addr, r.Result)
-		}
-		if e != nil {
-			return e
 		}
 	}
 

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -691,7 +691,9 @@ func (n *sros) setComponentEnvVars(componentConfig *clabtypes.NodeConfig, c *cla
 func (n *sros) deployFabric(ctx context.Context, deployParams *clabnodes.DeployParams) error {
 	// loop through the components, creating them
 	for _, c := range n.componentNodes {
-		c.PreDeploy(ctx, n.preDeployParams)
+		if err := c.PreDeploy(ctx, n.preDeployParams); err != nil {
+			return fmt.Errorf("pre-deploy for component node %q: %w", c.GetShortName(), err)
+		}
 		// deploy the component
 		err := c.Deploy(ctx, deployParams)
 		if err != nil {
@@ -773,6 +775,9 @@ func (n *sros) calcComponentFqdn(slot string) string {
 		return n.Cfg.Fqdn
 	}
 	fqdnDotIndex := strings.Index(n.Cfg.Fqdn, ".")
+	if fqdnDotIndex < 0 {
+		return fmt.Sprintf("%s-%s", n.Cfg.Fqdn, strings.ToLower(slot))
+	}
 	result := fmt.Sprintf(
 		"%s-%s%s",
 		n.Cfg.Fqdn[:fqdnDotIndex],


### PR DESCRIPTION
## Summary

Three nil/bounds-check fixes that prevent panics:

- `core/destroy.go`: `cont.Names[0]` was accessed without checking `len(cont.Names)`. Orphaned or stopped containers under Podman can have empty names, causing `clab destroy` to panic rather than skip or warn.
- `netconf/netconf.go`: `r.Input` and `r.Failed` were accessed before checking the operation error `e`. If `operation(d)` returns a nil `r` along with a transport error (connection reset, timeout), this panics. Fixed the check order so the error is returned first.
- `nodes/sros/sros.go`: `calcComponentFqdn` sliced `n.Cfg.Fqdn[:fqdnDotIndex]` where `fqdnDotIndex` comes from `strings.Index`, which returns `-1` when `.` is not found. A short hostname without a domain suffix causes an index out of range panic during distributed SR-SIM deployment.

## Testing

- `go vet ./core/... ./netconf/... ./nodes/sros/...` — clean
- `go test -race ./core/... ./nodes/sros/...` — all pass
- `netconf/` has no unit tests in the project; fix verified by code inspection (error check moved before nil dereference)