### PR TITLE
fix: propagate discarded errors in authz_keys, template, nftables, and sros

### DIFF
--- a/core/authz_keys.go
+++ b/core/authz_keys.go
@@ -89,12 +89,12 @@ func (c *CLab) RetrieveSSHPubKeys(ctx context.Context) ([]ssh.PublicKey, error) 
 	// we accumulate them and log.
 	fkeys, err := RetrieveSSHPubKeysFromFiles()
 	if err != nil {
-		errs = errors.Join(err)
+		errs = errors.Join(errs, err)
 	}
 
 	agentKeys, err := RetrieveSSHAgentKeys(ctx)
 	if err != nil {
-		errs = errors.Join(err)
+		errs = errors.Join(errs, err)
 	}
 
 	keysM := map[string]ssh.PublicKey{}

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -691,7 +691,9 @@ func (n *sros) setComponentEnvVars(componentConfig *clabtypes.NodeConfig, c *cla
 func (n *sros) deployFabric(ctx context.Context, deployParams *clabnodes.DeployParams) error {
 	// loop through the components, creating them
 	for _, c := range n.componentNodes {
-		c.PreDeploy(ctx, n.preDeployParams)
+		if err := c.PreDeploy(ctx, n.preDeployParams); err != nil {
+			return fmt.Errorf("pre-deploy for component node %q: %w", c.GetShortName(), err)
+		}
 		// deploy the component
 		err := c.Deploy(ctx, deployParams)
 		if err != nil {

--- a/runtime/docker/firewall/nftables/client.go
+++ b/runtime/docker/firewall/nftables/client.go
@@ -148,7 +148,9 @@ func (c *NftablesClient) DeleteForwardingRules(rule *definitions.FirewallRule) e
 		}
 	}
 
-	c.flush()
+	if err := c.flush(); err != nil {
+		return fmt.Errorf("failed to apply nftables rules: %w", err)
+	}
 	return nil
 }
 
@@ -232,7 +234,9 @@ func (c *NftablesClient) InstallForwardingRulesForAF(
 	// mark and note for installation
 	c.insertRule(r.rule)
 	// flush changes out to nftables
-	c.flush()
+	if err = c.flush(); err != nil {
+		return fmt.Errorf("failed to apply nftables rules: %w", err)
+	}
 
 	return nil
 }

--- a/utils/template.go
+++ b/utils/template.go
@@ -654,7 +654,9 @@ func SubstituteEnvsAndTemplate(r io.Reader, data any) (*bytes.Buffer, error) {
 
 	buf := new(bytes.Buffer)
 
-	t.Execute(buf, data)
+	if err = t.Execute(buf, data); err != nil {
+		return nil, fmt.Errorf("template execution failed: %w", err)
+	}
 
 	return buf, nil
 }


### PR DESCRIPTION
## Summary

Four places where errors were silently discarded:

- `core/authz_keys.go`: `errors.Join(err)` was called with a single argument twice, so the second call replaced (not accumulated) the first error. If both SSH key retrieval calls failed, only the second error was ever reported. Fixed to `errors.Join(errs, err)`.
- `utils/template.go`: `t.Execute(buf, data)` error was discarded. A template execution failure would produce a silently empty or partial config file written to the node.
- `runtime/docker/firewall/nftables/client.go`: `c.flush()` — which applies all buffered netlink operations atomically — was called without checking its return value in both `DeleteForwardingRules` and `InstallForwardingRulesForAF`. Firewall rules could silently fail to apply or be removed.
- `nodes/sros/sros.go`: `c.PreDeploy()` return value was completely ignored in the `deployFabric` component node loop. A pre-deploy failure (e.g. missing bind-mount dirs, cert error) would silently proceed to `Deploy`.

## Testing

- `go vet ./core/... ./utils/... ./runtime/... ./nodes/sros/...` — clean
- `go test -race ./core/... ./utils/... ./runtime/docker/... ./nodes/sros/...` — all pass
- `nftables/` has no unit tests in the project; fix verified by code inspection