### PR TITLE
Feature/annotations endpoint for UI persistance

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -823,8 +823,8 @@ func (c *CLab) magicVarReplacer(nodeName string) *strings.Replacer {
 
 	if nodeName != "" {
 		replacerPairs = append(replacerPairs,
-		nodeDirVar, c.TopoPaths.NodeDir(nodeName),
-		nodeNameVar, nodeName,
+			nodeDirVar, c.TopoPaths.NodeDir(nodeName),
+			nodeNameVar, nodeName,
 		)
 	}
 

--- a/core/events/stream.go
+++ b/core/events/stream.go
@@ -503,7 +503,13 @@ func formatExposedPort(port *clabtypes.GenericPortBinding) string {
 		}
 
 		if port.ContainerPort > 0 {
-			return fmt.Sprintf("%s:%d%s->%d", hostIP, port.HostPort, protoSuffix, port.ContainerPort)
+			return fmt.Sprintf(
+				"%s:%d%s->%d",
+				hostIP,
+				port.HostPort,
+				protoSuffix,
+				port.ContainerPort,
+			)
 		}
 
 		return fmt.Sprintf("%s:%d%s", hostIP, port.HostPort, protoSuffix)

--- a/core/graph.go
+++ b/core/graph.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -331,6 +333,45 @@ func (c *CLab) ServeTopoGraph(tmpl, staticDir, srv string, topoD TopoData) error
 
 	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = t.Execute(w, topoD)
+	})
+
+	// Annotations API for persisting node positions.
+	annotationsFile := filepath.Join(c.TopoPaths.TopologyFileDir(), ".clab-topo-editor.json")
+
+	http.HandleFunc("/api/v1/annotations", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			data, err := os.ReadFile(annotationsFile)
+			if err != nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"nodeAnnotations":[]}`))
+
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(data)
+
+		case http.MethodPost:
+			var body json.RawMessage
+
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "invalid JSON", http.StatusBadRequest)
+
+				return
+			}
+
+			if err := os.WriteFile(annotationsFile, body, 0o644); err != nil {
+				http.Error(w, "failed to write annotations file", http.StatusInternalServerError)
+
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
 	})
 
 	// If the server binds to 0.0.0.0, show all routable addresses for better usability

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -156,7 +156,11 @@ func (l *LinkVEth) deployAEnd(ctx context.Context, idx int) error {
 	// after LinkAdd succeeded, preventing orphaned interfaces from blocking retries.
 	cleanup := func(err error) error {
 		if delErr := netlink.LinkDel(linkA); delErr != nil {
-			log.Debugf("failed to cleanup veth pair %s after error: %v", ep.GetRandIfaceName(), delErr)
+			log.Debugf(
+				"failed to cleanup veth pair %s after error: %v",
+				ep.GetRandIfaceName(),
+				delErr,
+			)
 		}
 		return err
 	}


### PR DESCRIPTION
## Notes

This is a draft PR to gather feedback from maintainers. A companion React-based UI that consumes this API exists but is not part of this PR — the endpoints are useful independently for any custom frontend or tooling.

Code will be thoroughly reviewed and improved before the PR is marked ready for review.

## Summary

Add `GET/POST /api/v1/annotations` endpoints to the `clab graph` HTTP server that persist node position data to `.clab-topo-editor.json` next to the topology file.

This enables interactive graph UI frontends to save and restore node positions across browser sessions — for example after dragging nodes into a preferred layout, positions survive a page refresh.

The file format is intentionally compatible with the [VSCode containerlab extension](https://github.com/srl-labs/vscode-containerlab)'s `topoViewer` position storage:

```json
{
  "nodeAnnotations": [
    { "id": "srl1", "position": { "x": 100, "y": 200 } }
  ]
}
```

## API

- `GET /api/v1/annotations` — returns saved positions, or `{"nodeAnnotations":[]}` if the file doesn't exist
- `POST /api/v1/annotations` — writes the request body JSON to `.clab-topo-editor.json`

