### PR TITLE
fix(nodes): propagate PreDeploy certificate errors across all node types

### DIFF
--- a/nodes/c8000/c8000.go
+++ b/nodes/c8000/c8000.go
@@ -73,7 +73,7 @@ func (n *c8000) PreDeploy(ctx context.Context, params *clabnodes.PreDeployParams
 
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return n.create8000Files(ctx)

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -94,7 +94,7 @@ func (s *crpd) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) e
 	clabutils.CreateDirectory(s.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 	return createCRPDFiles(s)
 }

--- a/nodes/dell_sonic/dell_sonic.go
+++ b/nodes/dell_sonic/dell_sonic.go
@@ -95,7 +95,7 @@ func (n *dell_sonic) PreDeploy(_ context.Context, params *clabnodes.PreDeployPar
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 	return clabnodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
 }

--- a/nodes/f5_bigipve/f5_bigip-ve.go
+++ b/nodes/f5_bigipve/f5_bigip-ve.go
@@ -108,10 +108,10 @@ func (n *F5BigIPVE) PreDeploy(_ context.Context, params *clabnodes.PreDeployPara
 	clabutils.CreateDirectory(path.Join(n.Cfg.LabDir, configDirName), clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (n *F5BigIPVE) CheckInterfaceName() error {

--- a/nodes/generic_vm/generic_vm.go
+++ b/nodes/generic_vm/generic_vm.go
@@ -92,10 +92,10 @@ func (n *genericVM) PreDeploy(_ context.Context, params *clabnodes.PreDeployPara
 	clabutils.CreateDirectory(path.Join(n.Cfg.LabDir, configDirName), clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -145,7 +145,7 @@ func (n *iol) PreDeploy(ctx context.Context, params *clabnodes.PreDeployParams) 
 
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return n.CreateIOLFiles(ctx)

--- a/nodes/rare/rare.go
+++ b/nodes/rare/rare.go
@@ -62,7 +62,7 @@ func (n *rare) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) e
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return n.createRAREFiles()

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -61,7 +61,7 @@ func (s *sonic) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) 
 	clabutils.CreateDirectory(s.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 	return nil
 }

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -99,9 +99,7 @@ func (n *sonic_vm) PreDeploy(_ context.Context, params *clabnodes.PreDeployParam
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		log.Errorf("Error handling certificate for %s: %v", n.Cfg.ShortName, err)
-
-		return nil
+		return err
 	}
 
 	return clabnodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)

--- a/nodes/vr_freebsd/vr-freebsd.go
+++ b/nodes/vr_freebsd/vr-freebsd.go
@@ -102,10 +102,10 @@ func (n *vrFreeBSD) PreDeploy(_ context.Context, params *clabnodes.PreDeployPara
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (n *vrFreeBSD) SaveConfig(ctx context.Context) (*clabnodes.SaveConfigResult, error) {

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -53,7 +53,7 @@ func (n *VRNode) PreDeploy(_ context.Context, params *PreDeployParams) error {
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 	return LoadStartupConfigFileVr(n, n.ConfigDirName, n.StartupCfgFName)
 }

--- a/nodes/vr_openbsd/vr-openbsd.go
+++ b/nodes/vr_openbsd/vr-openbsd.go
@@ -103,10 +103,10 @@ func (n *vrOpenBSD) PreDeploy(_ context.Context, params *clabnodes.PreDeployPara
 	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (n *vrOpenBSD) SaveConfig(ctx context.Context) (*clabnodes.SaveConfigResult, error) {

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -144,7 +144,7 @@ func (s *vrSROS) PreDeploy(ctx context.Context, params *clabnodes.PreDeployParam
 	clabutils.CreateDirectory(s.Cfg.LabDir, clabconstants.PermissionsOpen)
 	_, err := s.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// store public keys extracted from clab host

--- a/nodes/xrd/xrd.go
+++ b/nodes/xrd/xrd.go
@@ -105,7 +105,7 @@ func (n *xrd) PreDeploy(ctx context.Context, params *clabnodes.PreDeployParams) 
 
 	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return n.createXRDFiles(ctx)


### PR DESCRIPTION
## Summary

Companion to #3130 — fixes the same `return nil` instead of `return err` bug in all remaining node types.

Every node that calls `LoadOrGenerateCertificate` in `PreDeploy` was returning `nil` on error, silently reporting success when certificate generation failed. The node would deploy without a TLS certificate and no error surfaced to the user.

Fixed in 13 files:
- `vr_node.go` (base class for FortiGate, Checkpoint, and other VR nodes)
- `crpd/crpd.go`, `vr_sros/vr-sros.go`, `xrd/xrd.go`, `iol/iol.go`, `c8000/c8000.go`
- `sonic/sonic.go`, `sonic_vm/sonic_vm.go`, `dell_sonic/dell_sonic.go`, `rare/rare.go`
- `vr_freebsd/vr-freebsd.go`, `vr_openbsd/vr-openbsd.go`, `f5_bigipve/f5_bigip-ve.go`, `generic_vm/generic_vm.go`

Also fixed a secondary issue in `f5_bigipve`, `generic_vm`, `vr_freebsd`, and `vr_openbsd` where the success path returned the (now nil) `err` variable instead of an explicit `nil`.

## Testing

- `go vet ./nodes/...` — clean
- `go test -race ./nodes/...` — all pass