### PR TITLE
fix: use SplitN for env vars and check CreateFile errors

### DIFF
--- a/core/graph.go
+++ b/core/graph.go
@@ -137,7 +137,9 @@ func (c *CLab) GenerateDotGraph(ctx context.Context) error {
 
 	// create graph filename
 	dotfile := c.TopoPaths.GraphFilename(".dot")
-	clabutils.CreateFile(dotfile, g.String())
+	if err := clabutils.CreateFile(dotfile, g.String()); err != nil {
+		return fmt.Errorf("failed to write dot graph file: %w", err)
+	}
 	log.Infof("Created %s", dotfile)
 
 	pngfile := c.TopoPaths.GraphFilename(".png")
@@ -281,7 +283,9 @@ func (c *CLab) GenerateMermaidGraph(direction string) error {
 	// Generate graph
 	var w strings.Builder
 	fc.Generate(&w)
-	clabutils.CreateFile(fname, w.String())
+	if err := clabutils.CreateFile(fname, w.String()); err != nil {
+		return fmt.Errorf("failed to write mermaid graph file: %w", err)
+	}
 
 	log.Infof("Created mermaid diagram file: %s", fname)
 

--- a/nodes/ceos/ceos.go
+++ b/nodes/ceos/ceos.go
@@ -264,7 +264,9 @@ func (n *ceos) createCEOSFiles(ctx context.Context) error {
 
 	// adding if-wait.sh script to flash dir
 	ifScriptP := path.Join(nodeCfg.LabDir, "flash", "if-wait.sh")
-	clabutils.CreateFile(ifScriptP, clabutils.IfWaitScript)
+	if err := clabutils.CreateFile(ifScriptP, clabutils.IfWaitScript); err != nil {
+		return fmt.Errorf("failed to write if-wait.sh: %w", err)
+	}
 	os.Chmod(ifScriptP, clabconstants.PermissionsOpen) // skipcq: GSC-G302
 
 	if *n.Cfg.Certificate.Issue {

--- a/nodes/crpd/crpd.go
+++ b/nodes/crpd/crpd.go
@@ -198,7 +198,7 @@ func createCRPDFiles(node clabnodes.Node) error {
 
 	err := node.GenerateConfig(cfg, cfgTemplate)
 	if err != nil {
-		log.Errorf("node=%s, failed to generate config: %v", nodeCfg.ShortName, err)
+		return fmt.Errorf("node=%s, failed to generate config: %w", nodeCfg.ShortName, err)
 	}
 
 	// write crpd sshd conf file to crpd node dir

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -132,7 +132,10 @@ func (n *NodeDefinition) ImportEnvs() {
 	}
 
 	for _, e := range os.Environ() {
-		kv := strings.Split(e, "=")
+		kv := strings.SplitN(e, "=", 2)
+		if len(kv) < 2 {
+			continue
+		}
 		if _, exists := n.Env[kv[0]]; exists {
 			continue
 		}


### PR DESCRIPTION
## Summary

Four correctness fixes:

- **`types/node_definition.go`**: `strings.Split(e, "=")` splits on every `=` in the value, truncating environment variables that contain `=` in their value (e.g. connection strings like `postgres://host/db?opt=val`, base64-encoded secrets). Changed to `strings.SplitN(e, "=", 2)` and added a length guard for malformed entries. This affects any topology using `__IMPORT_ENVS: true`.
- **`core/graph.go`**: `CreateFile` errors were discarded in both `GenerateDotGraph` and `GenerateMermaidGraph`. A disk-full or permission error would log success but produce no output file.
- **`nodes/crpd/crpd.go`**: `GenerateConfig` error was logged but not returned in `createCRPDFiles`, allowing crpd nodes to deploy with no `juniper.conf` generated.
- **`nodes/ceos/ceos.go`**: `CreateFile` error for `if-wait.sh` was discarded. A write failure causes the ceos container to start before interfaces are wired, breaking initialization.

## Testing

- `go vet ./types/... ./core/... ./nodes/crpd/... ./nodes/ceos/...` — clean
- `go test -race ./types/... ./core/... ./nodes/crpd/... ./nodes/ceos/...` — all pass