### PR TITLE
fix(cmd): move defer after nil check, fix nil error wrapping, and check errors

### DIFF
--- a/cmd/tools_gotty.go
+++ b/cmd/tools_gotty.go
@@ -328,7 +328,7 @@ func gottyAttach(cobraCmd *cobra.Command, o *Options) error { //nolint: funlen
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	if o.ToolsGoTTY.ContainerName == "" {
@@ -446,7 +446,7 @@ func gottyDetach(cobraCmd *cobra.Command, o *Options) error {
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	containerName := fmt.Sprintf("clab-%s-gotty", c.Config.Name)
@@ -473,7 +473,7 @@ func gottyList(cobraCmd *cobra.Command, o *Options) error { //nolint: funlen
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	containers, err := c.ListContainers(
@@ -603,7 +603,7 @@ func gottyReattach(cobraCmd *cobra.Command, o *Options) error { //nolint: funlen
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	if o.ToolsGoTTY.ContainerName == "" {

--- a/cmd/tools_netem.go
+++ b/cmd/tools_netem.go
@@ -256,7 +256,9 @@ func validateInputAndRoot(o *Options) error {
 		return fmt.Errorf("jitter cannot be set without setting delay")
 	}
 
-	clabutils.CheckAndGetRootPrivs()
+	if err := clabutils.CheckAndGetRootPrivs(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/tools_sshx.go
+++ b/cmd/tools_sshx.go
@@ -317,7 +317,7 @@ func sshxAttach(cobraCmd *cobra.Command, o *Options) error { //nolint: funlen
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	// Set container name if not provided
@@ -437,7 +437,7 @@ func sshxDetach(cobraCmd *cobra.Command, o *Options) error {
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	containerName := fmt.Sprintf("clab-%s-sshx", c.Config.Name)
@@ -464,7 +464,7 @@ func sshxList(cobraCmd *cobra.Command, o *Options) error {
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	containers, err := c.ListContainers(
@@ -577,7 +577,7 @@ func sshxReattach(cobraCmd *cobra.Command, o *Options) error { //nolint: funlen
 
 	rt, ok := c.Runtimes[o.Global.Runtime]
 	if !ok {
-		return fmt.Errorf("failed getting runtime: %w", err)
+		return fmt.Errorf("runtime %q not found", o.Global.Runtime)
 	}
 
 	// Set container name if not provided

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -131,7 +131,9 @@ func vethCreate(o *Options) error {
 
 	// deploy the endpoints of the Link
 	for _, ep := range link.GetEndpoints() {
-		ep.Deploy(ctx)
+		if err := ep.Deploy(ctx); err != nil {
+			return fmt.Errorf("failed to deploy veth endpoint: %w", err)
+		}
 	}
 
 	log.Info("veth interface successfully created!")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -159,12 +159,11 @@ func printNewVersionInfo(ver string) {
 
 func upgrade(cobraCmd *cobra.Command, _ []string) error {
 	f, err := os.CreateTemp("", "containerlab")
-
-	defer os.Remove(f.Name())
-
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
+
+	defer os.Remove(f.Name())
 
 	err = clabutils.CopyFileContents(cobraCmd.Context(), downloadURL, f)
 	if err != nil {


### PR DESCRIPTION
## Summary

Four cmd/ fixes:

- **`cmd/version.go`**: `defer os.Remove(f.Name())` was registered before the nil check on `f`. If `os.CreateTemp` fails (disk full, permissions), `f` is nil and the deferred `f.Name()` call panics at function exit. Moved the defer after the error guard.
- **`cmd/tools_sshx.go`, `cmd/tools_gotty.go`** (8 occurrences): `fmt.Errorf("failed getting runtime: %w", err)` wraps `err` which is always nil at that point (it was checked and returned earlier). Users see `"failed getting runtime: <nil>"` instead of a useful message. Changed to include the actual runtime name: `"runtime %q not found"`.
- **`cmd/tools_veth.go`**: `ep.Deploy(ctx)` return value was discarded. A half-deployed veth pair (one endpoint fails) silently reports success.
- **`cmd/tools_netem.go`**: `CheckAndGetRootPrivs()` return value was discarded. Running `clab tools netem` without root produces cryptic netlink permission errors instead of the clear "requires root privileges" message.

## Testing

- `go vet ./cmd/...` — clean
- `go test -race ./cmd/...` — all pass