### PR TITLE
fix: prevent panics and data loss in podman runtime and kernel module check

### DIFF
--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -76,8 +76,7 @@ func (r *PodmanRuntime) createContainerSpec(
 	// Storage, image and mounts
 	mounts, err := r.convertMounts(ctx, cfg.Binds)
 	if err != nil {
-		log.Errorf("Cannot convert mounts %v: %v", cfg.Binds, err)
-		mounts = nil
+		return "", fmt.Errorf("cannot convert mounts %v: %w", cfg.Binds, err)
 	}
 	specStorageConfig := specgen.ContainerStorageConfig{
 		Image: cfg.Image,
@@ -117,11 +116,12 @@ func (r *PodmanRuntime) createContainerSpec(
 	// Memory limits
 	if cfg.Memory != "" {
 		mem, err := humanize.ParseBytes(cfg.Memory)
-		mem64 := int64(mem)
 		if err != nil {
 			log.Warnf("Unable to parse memory limit %q for node %q", cfg.Memory, cfg.LongName)
+		} else {
+			mem64 := int64(mem)
+			lMem.Limit = &mem64
 		}
-		lMem.Limit = &mem64
 	}
 	resLimits.Memory = &lMem
 	// CPU resources limits
@@ -390,6 +390,7 @@ func (*PodmanRuntime) extractMgmtIP(
 	inspectRes, err := containers.Inspect(ctx, cID, &containers.InspectOptions{})
 	if err != nil {
 		log.Debugf("Couldn't extract mgmt IPs for container %q, %v", cID, err)
+		return toReturn, nil
 	}
 	// Extract the data only for a specific CNI. Network name is taken from a container's label
 	netName, ok := inspectRes.Config.Labels["clab-net-mgmt"]

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -23,14 +23,19 @@ func IsKernelModuleLoaded(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		if strings.HasPrefix(strings.Fields(scanner.Text())[0], name) {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		if strings.HasPrefix(fields[0], name) {
 			return true, nil
 		}
 	}
-	return false, f.Close()
+	return false, scanner.Err()
 }
 
 const kernelOSReleasePath = "/proc/sys/kernel/osrelease"


### PR DESCRIPTION
## Summary

Four correctness fixes found via code review:

### 1. Podman `extractMgmtIPs` — nil dereference panic
After `containers.Inspect` fails, the code falls through to access `inspectRes.Config.Labels` which panics on the nil pointer. **Fix:** return early on error.

### 2. Podman mount conversion error swallowed — silent data loss
When `convertMounts()` fails (invalid bind mount syntax), the error was logged but execution continued with `mounts = nil`. The container was created with **no mounts at all** — no startup configs, no license files. **Fix:** propagate the error to fail deployment clearly.

### 3. Podman memory limit set to zero on parse error
When `humanize.ParseBytes` fails to parse a memory limit string, the code still set `lMem.Limit` to the zero value from the failed parse. **Fix:** only set the limit on successful parse.

### 4. Kernel module check — file handle leak + empty line panic
`IsKernelModuleLoaded` leaked the file handle when a module was found (early return without close). Also, an empty line in `/proc/modules` would panic on `Fields()[0]` of an empty slice. **Fix:** use `defer f.Close()` and guard against empty lines.

## Testing

- `go vet ./utils/...` — clean
- `go test -race ./utils/...` — all pass
- Podman runtime cannot be compiled on this machine (missing C libs), but changes are syntactically equivalent patterns to existing code