### PR TITLE
fix(links): use sync.Once for singleton init and guard nil namespace

### DIFF
--- a/links/link_host.go
+++ b/links/link_host.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/charmbracelet/log"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -94,7 +95,10 @@ func (r *LinkHostRaw) Resolve(params *ResolveParams) (Link, error) {
 	return link, nil
 }
 
-var _hostLinkNodeInstance *hostLinkNode
+var (
+	_hostLinkNodeInstance *hostLinkNode
+	_hostLinkNodeOnce     sync.Once
+)
 
 // hostLinkNode represents a host node which is implicitly used when
 // a host link is defined in the topology file.
@@ -108,20 +112,20 @@ func (*hostLinkNode) GetLinkEndpointType() LinkEndpointType {
 
 // GetHostLinkNode returns the host link node singleton.
 func GetHostLinkNode() Node {
-	if _hostLinkNodeInstance == nil {
+	_hostLinkNodeOnce.Do(func() {
 		currns, err := ns.GetCurrentNS()
 		if err != nil {
-			log.Error(err)
+			log.Errorf("failed to get current network namespace: %v", err)
+			return
 		}
-		nspath := currns.Path()
 
 		_hostLinkNodeInstance = &hostLinkNode{
 			GenericLinkNode: GenericLinkNode{
 				shortname: "host",
 				endpoints: []Endpoint{},
-				nspath:    nspath,
+				nspath:    currns.Path(),
 			},
 		}
-	}
+	})
 	return _hostLinkNodeInstance
 }

--- a/links/link_mgmt-net.go
+++ b/links/link_mgmt-net.go
@@ -3,6 +3,7 @@ package links
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/charmbracelet/log"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -102,7 +103,10 @@ func mgmtNetLinkFromBrief(lb *LinkBriefRaw, specialEPIndex int) (*LinkMgmtNetRaw
 	return link, nil
 }
 
-var _mgmtBrLinkMgmtBrInstance *mgmtBridgeLinkNode
+var (
+	_mgmtBrLinkMgmtBrInstance *mgmtBridgeLinkNode
+	_mgmtBrLinkOnce           sync.Once
+)
 
 // mgmtBridgeLinkNode is a special node that represents the mgmt bridge node
 // that is used when mgmt-net link is defined in the topology.
@@ -142,20 +146,20 @@ func (b *mgmtBridgeLinkNode) AddLinkToContainer(
 }
 
 func getMgmtBrLinkNode() *mgmtBridgeLinkNode {
-	if _mgmtBrLinkMgmtBrInstance == nil {
+	_mgmtBrLinkOnce.Do(func() {
 		currns, err := ns.GetCurrentNS()
 		if err != nil {
-			log.Error(err)
+			log.Errorf("failed to get current network namespace: %v", err)
+			return
 		}
-		nspath := currns.Path()
 		_mgmtBrLinkMgmtBrInstance = &mgmtBridgeLinkNode{
 			GenericLinkNode: GenericLinkNode{
 				shortname: "mgmt-net",
 				endpoints: []Endpoint{},
-				nspath:    nspath,
+				nspath:    currns.Path(),
 			},
 		}
-	}
+	})
 	return _mgmtBrLinkMgmtBrInstance
 }
 


### PR DESCRIPTION
## Summary

Two issues in the host and mgmt-net link node singletons:

### 1. Race condition on singleton initialization
`GetHostLinkNode()` and `getMgmtBrLinkNode()` use a check-then-write pattern (`if instance == nil { instance = ... }`) on package-level variables without synchronization. Since containerlab deploys nodes in parallel (link resolution happens concurrently), two goroutines could both read nil and race on the write.

**Fix:** Replace manual nil check with `sync.Once` for thread-safe initialization.

### 2. Nil dereference when GetCurrentNS fails
When `ns.GetCurrentNS()` returns an error, `currns` is nil. The code logs the error but unconditionally calls `currns.Path()` on the next line, causing a nil pointer dereference panic.

**Fix:** Return early on error so the singleton remains nil rather than crashing.

## Testing

- `go vet ./links/...` — clean
- `go test -race ./links/...` — all pass