### PR TITLE
fix(runtime): close ExecNotWait connection, guard NetworkInspect error path

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -140,9 +140,7 @@ func (d *DockerRuntime) WithMgmtNet(n *clabtypes.MgmtNet) {
 		if err != nil {
 			d.mgmt.MTU = 1500
 			log.Debugf("an error occurred when trying to detect docker default network mtu")
-		}
-
-		if mtu, ok := netRes.Options["com.docker.network.driver.mtu"]; ok {
+		} else if mtu, ok := netRes.Options["com.docker.network.driver.mtu"]; ok {
 			log.Debugf("detected docker network mtu value - %s", mtu)
 			d.mgmt.MTU, err = strconv.Atoi(mtu)
 			if err != nil {
@@ -1114,10 +1112,11 @@ func (d *DockerRuntime) ExecNotWait(
 	}
 
 	execStartCheck := container.ExecStartOptions{}
-	_, err = d.Client.ContainerExecAttach(context.Background(), respID.ID, execStartCheck)
+	rsp, err := d.Client.ContainerExecAttach(context.Background(), respID.ID, execStartCheck)
 	if err != nil {
 		return err
 	}
+	rsp.Close()
 	return nil
 }
 

--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -206,13 +206,15 @@ func (r *PodmanRuntime) CreateContainer(
 		)
 	}
 	res, err := containers.CreateWithSpec(ctx, &sg, &containers.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create container %q: %w", cfg.LongName, err)
+	}
 	log.Debugf(
-		"Created a container with ID %v, warnings %v and error %v",
+		"Created a container with ID %v, warnings %v",
 		res.ID,
 		res.Warnings,
-		err,
 	)
-	return res.ID, err
+	return res.ID, nil
 }
 
 // StartContainer starts a previously created container by ID or its name and executes post-start


### PR DESCRIPTION
## Summary

Three runtime correctness fixes:

### 1. TCP connection leak in `ExecNotWait` (Docker)
`ContainerExecAttach` returns a `types.HijackedResponse` holding a TCP connection and bufio reader. The normal `Exec()` method properly calls `defer rsp.Close()`, but `ExecNotWait` discards the response with `_`, leaking a TCP socket on every call.

**Fix:** Capture the response and close it after attach.

### 2. `NetworkInspect` error fallthrough (Docker)
In `WithMgmtNet`, after `NetworkInspect` fails, the code sets MTU to 1500 and logs the error, but falls through to access `netRes.Options` on the zero-value `NetworkResource`. While Go nil-map reads don't panic (returns zero value), this is accidentally correct and fragile.

**Fix:** Use `else if` so `netRes.Options` is only accessed when inspect succeeded.

### 3. `CreateContainer` accesses result on error (Podman)
After `CreateWithSpec` fails, the code accesses `res.ID` and `res.Warnings` in the log statement and returns `res.ID` to callers. This returns a potentially invalid container ID that callers may try to use.

**Fix:** Check error first and return a wrapped error without accessing the result.

## Testing

- `go vet ./runtime/docker/...` — clean
- `go test -race ./runtime/docker/...` — all pass
- Podman changes cannot be compiled on this machine (missing C libs), but the fix follows the same early-return pattern