### PR TITLE
fix(srl): accept ixr-x4 as alias for ixr-x4-d topology type. Fixes #3149

### DIFF
--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -522,4 +522,4 @@ Or it's also possible via the proxmox configuration file `/etc/pve/qemu-server/v
 [^2]: The `authorized_keys` file will be created with the content of all found public keys. This file will be bind-mounted using the respecting paths inside SR Linux to enable password-less access. Experimental feature.
 [^3]: CLI configs can be saved also in the "flat" format using `info flat` command.
 [^4]: If running with `sudo`, add `-E` flag to sudo to preserve user' home directory for this feature to work as expected.
-[^5]: Can also use `ixr-x4-d` which denotes the use of QSFP-DD ports.
+[^5]: Alias of `ixr-x4-d` which denotes the use of QSFP-DD ports.

--- a/docs/manual/kinds/srl.md
+++ b/docs/manual/kinds/srl.md
@@ -175,7 +175,7 @@ The Nokia 7215 IXS model range consists of `ixs-a1` platform.
 
 The available Nokia 7220 IXR models support the following types: `ixr-d1`, `ixr-d2`, `ixr-d3`, `ixr-d2l`, `ixr-d3l`, `ixr-d4`, `ixr-d5`, `ixr-h2`, `ixr-h3`, `ixr-h4`, `ixr-h4-32d`,`ixr-h5-32d`, `ixr-h5-64d`,`ixr-h5-64o`.
 
-Nokia 7250 IXR chassis-based systems have types `ixr-6e`, `ixr-10e`, `ixr-18e`, `ixr-x1b`, `ixr-x3b`, `ixr-x4-d`[^5].
+Nokia 7250 IXR chassis-based systems have types `ixr-6e`, `ixr-10e`, `ixr-18e`, `ixr-x1b`, `ixr-x3b`, `ixr-x4`[^5].
 
 Nokia 7730 SXR routers have types `sxr-1x-44s`, `sxr-1d-32d`, `sxr-1-32d`.
 
@@ -522,4 +522,4 @@ Or it's also possible via the proxmox configuration file `/etc/pve/qemu-server/v
 [^2]: The `authorized_keys` file will be created with the content of all found public keys. This file will be bind-mounted using the respecting paths inside SR Linux to enable password-less access. Experimental feature.
 [^3]: CLI configs can be saved also in the "flat" format using `info flat` command.
 [^4]: If running with `sudo`, add `-E` flag to sudo to preserve user' home directory for this feature to work as expected.
-[^5]: The `d` in `ixr-x4-d` denotes the use of QSFP-DD ports.
+[^5]: Can also use `ixr-x4-d` which denotes the use of QSFP-DD ports.

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -119,6 +119,7 @@ var (
 		"ixr-x1b":    "7250IXRX1b.yml",
 		"ixrx3b":     "7250IXRX3b.yml",
 		"ixr-x3b":    "7250IXRX3b.yml",
+		"ixr-x4":     "7250IXRX4-QSFP-DD.yml",
 		"ixr-x4-d":   "7250IXRX4-QSFP-DD.yml",
 	}
 

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -554,7 +554,8 @@
                                     "ixr-x1b",
                                     "ixrx3b",
                                     "ixr-x3b",
-                                    "ixr-x4"
+                                    "ixr-x4",
+                                    "ixr-x4-d"
                                 ]
                             }
                         }


### PR DESCRIPTION
Align runtime srlTypes with clab.schema.json (issue #3149) and allow ixr-x4-d in schema validation for users who use the documented name.