### PR TITLE
fix(core): handle exec errors and fix tool container cleanup loop

### DIFF
--- a/core/destroy.go
+++ b/core/destroy.go
@@ -403,12 +403,12 @@ func (c *CLab) deleteToolContainers(ctx context.Context) {
 		containers, err := c.globalRuntime().ListContainers(ctx, toolFilter)
 		if err != nil {
 			log.Error("Failed to list tool containers", "tool", toolType, "error", err)
-			return
+			continue
 		}
 
 		if len(containers) == 0 {
 			log.Debug("No tool containers found for lab", "tool", toolType, "lab", c.Config.Name)
-			return
+			continue
 		}
 
 		log.Info("Found tool containers associated with a lab", "tool", toolType, "lab",

--- a/core/exec.go
+++ b/core/exec.go
@@ -2,8 +2,10 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/charmbracelet/log"
 	clabexec "github.com/srl-labs/containerlab/exec"
 	clablinks "github.com/srl-labs/containerlab/links"
 )
@@ -50,9 +52,11 @@ func (c *CLab) Exec(
 			execResult, err := containers[idx].RunExec(ctx, execCmd)
 			if err != nil {
 				// skip nodes that do not support exec
-				if err == clabexec.ErrRunExecNotSupported {
+				if errors.Is(err, clabexec.ErrRunExecNotSupported) {
 					continue
 				}
+				log.Warnf("exec on %s failed: %v", containers[idx].Names[0], err)
+				continue
 			}
 
 			resultCollection.Add(containers[idx].Names[0], execResult)


### PR DESCRIPTION
Two fixes in core/:

- `exec.go`: when `RunExec` fails with a non-`ErrRunExecNotSupported` error, the nil `execResult` was still added to the collection, causing a nil dereference panic on `Log()`/`Dump()`. Also switched to `errors.Is` for the sentinel check.
- `destroy.go`: `deleteToolContainers` used `return` instead of `continue` in a loop over tool types (`["sshx", "gotty"]`). If the sshx listing failed or found zero results, gotty containers were never cleaned up.

## Testing

- `go vet ./core/...` — clean
- `go test -race ./core/...` — all pass