### PR TITLE
fix(vyos): wrap resp.Failed instead of nil err in save error

### DIFF
--- a/nodes/vyosnetworks_vyos/helpers.go
+++ b/nodes/vyosnetworks_vyos/helpers.go
@@ -24,7 +24,7 @@ func (n *vyos) save(_ context.Context, cli *network.Driver) error {
 	if err != nil {
 		return err
 	} else if resp.Failed != nil {
-		return fmt.Errorf("save failed. Response: %w", err)
+		return fmt.Errorf("save failed: %w", resp.Failed)
 	}
 	log.Info("Save successful", "node", n.Cfg.ShortName)
 	return nil


### PR DESCRIPTION
In the save function, the else-if branch runs when err is nil but resp.Failed is non-nil. The fmt.Errorf wraps err (nil) instead of resp.Failed, producing "save failed: <nil>" and hiding the actual failure reason.

Noticed while debugging a VyOS save failure that returned no useful info.