### PR TITLE
feat(cmd): add --name flag to tools vxlan delete for exact-match deletion

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -474,6 +474,7 @@ type ToolsVxlanOptions struct {
 	Remote         string
 	ParentDevice   string
 	DeletionPrefix string
+	DeletionName   string
 }
 
 type ToolsSnapshotOptions struct {

--- a/cmd/tools_vxlan.go
+++ b/cmd/tools_vxlan.go
@@ -118,6 +118,15 @@ func vxlanCmd(o *Options) (*cobra.Command, error) { //nolint: funlen
 		o.ToolsVxlan.DeletionPrefix,
 		"delete all containerlab created VxLAN interfaces which start with this prefix",
 	)
+	vxlanDeleteCmd.Flags().StringVarP(
+		&o.ToolsVxlan.DeletionName,
+		"name",
+		"n",
+		o.ToolsVxlan.DeletionName,
+		"delete a single VxLAN interface whose name exactly matches this value",
+	)
+	vxlanDeleteCmd.MarkFlagsMutuallyExclusive("prefix", "name")
+	vxlanDeleteCmd.MarkFlagsOneRequired("prefix", "name")
 
 	return c, nil
 }
@@ -185,6 +194,10 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 }
 
 func vxlanDelete(o *Options) error {
+	if o.ToolsVxlan.DeletionName != "" {
+		return vxlanDeleteByName(o.ToolsVxlan.DeletionName)
+	}
+
 	ls, err := clabutils.GetLinksByNamePrefix(o.ToolsVxlan.DeletionPrefix)
 	if err != nil {
 		return err
@@ -201,6 +214,25 @@ func vxlanDelete(o *Options) error {
 		if err != nil {
 			log.Warnf("error when deleting link %s: %v", l.Attrs().Name, err)
 		}
+	}
+
+	return nil
+}
+
+func vxlanDeleteByName(name string) error {
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("vxlan interface %q not found: %v", name, err)
+	}
+
+	if l.Type() != "vxlan" {
+		return fmt.Errorf("interface %q is not a vxlan interface (type: %s)", name, l.Type())
+	}
+
+	log.Infof("Deleting VxLAN link %s", l.Attrs().Name)
+
+	if err := netlink.LinkDel(l); err != nil {
+		return fmt.Errorf("error when deleting link %s: %v", name, err)
 	}
 
 	return nil

--- a/docs/cmd/tools/vxlan/delete.md
+++ b/docs/cmd/tools/vxlan/delete.md
@@ -2,7 +2,9 @@
 
 ### Description
 
-The `delete` sub-command under the `tools vxlan` command deletes VxLAN interfaces which name matches a user specified prefix. The `delete` command is typically used to remove VxLAN interfaces created with [`create`](create.md) command.
+The `delete` sub-command under the `tools vxlan` command deletes VxLAN interfaces which name matches a user specified prefix or an exact name. The `delete` command is typically used to remove VxLAN interfaces created with [`create`](create.md) command.
+
+Either `--prefix` or `--name` must be provided. The two flags are mutually exclusive.
 
 ### Usage
 
@@ -13,10 +15,17 @@ The `delete` sub-command under the `tools vxlan` command deletes VxLAN interface
 #### prefix
 Set a prefix with `--prefix | -p` flag. The VxLAN interfaces which name is matched by the prefix will be deleted. Default prefix is `vx-` which is matched the default prefix used by [`create`](create.md) command.
 
+#### name
+Set an exact interface name with `--name | -n` flag. Exactly one VxLAN interface with the given name will be deleted. If no interface with that name exists, or if an interface with that name exists but is not a VxLAN, the command returns an error.
+
 ### Examples
 
 ```bash
 # delete all VxLAN interfaces created by containerlab
 ❯ clab tools vxlan create delete
 INFO[0000] Deleting VxLAN link vx-srl_e1-1
+
+# delete a single VxLAN interface by its exact name
+❯ clab tools vxlan delete --name vx-srl-e1-1
+INFO[0000] Deleting VxLAN link vx-srl-e1-1
 ```


### PR DESCRIPTION
## Summary

- Add a new `--name | -n` flag to `containerlab tools vxlan delete` to delete a single VxLAN interface by exact name.
- `--name` and `--prefix` are mutually exclusive; at least one of them is required.
- When `--name` refers to a non-existent interface, or an interface that is not a VxLAN, the command now returns an error instead of silently doing nothing.
- `--prefix` behavior is unchanged for backward compatibility.

## Motivation

The existing `--prefix` flag uses `strings.HasPrefix` for matching. When two VxLAN interfaces share a common naming stem (for example `vx-srl2-e1-1` and `vx-srl2-e1-10`), deleting one with `--prefix vx-srl2-e1-1` also removes `vx-srl2-e1-10`, which is surprising and has caused issues downstream.

clabernetes uses this command as a safety net before creating VxLAN interfaces. See srl-labs/clabernetes#252 for the concrete failure mode this addresses.

With `--name`, callers that know the exact interface name (like clabernetes) can request a precise deletion without affecting siblings.

## Test plan

- [x] `go build ./...` passes
- [x] Manually verified with dummy VxLAN interfaces:
  - `--name vx-srl2-e1-1` deletes only that interface, leaving `vx-srl2-e1-10` intact
  - `--name <non-existent>` returns an error
  - `--name <non-vxlan interface>` returns an error
  - `--name` and `--prefix` together → cobra rejects
  - Neither flag → cobra rejects
  - `--prefix` alone still works as before (including the prefix-overlap behavior, unchanged)