### PR TITLE
[SR-SIM] add missing support in schema to certain SAR boxes

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -660,6 +660,8 @@
                                             "sar-1",
                                             "sar-hm",
                                             "sar-hmc",
+					    "sar-hx",
+					    "sar-mx",
                                             "sr-1-24d",
                                             "sr-12e",
                                             "sr-12",


### PR DESCRIPTION
On 26.3.R1, new boxes were added but I missed the memo and didn't get them in the schema