### PR TITLE
fix: retry ContainerStart on transient IPv6 gateway 'file exists' error

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -877,19 +877,41 @@ func (d *DockerRuntime) StartContainer(
 	nodecfg := node.Config()
 
 	log.Debugf("Start container: %q", nodecfg.LongName)
-	err := d.Client.ContainerStart(nctx,
-		cID,
-		container.StartOptions{
-			CheckpointID:  "",
-			CheckpointDir: "",
-		},
+
+	// ContainerStart occasionally returns 'file exists' error on the IPv6 gateway
+	// route in large topologies with an IPv6 management network configured.
+	// A short retry seems to mitigate the error.
+	const (
+		ipv6GwRetries      = 3
+		ipv6GwRetryBackoff = 100 * time.Millisecond
 	)
+
+	var err error
+	for attempt := range ipv6GwRetries {
+		err = d.Client.ContainerStart(nctx, cID, container.StartOptions{})
+		if err == nil || !isIPv6GatewayExistsErr(err) {
+			break
+		}
+		log.Debugf("transient IPv6 gateway error starting %q (attempt %d/%d): %v",
+			nodecfg.ShortName, attempt+1, ipv6GwRetries, err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(ipv6GwRetryBackoff << attempt):
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
 	log.Debugf("Container started: %q", nodecfg.LongName)
 	err = d.postStartActions(ctx, cID, nodecfg)
 	return nil, err
+}
+
+// isIPv6GatewayExistsErr reports whether err is the transient "file exists" error
+func isIPv6GatewayExistsErr(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "failed to set IPv6 gateway") && strings.Contains(s, "file exists")
 }
 
 // postStartActions performs misc. tasks that are needed after the container starts.

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -908,7 +908,7 @@ func (d *DockerRuntime) StartContainer(
 	return nil, err
 }
 
-// isIPv6GatewayExistsErr reports whether err is the transient "file exists" error
+// isIPv6GatewayExistsErr reports whether err is the transient "file exists" error.
 func isIPv6GatewayExistsErr(err error) bool {
 	s := err.Error()
 	return strings.Contains(s, "failed to set IPv6 gateway") && strings.Contains(s, "file exists")


### PR DESCRIPTION
## Summary

Add a 3-attempt exponential-backoff retry in `StartContainer` for the transient IPv6 gateway "file exists" error when deploying larger labs.

## Problem

When deploying a topology with many nodes on a management network with IPv6 configured, some nodes may fail to start with:

    Error response from daemon: failed to set up container networking: updating gateway endpoint: failed to set IPv6 gateway (...): file exists

The failure is intermittent and occurs proportionally to the number of nodes. For example, reliably reproducible with 50+ XRd nodes on a management network bridge with IPv6 configured.

Disabling IPv6 on the management network avoids it; an IPv4-only management network is unaffected.

## Fix

`runtime/docker/docker.go`:

Adds a retry loop (up to 3 attempts, 100/200/400 ms exponential backoff) to `StartContainer` that retries only on the specific IPv6 gateway EEXIST error string and fails fast for all other errors.

Mirrors the approach in commit 57b6c44, which handles a similar transient error pattern for veth link deployment.

## Testing

Tested deploying 4 times on a 50-node XRd topology with an IPv6 management network.
Debug logs showed the retry catching between 6–13 transient "file exists" errors per run across the 50 nodes, all recovered on the second attempt; the third attempt was never reached. 
Overall behavior, aside from the retry, should stay the same.