### PR TITLE
Document local-only management network configuration

### DIFF
--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -245,7 +245,7 @@ mgmt:
 
 With this approach, users can prevent IP address overlap with nodes deployed on the same management network by other orchestration systems.
 
-#### external access
+#### access from external hosts
 
 Containerlab will attempt to enable external management access to the nodes by default. This means that external systems/hosts will be able to communicate with the nodes of your topology without requiring any manual iptables/nftables rules to be installed.
 
@@ -333,6 +333,19 @@ mgmt:
 ```
 
 All driver options can be overridden, even those set by containerlab.
+
+### local-only networking
+
+The default management bridge driver options are configured to allow external network access from the containers through the management interface, including internet. In order to prevent unintentional internet or external network access, ip masquerading needs to be disabled on the management interface bridge:
+
+```yaml
+mgmt:
+  network: custom-net
+  driver-opts:
+    com.docker.network.bridge.enable_ip_masquerade: false
+```
+
+This allows for bidirectional communication between the host and containers, as well as between containers, while preventing access to the host's external network.
 
 ### connection details
 


### PR DESCRIPTION
Add documentation to explain how to make the management network local-only and prevent containers from getting internet access unintentionally through the management interface.

Preventing containers from getting internet through the management interface doesn't look to be documented elsewhere, and the section on external access is only applicable for nodes being access from the outside, not the reverse case.