### PR TITLE
Make concurrent deploys on the same host more reliable

### DIFF
--- a/core/hostsfile.go
+++ b/core/hostsfile.go
@@ -8,7 +8,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
 
 	clabconstants "github.com/srl-labs/containerlab/constants"
 	clabtypes "github.com/srl-labs/containerlab/types"
@@ -18,12 +22,49 @@ import (
 const (
 	clabHostEntryPrefix  = "###### CLAB-%s-START ######"
 	clabHostEntryPostfix = "###### CLAB-%s-END ######"
-	clabHostsFilename    = "/etc/hosts"
 
 	hostEntriesPerNode = 2
 )
 
+// Overridable from tests; never mutated in production.
+var (
+	clabHostsFilename = "/etc/hosts"
+	clabHostsLockPath = "/run/lock/clab-hosts.lock"
+)
+
+var hostsFileMu sync.Mutex
+
+// withHostsFileLock serializes /etc/hosts edits across goroutines and
+// across concurrent clab processes on the same host.
+func withHostsFileLock(fn func() error) error {
+	hostsFileMu.Lock()
+	defer hostsFileMu.Unlock()
+
+	if dir := filepath.Dir(clabHostsLockPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("creating hosts lock directory %q: %w", dir, err)
+		}
+	}
+
+	// 0o644 so a non-root caller can co-acquire the lock with a prior root caller.
+	f, err := os.OpenFile(clabHostsLockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening hosts file lock %q: %w", clabHostsLockPath, err)
+	}
+	defer f.Close()
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("acquiring hosts file lock: %w", err)
+	}
+
+	return fn()
+}
+
 func (c *CLab) appendHostsFileEntries(ctx context.Context) error {
+	return withHostsFileLock(func() error { return c.appendHostsFileEntriesLocked(ctx) })
+}
+
+func (c *CLab) appendHostsFileEntriesLocked(ctx context.Context) error {
 	filename := clabHostsFilename
 
 	if c.Config.Name == "" {
@@ -38,7 +79,7 @@ func (c *CLab) appendHostsFileEntries(ctx context.Context) error {
 	}
 
 	// lets make sure to remove the entries of a non-properly destroyed lab in the hosts file
-	err := c.DeleteEntriesFromHostsFile()
+	err := c.deleteEntriesFromHostsFileLocked()
 	if err != nil {
 		return err
 	}
@@ -79,6 +120,10 @@ func (c *CLab) appendHostsFileEntries(ctx context.Context) error {
 }
 
 func (c *CLab) DeleteEntriesFromHostsFile() error {
+	return withHostsFileLock(c.deleteEntriesFromHostsFileLocked)
+}
+
+func (c *CLab) deleteEntriesFromHostsFileLocked() error {
 	if c.Config.Name == "" {
 		return errors.New("missing containerlab name")
 	}

--- a/core/hostsfile_test.go
+++ b/core/hostsfile_test.go
@@ -1,0 +1,183 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+)
+
+// withTestHostsFiles redirects the package hosts/lock paths to files in tmp
+// and seeds a baseline hosts file.
+func withTestHostsFiles(t *testing.T, tmp string) {
+	t.Helper()
+
+	origFile, origLock := clabHostsFilename, clabHostsLockPath
+
+	clabHostsFilename = filepath.Join(tmp, "hosts")
+	clabHostsLockPath = filepath.Join(tmp, "hosts.lock")
+
+	t.Cleanup(func() {
+		clabHostsFilename = origFile
+		clabHostsLockPath = origLock
+	})
+
+	if err := os.WriteFile(clabHostsFilename, []byte("127.0.0.1\tlocalhost\n"), 0o644); err != nil {
+		t.Fatalf("seeding test hosts file: %v", err)
+	}
+}
+
+// TestHostsFileConcurrentDeployAppend exercises appendHostsFileEntries from
+// many goroutines and asserts that each lab ends up with exactly one block
+// and the baseline lines are preserved.
+func TestHostsFileConcurrentDeployAppend(t *testing.T) {
+	withTestHostsFiles(t, t.TempDir())
+
+	const (
+		nLabs  = 16
+		rounds = 25
+	)
+
+	labs := make([]*CLab, nLabs)
+	for i := 0; i < nLabs; i++ {
+		labs[i] = &CLab{
+			Config: &Config{Name: fmt.Sprintf("race-deploy-%d", i)},
+			Nodes:  map[string]clabnodes.Node{},
+		}
+	}
+
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	errCh := make(chan error, nLabs*rounds)
+
+	for _, lab := range labs {
+		wg.Add(1)
+
+		go func(c *CLab) {
+			defer wg.Done()
+
+			<-start
+
+			for r := 0; r < rounds; r++ {
+				if err := c.appendHostsFileEntries(context.Background()); err != nil {
+					errCh <- fmt.Errorf("append %s round %d: %w", c.Config.Name, r, err)
+					return
+				}
+			}
+		}(lab)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
+
+	data, err := os.ReadFile(clabHostsFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents := string(data)
+
+	for _, lab := range labs {
+		prefix := fmt.Sprintf(clabHostEntryPrefix, lab.Config.Name)
+		postfix := fmt.Sprintf(clabHostEntryPostfix, lab.Config.Name)
+
+		if got := strings.Count(contents, prefix); got != 1 {
+			t.Errorf("lab %q: expected exactly 1 START marker, got %d", lab.Config.Name, got)
+		}
+
+		if got := strings.Count(contents, postfix); got != 1 {
+			t.Errorf("lab %q: expected exactly 1 END marker, got %d", lab.Config.Name, got)
+		}
+	}
+
+	if !strings.HasPrefix(contents, "127.0.0.1\tlocalhost\n") {
+		t.Errorf("baseline localhost line was clobbered; file starts with %q",
+			contents[:min(40, len(contents))])
+	}
+}
+
+// TestHostsFileConcurrentDeployAndDestroy interleaves appends and removals
+// from many goroutines; the file must return to its baseline with no
+// CLAB-* markers left over.
+func TestHostsFileConcurrentDeployAndDestroy(t *testing.T) {
+	withTestHostsFiles(t, t.TempDir())
+
+	const (
+		nLabs  = 16
+		rounds = 25
+	)
+
+	labs := make([]*CLab, nLabs)
+	for i := 0; i < nLabs; i++ {
+		labs[i] = &CLab{
+			Config: &Config{Name: fmt.Sprintf("race-cycle-%d", i)},
+			Nodes:  map[string]clabnodes.Node{},
+		}
+	}
+
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	errCh := make(chan error, nLabs*rounds*2)
+
+	for _, lab := range labs {
+		wg.Add(1)
+
+		go func(c *CLab) {
+			defer wg.Done()
+
+			<-start
+
+			for r := 0; r < rounds; r++ {
+				if err := c.appendHostsFileEntries(context.Background()); err != nil {
+					errCh <- fmt.Errorf("append %s round %d: %w", c.Config.Name, r, err)
+					return
+				}
+
+				if err := c.DeleteEntriesFromHostsFile(); err != nil {
+					errCh <- fmt.Errorf("delete %s round %d: %w", c.Config.Name, r, err)
+					return
+				}
+			}
+		}(lab)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
+
+	data, err := os.ReadFile(clabHostsFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents := string(data)
+	if strings.Contains(contents, "CLAB-") {
+		t.Errorf("expected no CLAB-* markers after deploy/destroy cycles, got:\n%s", contents)
+	}
+
+	if got := strings.TrimSpace(contents); got != "127.0.0.1\tlocalhost" {
+		t.Errorf("expected baseline preserved, got %q", got)
+	}
+}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	networkapi "github.com/docker/docker/api/types/network"
 	dockerC "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/dustin/go-humanize"
@@ -51,6 +52,7 @@ const (
 	defaultDockerNetwork = "bridge"
 
 	natUnprotectedValue         = "nat-unprotected"
+	bridgeNameOption            = "com.docker.network.bridge.name"
 	bridgeGatewayModeIPv4Option = "com.docker.network.bridge.gateway_mode_ipv4"
 	bridgeGatewayModeIPv6Option = "com.docker.network.bridge.gateway_mode_ipv6"
 )
@@ -169,7 +171,7 @@ func (d *DockerRuntime) WithMgmtNet(n *clabtypes.MgmtNet) {
 		)
 		// if the network is successfully found, set the bridge used by it
 		if err == nil {
-			if name, exists := netRes.Options["com.docker.network.bridge.name"]; exists {
+			if name, exists := netRes.Options[bridgeNameOption]; exists {
 				d.mgmt.Bridge = name
 			} else {
 				d.mgmt.Bridge = "br-" + netRes.ID[:12]
@@ -201,18 +203,9 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 		}
 	case err == nil:
 		log.Debugf("network %q was found. Reusing it...", d.mgmt.Network)
-		if len(netResource.ID) < 12 {
-			return fmt.Errorf("could not get bridge ID")
-		}
-		switch d.mgmt.Network {
-		case "bridge":
-			bridgeName = "docker0"
-		default:
-			if netResource.Options["com.docker.network.bridge.name"] != "" {
-				bridgeName = netResource.Options["com.docker.network.bridge.name"]
-			} else {
-				bridgeName = "br-" + netResource.ID[:12]
-			}
+		bridgeName, err = bridgeNameFromInspect(&netResource, d.mgmt.Network)
+		if err != nil {
+			return err
 		}
 
 	default:
@@ -316,7 +309,7 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 	}
 
 	if bridgeName != "" {
-		netwOpts["com.docker.network.bridge.name"] = bridgeName
+		netwOpts[bridgeNameOption] = bridgeName
 	}
 
 	// nat-unprotected mode is needed starting in Docker release 28 to access all ports without
@@ -348,6 +341,24 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 
 	netCreateResponse, err := d.Client.NetworkCreate(nctx, d.mgmt.Network, opts)
 	if err != nil {
+		// Another clab process created the same management network between
+		// our Inspect and our Create. Re-inspect and reuse it.
+		if errdefs.IsConflict(err) {
+			log.Debug("docker network was created concurrently by another clab deploy; reusing it",
+				"name", d.mgmt.Network)
+
+			netResource, ierr := d.Client.NetworkInspect(
+				nctx, d.mgmt.Network, networkapi.InspectOptions{},
+			)
+			if ierr != nil {
+				return "", fmt.Errorf(
+					"re-inspect %q after concurrent create: %w", d.mgmt.Network, ierr,
+				)
+			}
+
+			return bridgeNameFromInspect(&netResource, d.mgmt.Network)
+		}
+
 		// Handle subnet overlap error
 		if strings.Contains(strings.ToLower(err.Error()), strings.ToLower("Pool overlaps")) ||
 			strings.Contains(strings.ToLower(err.Error()), strings.ToLower("subnet")) {
@@ -402,6 +413,23 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 		bridgeName = "br-" + netCreateResponse.ID[:12]
 	}
 	return bridgeName, nil
+}
+
+// bridgeNameFromInspect resolves the underlying linux bridge name from a docker network inspect response.
+func bridgeNameFromInspect(netResource *networkapi.Inspect, mgmtNetwork string) (string, error) {
+	if len(netResource.ID) < 12 {
+		return "", fmt.Errorf("could not get bridge ID")
+	}
+
+	if mgmtNetwork == "bridge" {
+		return "docker0", nil
+	}
+
+	if name := netResource.Options[bridgeNameOption]; name != "" {
+		return name, nil
+	}
+
+	return "br-" + netResource.ID[:12], nil
 }
 
 // getMgmtBridgeIPs gets the management bridge v4/6 addresses.
@@ -1065,6 +1093,10 @@ func (d *DockerRuntime) produceGenericContainerList(
 
 		var err error
 		ctr.Pid, err = d.containerPid(ctx, i.ID)
+		if errdefs.IsNotFound(err) {
+			// Concurrent destroy removed it between List and Inspect.
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1415,7 +1447,7 @@ func (d *DockerRuntime) GetContainerStatus(
 func (d *DockerRuntime) containerPid(ctx context.Context, cID string) (int, error) {
 	inspect, err := d.Client.ContainerInspect(ctx, cID)
 	if err != nil {
-		return 0, fmt.Errorf("container %q cannot be found", cID)
+		return 0, fmt.Errorf("container %q cannot be found: %w", cID, err)
 	}
 	return inspect.State.Pid, nil
 }

--- a/runtime/docker/list_test.go
+++ b/runtime/docker/list_test.go
@@ -1,0 +1,128 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package docker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	dockerTypes "github.com/docker/docker/api/types"
+	containerTypes "github.com/docker/docker/api/types/container"
+	dockerC "github.com/docker/docker/client"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+// TestProduceGenericContainerList_SkipsConcurrentlyRemoved asserts the
+// enumeration loop tolerates a 404 from ContainerInspect when a concurrent
+// clab destroy removed the container between List and Inspect.
+func TestProduceGenericContainerList_SkipsConcurrentlyRemoved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"No such container"}`))
+	}))
+	defer srv.Close()
+
+	cli, err := dockerC.NewClientWithOpts(
+		dockerC.WithHost(srv.URL),
+		dockerC.WithVersion("1.43"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	rt := &DockerRuntime{
+		Client: cli,
+		mgmt:   &clabtypes.MgmtNet{Network: "clab"},
+		config: clabruntime.RuntimeConfig{Timeout: defaultTimeout},
+	}
+
+	inputs := []dockerTypes.Container{
+		{ID: strings.Repeat("a", 64), Names: []string{"/clab-x-n1"}},
+		{ID: strings.Repeat("b", 64), Names: []string{"/clab-x-n2"}},
+	}
+
+	got, err := rt.produceGenericContainerList(context.Background(), inputs, nil)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("got %d surviving containers, want 0", len(got))
+	}
+}
+
+// TestProduceGenericContainerList_MixedKeepsSurvivor asserts that when one
+// container 404s and another inspects successfully, the survivor is returned.
+func TestProduceGenericContainerList_MixedKeepsSurvivor(t *testing.T) {
+	goneID := strings.Repeat("a", 64)
+	survivorID := strings.Repeat("b", 64)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, goneID):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"No such container"}`))
+		case strings.Contains(r.URL.Path, survivorID):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"Id":"` + survivorID + `","State":{"Pid":1234}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cli, err := dockerC.NewClientWithOpts(
+		dockerC.WithHost(srv.URL),
+		dockerC.WithVersion("1.43"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	rt := &DockerRuntime{
+		Client: cli,
+		mgmt:   &clabtypes.MgmtNet{Network: "clab"},
+		config: clabruntime.RuntimeConfig{Timeout: defaultTimeout},
+	}
+
+	inputs := []dockerTypes.Container{
+		{
+			ID:              goneID,
+			Names:           []string{"/clab-x-gone"},
+			NetworkSettings: &containerTypes.NetworkSettingsSummary{},
+		},
+		{
+			ID:              survivorID,
+			Names:           []string{"/clab-x-alive"},
+			NetworkSettings: &containerTypes.NetworkSettingsSummary{},
+		},
+	}
+
+	got, err := rt.produceGenericContainerList(context.Background(), inputs, nil)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d surviving containers, want 1", len(got))
+	}
+
+	if got[0].ID != survivorID {
+		t.Errorf("survivor id = %q, want %q", got[0].ID, survivorID)
+	}
+
+	if got[0].Pid != 1234 {
+		t.Errorf("survivor pid = %d, want 1234", got[0].Pid)
+	}
+}

--- a/runtime/docker/network_test.go
+++ b/runtime/docker/network_test.go
@@ -1,0 +1,185 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	networkapi "github.com/docker/docker/api/types/network"
+	dockerC "github.com/docker/docker/client"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+// fakeDockerNetworkServer is a minimal stand-in for the docker daemon's
+// /networks endpoints. While created==false, NetworkInspect returns 404 and
+// NetworkCreate flips created==true; thereafter NetworkCreate returns 409
+// Conflict and NetworkInspect serves the stored network. This mirrors the
+// daemon's response when two callers race to create the same network.
+type fakeDockerNetworkServer struct {
+	t       *testing.T
+	netName string
+	mu      sync.Mutex
+	created bool
+	info    networkapi.Inspect
+	creates atomic.Int32
+}
+
+func (f *fakeDockerNetworkServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Docker client prefixes paths with /v<version>/; strip it.
+		path := r.URL.Path
+		if strings.HasPrefix(path, "/v") {
+			if idx := strings.Index(path[1:], "/"); idx != -1 {
+				path = path[idx+1:]
+			}
+		}
+
+		switch {
+		case r.Method == http.MethodPost && path == "/networks/create":
+			f.creates.Add(1)
+
+			var req networkapi.CreateRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			f.mu.Lock()
+			if f.created {
+				f.mu.Unlock()
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"message": "network with name " + f.netName + " already exists",
+				})
+				return
+			}
+
+			f.info = networkapi.Inspect{
+				ID:     "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				Name:   req.Name,
+				Driver: "bridge",
+				Options: map[string]string{
+					bridgeNameOption: "br-fake",
+				},
+			}
+			f.created = true
+			f.mu.Unlock()
+
+			writeJSON(w, http.StatusCreated, networkapi.CreateResponse{ID: f.info.ID})
+
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/networks/"):
+			f.mu.Lock()
+			created := f.created
+			info := f.info
+			f.mu.Unlock()
+
+			if !created {
+				writeJSON(w, http.StatusNotFound, map[string]string{
+					"message": "network " + f.netName + " not found",
+				})
+				return
+			}
+
+			writeJSON(w, http.StatusOK, info)
+
+		default:
+			f.t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func newFakeDockerRuntime(t *testing.T, netName string) (*DockerRuntime, *fakeDockerNetworkServer, func()) {
+	t.Helper()
+
+	fake := &fakeDockerNetworkServer{t: t, netName: netName}
+	srv := httptest.NewServer(fake.handler())
+
+	cli, err := dockerC.NewClientWithOpts(
+		dockerC.WithHost(srv.URL),
+		dockerC.WithVersion("1.43"),
+	)
+	if err != nil {
+		srv.Close()
+		t.Fatal(err)
+	}
+
+	rt := &DockerRuntime{
+		Client: cli,
+		mgmt: &clabtypes.MgmtNet{
+			Network:    netName,
+			IPv4Subnet: "172.45.99.0/24",
+			MTU:        1500,
+		},
+		config:  clabruntime.RuntimeConfig{Timeout: defaultTimeout},
+		version: "v27.0.0",
+	}
+
+	return rt, fake, func() { _ = cli.Close(); srv.Close() }
+}
+
+// TestCreateMgmtBridge_ConcurrentSafe is the regression test for the race
+// fixed by this PR: N goroutines all call createMgmtBridge for the same
+// docker network. The first to call NetworkCreate wins, the rest receive
+// 409 Conflict from the daemon and must recover via re-inspect rather than
+// propagate the error.
+//
+// Without the errdefs.IsConflict branch the losing goroutines return
+// "network with name clab already exists".
+func TestCreateMgmtBridge_ConcurrentSafe(t *testing.T) {
+	rt, fake, cleanup := newFakeDockerRuntime(t, "clab")
+	defer cleanup()
+
+	const n = 16
+
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	names := make([]string, n)
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			names[i], errs[i] = rt.createMgmtBridge(context.Background(), "")
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Errorf("goroutine %d: %v", i, e)
+		}
+	}
+
+	for i, got := range names {
+		if got == "" {
+			t.Errorf("goroutine %d returned empty bridge name", i)
+		}
+	}
+
+	if got := fake.creates.Load(); int(got) < 2 {
+		t.Errorf("expected concurrent goroutines to all attempt NetworkCreate, only saw %d", got)
+	}
+}


### PR DESCRIPTION
Running two `clab deploy`s (or a deploy and a destroy) at the same time on one host tends to fail in the following ways:

- `/etc/hosts` can end up with a half-written block, or lose its baseline `localhost` lines.
- The second deploy's `docker network create` races with the first and errors out with "network with name clab already exists".
- A destroy that removes a container while another deploy is listing containers makes that deploy abort with "container cannot be found".

This serializes the `/etc/hosts` edits with a file lock, proceeds on "already exists" 409 and skips containers that vanish mid-enumeration. Each one has a regression test.