### PR TITLE
Switch to HTTPS in api-server smoke tests

### DIFF
--- a/tests/01-smoke/22-tools-api-server.robot
+++ b/tests/01-smoke/22-tools-api-server.robot
@@ -37,7 +37,7 @@ Test API Server Health Endpoint
     Sleep    15s
 
     ${rc}    ${output}=    Run And Return Rc And Output
-    ...    curl -s http://localhost:8080/health -H 'accept: application/json'
+    ...    curl -sk https://localhost:8080/health -H 'accept: application/json'
     Log    Health check output:
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
@@ -105,7 +105,7 @@ Test API Server Health Endpoint Custom Port
     Sleep    15s
 
     ${rc}    ${output}=    Run And Return Rc And Output
-    ...    curl -s http://localhost:8081/health -H 'accept: application/json'
+    ...    curl -sk https://localhost:8081/health -H 'accept: application/json'
     Log    ${output}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    "status":"healthy"


### PR DESCRIPTION
clab-api-server v0.3.0+ defaults TLS_ENABLE to true and serves HTTPS with a self-signed cert. The smoke test was still curling plain HTTP and getting "Client sent an HTTP request to an HTTPS server." 