### PR TITLE
add srsim hw schema sidecar

### DIFF
--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -323,122 +323,12 @@
                 "components": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "properties": {
-                            "slot": {
-                                "description": "Set component physical position on a distributed chassis",
-                                "anyOf": [
-                                    {
-                                        "type": "string",
-                                        "pattern": "^[ABab]$"
-                                    },
-                                    {
-                                        "type": "integer",
-                                        "minimum": 1
-                                    }
-                                ]
-                            },
-                            "type": {
-                                "description": "Set component type"
-                            },
-                            "sfm": {
-                                "description": "Set SFM type (SR OS specific).",
-                                "$ref": "#/definitions/sros-sfm-types"
-                            },
-                            "xiom": {
-                                "type": "array",
-                                "description": "Define list of XIOMs (SR OS Specific). Each XIOM must have values of 'slot' and 'type'. MDAs must be defined under the XIOM.",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "slot": {
-                                            "type": "integer",
-                                            "minimum": 1
-                                        },
-                                        "type": {
-                                            "$ref": "#/definitions/sros-xiom-types"
-                                        },
-                                        "mda": {
-                                            "type": "array",
-                                            "description": "Define list of MDAs under this XIOM. Each defined MDA must have values of 'slot' and 'type'",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "slot": {
-                                                        "type": "integer",
-                                                        "minimum": 1
-                                                    },
-                                                    "type": {
-                                                        "$ref": "#/definitions/sros-xiom-mda-types"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "slot",
-                                                    "type"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        }
-                                    },
-                                    "required": [
-                                        "slot",
-                                        "type"
-                                    ],
-                                    "additionalProperties": false
-                                },
-                                "uniqueItems": true
-                            },
-                            "mda": {
-                                "type": "array",
-                                "description": "Define list of MDAs (SR OS Specific). Each defined MDA must have values of 'slot' and 'type'",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "slot": {
-                                            "type": "integer",
-                                            "minimum": 1
-                                        },
-                                        "type": {
-                                            "description": "Set MDA type (SR OS specific)",
-                                            "$ref": "#/definitions/sros-mda-types"
-                                        }
-                                    },
-                                    "required": [
-                                        "slot",
-                                        "type"
-                                    ],
-                                    "additionalProperties": false
-                                }
-                            },
-                            "env": {
-                                "type": "object",
-                                "$ref": "#/definitions/env"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "allOf": [
+                        "anyOf": [
                             {
-                                "if": {
-                                    "properties": {
-                                        "slot": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "properties": {
-                                        "type": {
-                                            "$ref": "#/definitions/sros-cpm-types"
-                                        }
-                                    }
-                                },
-                                "else": {
-                                    "properties": {
-                                        "type": {
-                                            "$ref": "#/definitions/sros-card-types"
-                                        }
-                                    }
-                                }
+                                "$ref": "#/definitions/sros-component"
+                            },
+                            {
+                                "$ref": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/srsim-hw.schema.json#/definitions/srsim-component"
                             }
                         ]
                     },
@@ -636,66 +526,11 @@
                         ]
                     },
                     "then": {
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "anyOf": [
-                                    {
-                                        "enum": [
-                                            "dms-1-24d",
-                                            "ixr-10",
-                                            "ixr-6",
-                                            "ixr-e2c",
-                                            "ixr-e2",
-                                            "ixr-e2n",
-                                            "ixr-e2n-s",
-                                            "ixr-e3c",
-                                            "ixr-e3x",
-                                            "ixr-ec",
-                                            "ixr-e",
-                                            "ixr-r4",
-                                            "ixr-r6dl",
-                                            "ixr-r6d",
-                                            "ixr-r6",
-                                            "ixr-s",
-                                            "ixr-x3",
-                                            "ixr-x",
-                                            "sar-1",
-                                            "sar-hm",
-                                            "sar-hmc",
-                                            "sar-hx",
-                                            "sar-mx",
-                                            "sr-1-24d",
-                                            "sr-12e",
-                                            "sr-12",
-                                            "sr-1-46s",
-                                            "sr-14s",
-                                            "sr-1-92s",
-                                            "sr-1e",
-                                            "sr-1se",
-                                            "sr-1s",
-                                            "sr-1-48d",
-                                            "sr-1x-48d",
-                                            "sr-1x-92s",
-                                            "sr-1",
-                                            "sr-2e",
-                                            "sr-2se",
-                                            "sr-2s",
-                                            "sr-3e",
-                                            "sr-7s",
-                                            "sr-7",
-                                            "sr-a4",
-                                            "sr-a8",
-                                            "vsr-i",
-                                            "xrs-20e",
-                                            "xrs-20",
-                                            "ess-7",
-                                            "ess-12"
-                                        ]
-                                    }
-                                ]
+                        "allOf": [
+                            {
+                                "$ref": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/srsim-hw.schema.json#/definitions/srsim-node"
                             }
-                        }
+                        ]
                     }
                 },
                 {
@@ -1839,6 +1674,126 @@
                 "sfm2-s",
                 "sfm2-x20s"
             ]
+        },
+        "sros-component": {
+            "type": "object",
+            "properties": {
+                "slot": {
+                    "description": "Set component physical position on a distributed chassis",
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "pattern": "^[ABab]$"
+                        },
+                        {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    ]
+                },
+                "type": {
+                    "description": "Set component type"
+                },
+                "sfm": {
+                    "description": "Set SFM type (SR OS specific).",
+                    "$ref": "#/definitions/sros-sfm-types"
+                },
+                "xiom": {
+                    "type": "array",
+                    "description": "Define list of XIOMs (SR OS Specific). Each XIOM must have values of 'slot' and 'type'. MDAs must be defined under the XIOM.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "slot": {
+                                "type": "integer",
+                                "minimum": 1
+                            },
+                            "type": {
+                                "$ref": "#/definitions/sros-xiom-types"
+                            },
+                            "mda": {
+                                "type": "array",
+                                "description": "Define list of MDAs under this XIOM. Each defined MDA must have values of 'slot' and 'type'",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "slot": {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        "type": {
+                                            "$ref": "#/definitions/sros-xiom-mda-types"
+                                        }
+                                    },
+                                    "required": [
+                                        "slot",
+                                        "type"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": [
+                            "slot",
+                            "type"
+                        ],
+                        "additionalProperties": false
+                    },
+                    "uniqueItems": true
+                },
+                "mda": {
+                    "type": "array",
+                    "description": "Define list of MDAs (SR OS Specific). Each defined MDA must have values of 'slot' and 'type'",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "slot": {
+                                "type": "integer",
+                                "minimum": 1
+                            },
+                            "type": {
+                                "description": "Set MDA type (SR OS specific)",
+                                "$ref": "#/definitions/sros-mda-types"
+                            }
+                        },
+                        "required": [
+                            "slot",
+                            "type"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "env": {
+                    "type": "object",
+                    "$ref": "#/definitions/env"
+                }
+            },
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/definitions/sros-cpm-types"
+                            }
+                        }
+                    },
+                    "else": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/definitions/sros-card-types"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     },
     "type": "object",
@@ -2205,5 +2160,16 @@
     "required": [
         "name",
         "topology"
-    ]
+    ],
+    "x-srsim-metadata": {
+        "source": "https://documentation.nokia.com/sr/26-3/7x50-shared/srsim-installation-setup/appendices.html",
+        "generated_at": "2026-05-20T16:51:10.911408+00:00",
+        "models": 52,
+        "chassis": 49,
+        "default_rows": 83,
+        "supported_rows": 411,
+        "allow_unknown_values": false,
+        "component_definitions": 43
+    },
+    "x-srsim-schema-ref": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/srsim-hw.schema.json"
 }

--- a/schemas/srsim-hw.schema.json
+++ b/schemas/srsim-hw.schema.json
@@ -1,0 +1,8810 @@
+{
+    "$id": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/srsim-hw.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "srsim-card-types": {
+            "description": "SR-SIM line card types generated from Nokia supported hardware tables.",
+            "enum": [
+                "cpiom-ixr-r6",
+                "cpm-1",
+                "cpm-1s",
+                "cpm-1se/imm36-800g-qsfpdd",
+                "cpm-1x/dms24-800g-qsfpdd-1",
+                "cpm-1x/i24-800g-qsfpdd-1",
+                "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1",
+                "cpm-1x/i48-400g-qsfpdd-1",
+                "cpm-1x/i48-800g-qsfpdd-1x",
+                "cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1",
+                "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x",
+                "cpm-ixr-e-gnss/imm14-10g-sfp++4-1g-tx",
+                "cpm-ixr-e-gnss/imm24-sfp++8-sfp28+2-qsfp28",
+                "cpm-ixr-e/imm14-10g-sfp++4-1g-tx",
+                "cpm-ixr-e/imm24-sfp++8-sfp28+2-qsfp28",
+                "cpm-ixr-e2",
+                "cpm-ixr-e2c",
+                "cpm-ixr-e2n-s/imm4-sfp+4-sfp+-s",
+                "cpm-ixr-e2n/imm4-sfp+4-sfp+",
+                "cpm-ixr-e3c/imm4-qsfp28+16-sfp28+8-sfp56",
+                "cpm-ixr-e3x/imm16-sfp112+15-sfp56+6-qsfpdd",
+                "cpm-ixr-ec",
+                "cpm-ixr-r6d/iom-ixr-r6d",
+                "cpm-ixr-s/imm48-sfp++6-qsfp28",
+                "cpm-ixr-x/imm32-qsfp28+4-qsfpdd",
+                "cpm-ixr-x/imm36-qsfpdd",
+                "cpm-ixr-x/imm6-qsfpdd+48-sfp56",
+                "cpm-sar-hm",
+                "cpm-sar-hmc",
+                "cpm-v/iom-v",
+                "imm-2pac-fp3",
+                "imm24-sfp++8-sfp28+2-qsfp28",
+                "imm32-qsfp28+4-qsfpdd",
+                "imm36-100g-qsfp28",
+                "imm36-qsfpdd",
+                "imm4-100gb-cfp4",
+                "imm4-sfp+4-sfp+-s",
+                "imm40-10gb-sfp",
+                "imm48-1gb-sfp-c",
+                "imm48-sfp+2-qsfp28",
+                "imm6-qsfpdd+48-sfp56",
+                "iom-a",
+                "iom-e",
+                "iom-ixr-r4",
+                "iom-ixr-r6d",
+                "iom-sar",
+                "iom-sar-1x",
+                "iom4-e",
+                "iom4-e-b",
+                "iom4-e-hs",
+                "iom5-e",
+                "xcm-14s",
+                "xcm-14s-b",
+                "xcm-2s",
+                "xcm-2se",
+                "xcm-7s",
+                "xcm-7s-b",
+                "xcm-x20",
+                "xcm2-14s",
+                "xcm2-7s",
+                "xcm2-x20",
+                "xcmc-2se"
+            ],
+            "type": "string"
+        },
+        "srsim-chassis-types": {
+            "description": "SR-SIM chassis types generated from Nokia supported hardware tables.",
+            "enum": [
+                "dms-1-24d",
+                "ess-12",
+                "ess-7",
+                "ixr-10",
+                "ixr-6",
+                "ixr-e",
+                "ixr-e2",
+                "ixr-e2c",
+                "ixr-e2n",
+                "ixr-e2n-s",
+                "ixr-e3c",
+                "ixr-e3x",
+                "ixr-ec",
+                "ixr-r4",
+                "ixr-r6",
+                "ixr-r6d",
+                "ixr-r6dl",
+                "ixr-s",
+                "ixr-x",
+                "ixr-x3",
+                "sar-1",
+                "sar-hm",
+                "sar-hmc",
+                "sar-hx",
+                "sar-mx",
+                "sr-1",
+                "sr-1-24d",
+                "sr-1-46s",
+                "sr-1-48d",
+                "sr-1-92s",
+                "sr-12",
+                "sr-12e",
+                "sr-14s",
+                "sr-1e",
+                "sr-1s",
+                "sr-1se",
+                "sr-1x-48d",
+                "sr-1x-92s",
+                "sr-2e",
+                "sr-2s",
+                "sr-2se",
+                "sr-3e",
+                "sr-7",
+                "sr-7s",
+                "sr-a4",
+                "sr-a8",
+                "vsr-i",
+                "xrs-20",
+                "xrs-20e"
+            ],
+            "type": "string"
+        },
+        "srsim-component": {
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "else": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/definitions/srsim-card-types"
+                            }
+                        }
+                    },
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/definitions/srsim-cpm-types"
+                            }
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "env": {
+                    "$ref": "#/definitions/env",
+                    "type": "object"
+                },
+                "mda": {
+                    "items": {
+                        "$ref": "#/definitions/srsim-mda"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "sfm": {
+                    "$ref": "#/definitions/srsim-sfm-types"
+                },
+                "slot": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[ABab]$",
+                            "type": "string"
+                        },
+                        {
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    ],
+                    "description": "Set component physical position on a distributed chassis"
+                },
+                "type": {
+                    "description": "Set SR-SIM component type"
+                },
+                "xiom": {
+                    "items": {
+                        "$ref": "#/definitions/srsim-xiom"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                }
+            },
+            "type": "object"
+        },
+        "srsim-component-dms-1-24d": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/dms24-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/dms24-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/dms24-800g-qsfpdd-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "d24-800g-qsfpdd-1"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ess-12": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm5"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom5-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm5"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom5-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me6-100gb-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-10": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "imm36-100g-qsfp28",
+                                    "imm48-sfp+2-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-10"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm36-100g-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m36-100g-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-10"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm48-sfp+2-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m48-sfp+2-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-10"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-6": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "imm36-100g-qsfp28",
+                                    "imm48-sfp+2-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-6"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm36-100g-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m36-100g-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-6"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm48-sfp+2-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m48-sfp+2-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-ixr-6"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e",
+                                    "cpm-ixr-e-gnss/imm14-10g-sfp++4-1g-tx",
+                                    "cpm-ixr-e-gnss/imm24-sfp++8-sfp28+2-qsfp28",
+                                    "cpm-ixr-e/imm14-10g-sfp++4-1g-tx",
+                                    "cpm-ixr-e/imm24-sfp++8-sfp28+2-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e-gnss/imm14-10g-sfp++4-1g-tx",
+                                    "cpm-ixr-e-gnss/imm24-sfp++8-sfp28+2-qsfp28",
+                                    "cpm-ixr-e/imm14-10g-sfp++4-1g-tx",
+                                    "cpm-ixr-e/imm24-sfp++8-sfp28+2-qsfp28",
+                                    "imm24-sfp++8-sfp28+2-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e-gnss/imm14-10g-sfp++4-1g-tx"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m14-10g-sfp++4-1g-tx"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e-gnss/imm24-sfp++8-sfp28+2-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m24-sfp++8-sfp28+2-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e/imm14-10g-sfp++4-1g-tx"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m14-10g-sfp++4-1g-tx"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e/imm24-sfp++8-sfp28+2-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m24-sfp++8-sfp28+2-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm24-sfp++8-sfp28+2-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e2": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e2"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m2-qsfpdd+2-qsfp28+24-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e2c": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2c"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2c"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e2c"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m12-sfp28+2-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e2n": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2n/imm4-sfp+4-sfp+"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2n/imm4-sfp+4-sfp+"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e2n/imm4-sfp+4-sfp+"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-sfp+4-sfp+"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e2n-s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2n-s/imm4-sfp+4-sfp+-s",
+                                    "imm4-sfp+4-sfp+-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e2n-s/imm4-sfp+4-sfp+-s",
+                                    "imm4-sfp+4-sfp+-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e2n-s/imm4-sfp+4-sfp+-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-sfp+4-sfp+-s"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm4-sfp+4-sfp+-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-sfp+4-sfp+-s"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e3c": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e3c/imm4-qsfp28+16-sfp28+8-sfp56"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e3c/imm4-qsfp28+16-sfp28+8-sfp56"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e3c/imm4-qsfp28+16-sfp28+8-sfp56"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-qsfp28+16-sfp28+8-sfp56"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-e3x": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e3x/imm16-sfp112+15-sfp56+6-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-e3x/imm16-sfp112+15-sfp56+6-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-e3x/imm16-sfp112+15-sfp56+6-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m16-sfp112+15-sfp56+6-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-ec": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-ec"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-ec"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-ec"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-1g-tx+20-1g-sfp+6-10g-sfp+"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-r4": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-r4"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-ixr-r4"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-r4"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-ixr-r4"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m10-10g-sfp+",
+                                                "m10-1g-sfp+2-10g-sfp+",
+                                                "m20-1g-csfp",
+                                                "m4-10g-sfp++1-100g-cfp2",
+                                                "m6-10g-sfp++1-100g-qsfp28",
+                                                "m6-10g-sfp++4-25g-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-r6": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpiom-ixr-r6"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpiom-ixr-r6"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpiom-ixr-r6"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "a32-chds1v2",
+                                                "m10-10g-sfp+",
+                                                "m20-1g-csfp",
+                                                "m4-10g-sfp++1-100g-cfp2",
+                                                "m6-10g-sfp++1-100g-qsfp28",
+                                                "m6-10g-sfp++4-25g-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-r6d": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-r6d",
+                                    "cpm-ixr-r6d/iom-ixr-r6d"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-r6d/iom-ixr-r6d",
+                                    "iom-ixr-r6d"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-r6d/iom-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m1-400g-qsfpdd+1-100g-qsfp28",
+                                                "m10-50g-sfp56",
+                                                "m18-25g-sfp28",
+                                                "m2-100g-qsfp28+16-10g-sfp+",
+                                                "m2-cfp2",
+                                                "m20-10g-sfp+",
+                                                "m32-1g-csfp",
+                                                "m5-100g-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m1-400g-qsfpdd+1-100g-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-r6dl": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-r6d",
+                                    "cpm-ixr-r6d/iom-ixr-r6d"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-r6d/iom-ixr-r6d",
+                                    "iom-ixr-r6d"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-r6d/iom-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m1-400g-qsfpdd+1-100g-qsfp28",
+                                                "m10-50g-sfp56",
+                                                "m18-25g-sfp28",
+                                                "m2-100g-qsfp28+16-10g-sfp+",
+                                                "m2-cfp2",
+                                                "m20-10g-sfp+",
+                                                "m32-1g-csfp",
+                                                "m46-10g-sfp+",
+                                                "m5-100g-qsfp28",
+                                                "m80-1g-csfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m1-400g-qsfpdd+1-100g-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-s/imm48-sfp++6-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-s/imm48-sfp++6-qsfp28"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-s/imm48-sfp++6-qsfp28"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m48-sfp++6-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-x": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-x",
+                                    "cpm-ixr-x/imm32-qsfp28+4-qsfpdd",
+                                    "cpm-ixr-x/imm6-qsfpdd+48-sfp56"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-x/imm32-qsfp28+4-qsfpdd",
+                                    "cpm-ixr-x/imm6-qsfpdd+48-sfp56",
+                                    "imm32-qsfp28+4-qsfpdd",
+                                    "imm6-qsfpdd+48-sfp56"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-x/imm32-qsfp28+4-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m32-qsfp28+4-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-x/imm6-qsfpdd+48-sfp56"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m6-qsfpdd+48-sfp56"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm32-qsfp28+4-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm6-qsfpdd+48-sfp56"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "srsim-component-ixr-x3": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-x",
+                                    "cpm-ixr-x/imm36-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-ixr-x/imm36-qsfpdd",
+                                    "imm36-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-ixr-x/imm36-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m36-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm36-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "srsim-component-sar-1": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-sar"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-sar"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-sar"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa-ms-v",
+                                                "m10-sfp++6-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sar-hm": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-sar-hm"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-sar-hm"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-sar-hm"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "i1-wlan",
+                                                "i2-cellular",
+                                                "i2-sdi",
+                                                "i6-10/100eth-tx",
+                                                "isa-ms-v"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sar-hmc": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-sar-hmc"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-sar-hmc"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-sar-hmc"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "i2-cellular",
+                                                "i2-sdi",
+                                                "i3-10/100eth-tx",
+                                                "isa-ms-v"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sar-hx": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-sar-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-sar-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-sar-1x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa-ms-v",
+                                                "m2-1g-sfp+2-10g-sfp+",
+                                                "m4-1g-rj+6-10g-sfp++2-25g-sfp28",
+                                                "m4-rs232-rj45+4-c3794-sfp",
+                                                "m8-t1e1-rj48"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me12-100gb-qsfp28",
+                                                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                                                "me16-25gb-sfp28+2-100gb-qsfp28",
+                                                "me3-200gb-cfp2-dco",
+                                                "me3-400gb-qsfpdd",
+                                                "me6-100gb-qsfp28",
+                                                "me6-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1-24d": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i24-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i24-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i24-800g-qsfpdd-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m24-800g-qsfpdd-1"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1-46s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m40-200g-sfpdd+6-800g-qsfpdd-1"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1-48d": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i48-400g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i48-400g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i48-400g-qsfpdd-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m48-400g-qsfpdd-1"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1-92s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m80-200g-sfpdd+12-400g-qsfpdd-1"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-12": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm5"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "imm-2pac-fp3",
+                                    "imm48-1gb-sfp-c",
+                                    "iom4-e",
+                                    "iom4-e-b",
+                                    "iom4-e-hs",
+                                    "iom5-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm5"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm-2pac-fp3"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "p1-100g-cfp",
+                                                "p10-10g-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm48-1gb-sfp-c"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "imm24-1gb-xp-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-b"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-hs"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom5-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                                                "me16-25gb-sfp28+2-100gb-qsfp28",
+                                                "me3-200gb-cfp2-dco",
+                                                "me3-400gb-qsfpdd",
+                                                "me6-100gb-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-12e": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm5"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "imm-2pac-fp3",
+                                    "imm4-100gb-cfp4",
+                                    "imm40-10gb-sfp",
+                                    "iom4-e",
+                                    "iom4-e-b",
+                                    "iom4-e-hs",
+                                    "iom5-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm5"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm-2pac-fp3"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "p1-100g-cfp",
+                                                "p10-10g-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm4-100gb-cfp4"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m4-100g-cfp4"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm40-10gb-sfp"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m40-10g-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-b"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-hs"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12e",
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom5-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me12-100gb-qsfp28",
+                                                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                                                "me16-25gb-sfp28+2-100gb-qsfp28",
+                                                "me3-200gb-cfp2-dco",
+                                                "me3-400gb-qsfpdd",
+                                                "me6-100gb-qsfp28",
+                                                "me6-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm6-12e"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-14s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-s",
+                                    "cpm2-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xcm-14s",
+                                    "xcm-14s-b",
+                                    "xcm2-14s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm2-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s",
+                                    "sfm2-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-14s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-1.5t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-1.5t",
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-14s-b"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-1.5t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-1.5t",
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm2-14s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "x2-s36-800g-qsfpdd-12.0t",
+                                                "x2-s36-800g-qsfpdd-18.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-400g-qsfp112-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-400g-qsfp112"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-800g-qsfpdd-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom2-se-3.0t",
+                                                "iom2-se-6.0t",
+                                                "x2-s36-400g-qsfp112-3.0t",
+                                                "x2-s36-800g-qsfpdd-6.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1e": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1se": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1se/imm36-800g-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1se/imm36-800g-qsfpdd"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1se/imm36-800g-qsfpdd"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "ms36-800g-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1x-48d": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i48-800g-qsfpdd-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i48-800g-qsfpdd-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i48-800g-qsfpdd-1x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m48-800g-qsfpdd-1x"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-1x-92s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m80-200g-sfpdd+12-800g-qsfpdd-1x"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-2s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-2s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xcm-2s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-2s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-2s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-2s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-2s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-1.5t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-1.5t",
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-2se": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-2se"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xcm-2se",
+                                    "xcmc-2se"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-2se"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-2se"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-2se"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me6-100gb-qsfp28",
+                                                "x2-s36-800g-qsfpdd-12.0t",
+                                                "x2-s36-800g-qsfpdd-18.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-2se"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-400g-qsfp112-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-400g-qsfp112"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-800g-qsfpdd-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom2-se-3.0t",
+                                                "iom2-se-6.0t",
+                                                "x2-s36-400g-qsfp112-3.0t",
+                                                "x2-s36-800g-qsfpdd-6.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcmc-2se"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-2se"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-400g-qsfp112-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-400g-qsfp112"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-800g-qsfpdd-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom2-se-3.0t",
+                                                "iom2-se-6.0t",
+                                                "x2-s36-400g-qsfp112-3.0t",
+                                                "x2-s36-800g-qsfpdd-6.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-7": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm5"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "imm-2pac-fp3",
+                                    "imm48-1gb-sfp-c",
+                                    "iom4-e",
+                                    "iom4-e-b",
+                                    "iom4-e-hs",
+                                    "iom5-e"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm5"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-7",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm-2pac-fp3"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "p1-100g-cfp",
+                                                "p10-10g-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-7",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "imm48-1gb-sfp-c"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "imm24-1gb-xp-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-7",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-7",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-b"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "isa2-aa",
+                                                "isa2-bb",
+                                                "isa2-tunnel",
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-7",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom4-e-hs"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me1-100gb-cfp2",
+                                                "me10-10gb-sfp+",
+                                                "me12-10/1gb-sfp+",
+                                                "me2-100gb-cfp4",
+                                                "me2-100gb-ms-qsfp28",
+                                                "me2-100gb-qsfp28",
+                                                "me40-1gb-csfp",
+                                                "me6-10gb-sfp+",
+                                                "me8-10/25gb-sfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm5-12",
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom5-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                                                "me16-25gb-sfp28+2-100gb-qsfp28",
+                                                "me3-200gb-cfp2-dco",
+                                                "me3-400gb-qsfpdd",
+                                                "me6-100gb-qsfp28"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "m-sfm6-7/12"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-7s": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-s",
+                                    "cpm2-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xcm-7s",
+                                    "xcm-7s-b",
+                                    "xcm2-7s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm2-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s",
+                                    "sfm2-s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-7s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-1.5t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-1.5t",
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-7s-b"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "s18-100gb-qsfp28",
+                                                "s36-100gb-qsfp28",
+                                                "s36-100gb-qsfp28-3.6t",
+                                                "s36-400gb-qsfpdd"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-1.5t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom-s-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                                                                        "ms16-sdd+4-qsfp28-b",
+                                                                        "ms18-100gb-qsfp28",
+                                                                        "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                                                                        "ms24-10/100gb-sfpdd",
+                                                                        "ms3-200gb-cfp2-dco",
+                                                                        "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                                                                        "ms6-300gb-cfp2-dco",
+                                                                        "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                                                                        "ms8-sdd+2-qsfp28-b"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom-s-1.5t",
+                                                "iom-s-3.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm2-7s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "x2-s36-800g-qsfpdd-12.0t",
+                                                "x2-s36-800g-qsfpdd-18.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-s"
+                                ]
+                            },
+                            "xiom": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "iom2-se-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "mse14-800g+4-400g",
+                                                                        "mse24-200g-sfpdd",
+                                                                        "mse6-800g-cfp2-dco",
+                                                                        "mse6-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-400g-qsfp112-3.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-400g-qsfp112"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "if": {
+                                                "properties": {
+                                                    "type": {
+                                                        "const": "x2-s36-800g-qsfpdd-6.0t"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "then": {
+                                                "properties": {
+                                                    "mda": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "enum": [
+                                                                        "m36-800g-qsfpdd"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "iom2-se-3.0t",
+                                                "iom2-se-6.0t",
+                                                "x2-s36-400g-qsfp112-3.0t",
+                                                "x2-s36-800g-qsfpdd-6.0t"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-sr-a4": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-a"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "iom-a"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-a"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "iom-a"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "ma2-10gb-sfp+12-1gb-sfp",
+                                                "ma20-1gb-tx",
+                                                "ma4-10gb-sfp+",
+                                                "ma44-1gb-csfp",
+                                                "maxp1-100gb-cfp",
+                                                "maxp1-100gb-cfp2",
+                                                "maxp1-100gb-cfp4",
+                                                "maxp10-10/1gb-msec-sfp+",
+                                                "maxp10-10gb-sfp+",
+                                                "maxp6-10gb-sfp+1-40gb-qsfp+"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-vsr-i": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-v/iom-v"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-v/iom-v"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-v/iom-v"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "sfm"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "m20-v"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-component-xrs-20": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/srsim-component"
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "cpm-x20",
+                                    "cpm2-x20"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "slot": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "slot"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xcm-x20",
+                                    "xcm2-x20"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm-x20"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm-x20",
+                                    "sfm-x20-b",
+                                    "sfm-x20s-b",
+                                    "sfm2-x20s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "cpm2-x20"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "mda"
+                                    ]
+                                }
+                            },
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-x20s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm-x20"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "x2-100g-tun",
+                                                "x4-100g-cfp2",
+                                                "x40-10g-sfp"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm-x20",
+                                    "sfm-x20-b",
+                                    "sfm-x20s-b",
+                                    "sfm2-x20s"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "xcm2-x20"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "required": [
+                                        "xiom"
+                                    ]
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "mda": {
+                                "items": {
+                                    "properties": {
+                                        "type": {
+                                            "enum": [
+                                                "x12-400g-qsfpdd",
+                                                "x24-100g-qsfp28",
+                                                "x6-200g-cfp2-dco",
+                                                "x6-400g-cfp8"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "sfm": {
+                                "enum": [
+                                    "sfm2-x20s"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "srsim-cpm-types": {
+            "description": "SR-SIM CPM types generated from Nokia supported hardware tables.",
+            "enum": [
+                "cpiom-ixr-r6",
+                "cpm-1",
+                "cpm-1s",
+                "cpm-1se/imm36-800g-qsfpdd",
+                "cpm-1x/dms24-800g-qsfpdd-1",
+                "cpm-1x/i24-800g-qsfpdd-1",
+                "cpm-1x/i40-200g-sfpdd+6-800g-qsfpdd-1",
+                "cpm-1x/i48-400g-qsfpdd-1",
+                "cpm-1x/i48-800g-qsfpdd-1x",
+                "cpm-1x/i80-200g-sfpdd+12-400g-qsfpdd-1",
+                "cpm-1x/i80-200g-sfpdd+12-800g-qsfpdd-1x",
+                "cpm-2s",
+                "cpm-2se",
+                "cpm-a",
+                "cpm-e",
+                "cpm-ixr",
+                "cpm-ixr-e",
+                "cpm-ixr-e-gnss/imm14-10g-sfp++4-1g-tx",
+                "cpm-ixr-e-gnss/imm24-sfp++8-sfp28+2-qsfp28",
+                "cpm-ixr-e/imm14-10g-sfp++4-1g-tx",
+                "cpm-ixr-e/imm24-sfp++8-sfp28+2-qsfp28",
+                "cpm-ixr-e2",
+                "cpm-ixr-e2c",
+                "cpm-ixr-e2n-s/imm4-sfp+4-sfp+-s",
+                "cpm-ixr-e2n/imm4-sfp+4-sfp+",
+                "cpm-ixr-e3c/imm4-qsfp28+16-sfp28+8-sfp56",
+                "cpm-ixr-e3x/imm16-sfp112+15-sfp56+6-qsfpdd",
+                "cpm-ixr-ec",
+                "cpm-ixr-r4",
+                "cpm-ixr-r6d",
+                "cpm-ixr-r6d/iom-ixr-r6d",
+                "cpm-ixr-s/imm48-sfp++6-qsfp28",
+                "cpm-ixr-x",
+                "cpm-ixr-x/imm32-qsfp28+4-qsfpdd",
+                "cpm-ixr-x/imm36-qsfpdd",
+                "cpm-ixr-x/imm6-qsfpdd+48-sfp56",
+                "cpm-s",
+                "cpm-sar-hm",
+                "cpm-sar-hmc",
+                "cpm-v/iom-v",
+                "cpm-x20",
+                "cpm2-s",
+                "cpm2-x20",
+                "cpm5",
+                "imm4-sfp+4-sfp+-s",
+                "iom-sar",
+                "iom-sar-1x"
+            ],
+            "type": "string"
+        },
+        "srsim-mda": {
+            "additionalProperties": false,
+            "properties": {
+                "slot": {
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/srsim-mda-types"
+                }
+            },
+            "required": [
+                "slot",
+                "type"
+            ],
+            "type": "object"
+        },
+        "srsim-mda-types": {
+            "description": "SR-SIM MDA types generated from Nokia supported hardware tables.",
+            "enum": [
+                "a32-chds1v2",
+                "d24-800g-qsfpdd-1",
+                "i1-wlan",
+                "i2-cellular",
+                "i2-sdi",
+                "i3-10/100eth-tx",
+                "i6-10/100eth-tx",
+                "imm24-1gb-xp-sfp",
+                "isa-ms-v",
+                "isa2-aa",
+                "isa2-bb",
+                "isa2-tunnel",
+                "m1-400g-qsfpdd+1-100g-qsfp28",
+                "m10-10g-sfp+",
+                "m10-1g-sfp+2-10g-sfp+",
+                "m10-50g-sfp56",
+                "m10-sfp++6-sfp",
+                "m12-sfp28+2-qsfp28",
+                "m14-10g-sfp++4-1g-tx",
+                "m16-sfp112+15-sfp56+6-qsfpdd",
+                "m18-25g-sfp28",
+                "m2-100g-qsfp28+16-10g-sfp+",
+                "m2-1g-sfp+2-10g-sfp+",
+                "m2-cfp2",
+                "m2-qsfpdd+2-qsfp28+24-sfp28",
+                "m20-10g-sfp+",
+                "m20-1g-csfp",
+                "m20-v",
+                "m24-800g-qsfpdd-1",
+                "m24-sfp++8-sfp28+2-qsfp28",
+                "m32-1g-csfp",
+                "m32-qsfp28+4-qsfpdd",
+                "m36-100g-qsfp28",
+                "m36-400g-qsfp112",
+                "m36-800g-qsfpdd",
+                "m36-qsfpdd",
+                "m4-100g-cfp4",
+                "m4-10g-sfp++1-100g-cfp2",
+                "m4-1g-rj+6-10g-sfp++2-25g-sfp28",
+                "m4-1g-tx+20-1g-sfp+6-10g-sfp+",
+                "m4-qsfp28+16-sfp28+8-sfp56",
+                "m4-rs232-rj45+4-c3794-sfp",
+                "m4-sfp+4-sfp+",
+                "m4-sfp+4-sfp+-s",
+                "m40-10g-sfp",
+                "m40-200g-sfpdd+6-800g-qsfpdd-1",
+                "m46-10g-sfp+",
+                "m48-400g-qsfpdd-1",
+                "m48-800g-qsfpdd-1x",
+                "m48-sfp++6-qsfp28",
+                "m48-sfp+2-qsfp28",
+                "m5-100g-qsfp28",
+                "m6-10g-sfp++1-100g-qsfp28",
+                "m6-10g-sfp++4-25g-sfp28",
+                "m6-qsfpdd+48-sfp56",
+                "m8-t1e1-rj48",
+                "m80-1g-csfp",
+                "m80-200g-sfpdd+12-400g-qsfpdd-1",
+                "m80-200g-sfpdd+12-800g-qsfpdd-1x",
+                "ma2-10gb-sfp+12-1gb-sfp",
+                "ma20-1gb-tx",
+                "ma4-10gb-sfp+",
+                "ma44-1gb-csfp",
+                "maxp1-100gb-cfp",
+                "maxp1-100gb-cfp2",
+                "maxp1-100gb-cfp4",
+                "maxp10-10/1gb-msec-sfp+",
+                "maxp10-10gb-sfp+",
+                "maxp6-10gb-sfp+1-40gb-qsfp+",
+                "me1-100gb-cfp2",
+                "me10-10gb-sfp+",
+                "me12-10/1gb-sfp+",
+                "me12-100gb-qsfp28",
+                "me16-25gb-sfp28+2-100gb-qsfp-b",
+                "me16-25gb-sfp28+2-100gb-qsfp28",
+                "me2-100gb-cfp4",
+                "me2-100gb-ms-qsfp28",
+                "me2-100gb-qsfp28",
+                "me3-200gb-cfp2-dco",
+                "me3-400gb-qsfpdd",
+                "me40-1gb-csfp",
+                "me6-100gb-qsfp28",
+                "me6-10gb-sfp+",
+                "me6-400gb-qsfpdd",
+                "me8-10/25gb-sfp28",
+                "ms16-100gb-sfpdd+4-100gb-qsfp28",
+                "ms16-sdd+4-qsfp28-b",
+                "ms18-100gb-qsfp28",
+                "ms2-400gb-qsfpdd+2-100gb-qsfp28",
+                "ms24-10/100gb-sfpdd",
+                "ms3-200gb-cfp2-dco",
+                "ms36-800g-qsfpdd",
+                "ms4-400gb-qsfpdd+4-100gb-qsfp28",
+                "ms6-300gb-cfp2-dco",
+                "ms8-100gb-sfpdd+2-100gb-qsfp28",
+                "ms8-sdd+2-qsfp28-b",
+                "mse14-800g+4-400g",
+                "mse24-200g-sfpdd",
+                "mse6-800g-cfp2-dco",
+                "mse6-800g-qsfpdd",
+                "p1-100g-cfp",
+                "p10-10g-sfp",
+                "s18-100gb-qsfp28",
+                "s36-100gb-qsfp28",
+                "s36-100gb-qsfp28-3.6t",
+                "s36-400gb-qsfpdd",
+                "x12-400g-qsfpdd",
+                "x2-100g-tun",
+                "x2-s36-800g-qsfpdd-12.0t",
+                "x2-s36-800g-qsfpdd-18.0t",
+                "x24-100g-qsfp28",
+                "x4-100g-cfp2",
+                "x40-10g-sfp",
+                "x6-200g-cfp2-dco",
+                "x6-400g-cfp8"
+            ],
+            "type": "string"
+        },
+        "srsim-node": {
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "dms-1-24d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-dms-1-24d"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "ess-12",
+                                    "ess-7"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ess-12"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-10"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-10"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-6"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-6"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e2"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e2"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e2c"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e2c"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e2n"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e2n"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e2n-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e2n-s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e3c"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e3c"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-e3x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-e3x"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-ec"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-ec"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-r4"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-r4"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-r6"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-r6"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-r6d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-r6d"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-r6dl"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-r6dl"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-x"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-x"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "ixr-x3"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-ixr-x3"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sar-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sar-1"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sar-hm"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sar-hm"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sar-hmc"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sar-hmc"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "sar-hx",
+                                    "sar-mx"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sar-hx"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1-24d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1-24d"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1-46s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1-46s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1-48d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1-48d"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1-92s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1-92s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-12"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-12"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-12e"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-12e"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-14s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-14s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "sr-1e",
+                                    "sr-2e",
+                                    "sr-3e"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1e"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1se"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1se"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1x-48d"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1x-48d"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-1x-92s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-1x-92s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-2s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-2s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-2se"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-2se"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-7"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-7"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "sr-7s"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-7s"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "sr-a4",
+                                    "sr-a8"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-sr-a4"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "vsr-i"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-vsr-i"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "xrs-20",
+                                    "xrs-20e"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "components": {
+                                "items": {
+                                    "$ref": "#/definitions/srsim-component-xrs-20"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "components": {
+                    "items": {
+                        "$ref": "#/definitions/srsim-component"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "type": {
+                    "$ref": "#/definitions/srsim-chassis-types"
+                }
+            },
+            "type": "object"
+        },
+        "srsim-sfm-types": {
+            "description": "SR-SIM SFM types generated from Nokia supported hardware tables.",
+            "enum": [
+                "m-sfm5-12",
+                "m-sfm5-12e",
+                "m-sfm5-7",
+                "m-sfm6-12e",
+                "m-sfm6-7/12",
+                "sfm-2s",
+                "sfm-2se",
+                "sfm-ixr-10",
+                "sfm-ixr-6",
+                "sfm-s",
+                "sfm-x20",
+                "sfm-x20-b",
+                "sfm-x20s-b",
+                "sfm2-s",
+                "sfm2-x20s"
+            ],
+            "type": "string"
+        },
+        "srsim-xiom": {
+            "additionalProperties": false,
+            "properties": {
+                "mda": {
+                    "items": {
+                        "$ref": "#/definitions/srsim-mda"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "slot": {
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/srsim-xiom-types"
+                }
+            },
+            "required": [
+                "slot",
+                "type"
+            ],
+            "type": "object"
+        },
+        "srsim-xiom-types": {
+            "description": "SR-SIM XIOM types generated from Nokia supported hardware tables.",
+            "enum": [
+                "iom-s-1.5t",
+                "iom-s-3.0t",
+                "iom2-se-3.0t",
+                "iom2-se-6.0t",
+                "x2-s36-400g-qsfp112-3.0t",
+                "x2-s36-800g-qsfpdd-6.0t"
+            ],
+            "type": "string"
+        }
+    },
+    "title": "Containerlab SR-SIM hardware compatibility schema",
+    "x-srsim-metadata": {
+        "allow_unknown_values": false,
+        "chassis": 49,
+        "component_definitions": 43,
+        "default_rows": 83,
+        "generated_at": "2026-05-20T16:51:10.911408+00:00",
+        "models": 52,
+        "source": "https://documentation.nokia.com/sr/26-3/7x50-shared/srsim-installation-setup/appendices.html",
+        "supported_rows": 411
+    }
+}


### PR DESCRIPTION
This adds a full compability matrix for srsim components, generated by https://github.com/FloSch62/srsim-hw-schema with the input from https://documentation.nokia.com/sr/26-3/7x50-shared/srsim-installation-setup/appendices.htm 

I know its a massive 8k lines sidecar, but if we want default yaml validations I fear it only works with the massive if`s ( but this is anyhow auto generated ) But because of that the idea is just to have the ref in current schema and just load the sidecar schema. 