### PR TITLE
kind/cumulus_vm: add QEMU-based Cumulus VX node kind

### DIFF
--- a/core/register.go
+++ b/core/register.go
@@ -17,6 +17,7 @@ import (
 	clabnodescjunosevolved "github.com/srl-labs/containerlab/nodes/cjunosevolved"
 	clabnodescrpd "github.com/srl-labs/containerlab/nodes/crpd"
 	clabnodescvx "github.com/srl-labs/containerlab/nodes/cvx"
+  	clabnodescumulus_vm "github.com/srl-labs/containerlab/nodes/cumulus_vm"
 	clabnodesdell_sonic "github.com/srl-labs/containerlab/nodes/dell_sonic"
 	clabnodesext_container "github.com/srl-labs/containerlab/nodes/ext_container"
 	clabnodesf5_bigipve "github.com/srl-labs/containerlab/nodes/f5_bigipve"
@@ -73,6 +74,7 @@ func (c *CLab) RegisterNodes() { //nolint:funlen
 	clabnodescrpd.Register(c.Reg)
 	clabnodesjuniper_csrx.Register(c.Reg)
 	clabnodescvx.Register(c.Reg)
+  	clabnodescumulus_vm.Register(c.Reg)
 	clabnodesext_container.Register(c.Reg)
 	clabnodesfortinet_fortigate.Register(c.Reg)
 	clabnodeshost.Register(c.Reg)

--- a/nodes/cumulus_vm/cumulus_vm.go
+++ b/nodes/cumulus_vm/cumulus_vm.go
@@ -1,0 +1,95 @@
+// Copyright 2026 NVIDIA
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package cumulus_vm
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	clabutils "github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindNames          = []string{"cumulus_vm"}
+	defaultCredentials = clabnodes.NewCredentials("cumulus", "Nsn1234!")
+
+	InterfaceRegexp = regexp.MustCompile(`swp(?P<port>\d+)`)
+	InterfaceOffset = 1
+	InterfaceHelp   = "swpX (where X >= 1) or ethX (where X >= 1)"
+)
+
+const (
+	generateable     = true
+	generateIfFormat = "swp%d"
+	configDirName    = "config"
+)
+
+func Register(r *clabnodes.NodeRegistry) {
+	generateNodeAttributes := clabnodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	nrea := clabnodes.NewNodeRegistryEntryAttributes(
+		defaultCredentials,
+		generateNodeAttributes,
+		nil,
+	)
+
+	r.Register(kindNames, func() clabnodes.Node {
+		return new(cumulusVM)
+	}, nrea)
+}
+
+type cumulusVM struct {
+	clabnodes.VRNode
+}
+
+func (n *cumulusVM) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) error {
+	n.VRNode = *clabnodes.NewVRNode(n, defaultCredentials, "")
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+
+	defEnv := map[string]string{
+		"CONNECTION_MODE":    clabnodes.VrDefConnMode,
+		"USERNAME":           n.Cfg.Credentials.Username,
+		"PASSWORD":           n.Cfg.Credentials.Password,
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+	}
+	n.Cfg.Env = clabutils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	n.Cfg.Binds = append(
+		n.Cfg.Binds,
+		fmt.Sprint(path.Join(n.Cfg.LabDir, configDirName), ":/config"),
+	)
+
+	if n.Cfg.Env["CONNECTION_MODE"] == "macvtap" {
+		n.Cfg.Binds = append(n.Cfg.Binds, "/dev:/dev")
+	}
+
+	n.Cfg.Cmd = fmt.Sprintf(
+		"--username %s --password %s --hostname %s --connection-mode %s --trace",
+		n.Cfg.Env["USERNAME"],
+		n.Cfg.Env["PASSWORD"],
+		n.Cfg.ShortName,
+		n.Cfg.Env["CONNECTION_MODE"],
+	)
+
+	n.InterfaceRegexp = InterfaceRegexp
+	n.InterfaceOffset = InterfaceOffset
+	n.InterfaceHelp = InterfaceHelp
+
+	return nil
+}
+
+// CheckInterfaceName validates via VRNode (accepts ethX names after swp→eth mapping,
+// or swpX names when checked before mapping).
+func (n *cumulusVM) CheckInterfaceName() error {
+	return n.VRNode.CheckInterfaceName()
+}


### PR DESCRIPTION
  Add a cumulus_vm kind for running NVIDIA Cumulus VX virtual switches
  inside vrnetlab QEMU containers.

  Uses VRNode base for swpX -> ethX interface mapping so topology
  endpoint names match Cumulus switch port conventions.

  - Accepts swpX interface names (e.g. swp1, swp6, swp7)
  - Maps swpX -> ethX internally for Docker/vrnetlab compatibility
  - Default credentials: cumulus / Nsn1234!
  - Interface auto-generation format: swp%d

 ## Summary

  Adds a `cumulus_vm` kind for running [NVIDIA Cumulus VX](https://www.nvidia.com/en-us/networking/ethernet-switching/cumulus-vx/)
  inside vrnetlab QEMU containers. Uses `VRNode` base for `swpX -> ethX` interface
  mapping so topology endpoint names match Cumulus switch port conventions.

  ## Changes

  - `nodes/cumulus_vm/cumulus_vm.go` — new kind (96 lines)
  - `core/register.go` — +2 lines (import + registration)

  ## Usage

  ```yaml
  topology:
    nodes:
      l1:
        kind: cumulus_vm
        image: vrnetlab/nvidia_cumulus-vx:5.15.1
      s1:
        kind: cumulus_vm
        image: vrnetlab/nvidia_cumulus-vx:5.15.1
    links:
      - endpoints: ["s1:swp1", "l1:swp6"]
  ```

  ## Dependencies

  Requires companion vrnetlab PR that adds `vrnetlab/nvidia_cumulus-vx` image.

  ## Test plan
  
  - [x] Topology parses with `cumulus_vm` kind
  - [x] Interface mapping `swpX -> ethX` works correctly
  - [x] Deploy/destroy cycle clean
  - [x] Verified with 5-node Cumulus MLAG topology
