### PR TITLE
docs: clarify exec runs in launcher container, not guest VM, for vrnetlab kinds

### DIFF
--- a/docs/cmd/exec.md
+++ b/docs/cmd/exec.md
@@ -6,6 +6,10 @@ The `exec` command allows a user to execute a command inside the nodes (containe
 
 This command is similar to `docker exec`, but it allows a user to run the same command across multiple lab nodes matching the filter. Users can provide a path to the topology file and use the `--label` argument to narrow down the list of nodes to execute the command on.
 
+/// note | VM-based (vrnetlab) kinds
+Like `docker exec`, `exec` runs inside the node's container namespace. For VM-based kinds (vrnetlab integration, e.g. `sonic-vm`), that container is the QEMU launcher wrapping the VM, not the guest VM itself, so guest network-OS commands are not reachable via `exec` and fail with `executable file not found in $PATH`. Use SSH to the node's management address (or its native CLI) to run guest-OS commands. See the [`exec` node property](../manual/nodes.md#exec) for details.
+///
+
 --8<-- "docs/cmd/deploy.md:env-vars-flags"
 
 ## Usage

--- a/docs/manual/kinds/sonic-vm.md
+++ b/docs/manual/kinds/sonic-vm.md
@@ -48,6 +48,10 @@ SONiC node launched with containerlab takes approximately 1 minute to boot up an
 The default login credentials for the SONiC VM are `admin:admin`
 ///
 
+/// note | exec runs in the launcher container, not the SONiC VM
+`sonic-vm` is a VM-based (vrnetlab) kind, so the [`exec` node property](../nodes.md#exec) and the [`exec` command](../../cmd/exec.md) run inside the launcher container that wraps the VM, not inside the SONiC guest. SONiC CLI commands such as `show version` are not available via `exec` and fail with `executable file not found in $PATH`. Use the SSH method below to run commands against SONiC.
+///
+
 /// tab | SSH
 To open a linux shell simply type in
 

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -633,6 +633,12 @@ When you want the `exec` command to have access to the env variables defined in 
 
 ///
 
+/// note | exec and VM-based (vrnetlab) kinds
+For VM-based kinds (vrnetlab integration, e.g. `sonic-vm` and other [VM-based routers](vrnetlab.md)), `exec` runs the command inside the launcher container that wraps the VM, not inside the guest VM itself. The container is only the QEMU wrapper, so guest network-OS commands (e.g. SONiC `show version`) are not on the container's `PATH` and fail with `executable file not found in $PATH`.
+
+To run commands against the guest network OS, connect to the node over SSH at its management address (or use the node's native CLI), as described on the node's kind documentation page.
+///
+
 ### memory
 
 By default, container runtimes do not impose any memory resource constraints[^1].

--- a/docs/manual/vrnetlab.md
+++ b/docs/manual/vrnetlab.md
@@ -143,6 +143,10 @@ The following env vars are supported:
 
 By hosting a VM inside a container, we made it easy to run VM-based routers in a containerized environment. However, how would you connect container's interfaces to the VM's tap interfaces in a transparent way?
 
+/// note | exec targets the launcher container
+Because the guest network OS runs in a VM inside the launcher container, the [`exec` node property](nodes.md#exec) and the [`exec` command](../cmd/exec.md) run inside the launcher container, not inside the guest VM. Guest network-OS commands are therefore not reachable via `exec`; connect to the node over SSH at its management address (or use the node's native CLI) instead.
+///
+
 To solve this challenge containerlab uses **tc** backend[^4], which mirrors the traffic to and from container interfaces to the appropriate VM interfaces. A huge bonus of `tc` is that there are not bridges inbetween, and we have a clear channel that supports transparent passage of any frames, like LACP, for example.
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:6,&quot;zoom&quot;:1.5,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/srl-labs/containerlab/diagrams/vrnetlab.drawio&quot;}"></div>


### PR DESCRIPTION
## Summary

Documents that `exec` (both the `exec` node property and the `containerlab exec` command) runs inside a node's container namespace, and for VM-based (vrnetlab) kinds that container is the QEMU launcher wrapping the guest VM, not the guest VM itself. Guest network-OS commands (e.g. SONiC `show version`) are therefore not reachable via `exec` and fail with `executable file not found in $PATH`. The notes point users to SSH (or the node's native CLI) at the management address for guest-OS commands.

Notes added to:

- `docs/manual/nodes.md` (the `exec` node property section)
- `docs/cmd/exec.md` (the `exec` command Description)
- `docs/manual/vrnetlab.md` (Datapath connectivity overview)
- `docs/manual/kinds/sonic-vm.md` (the kind named in the issue)

## Why this matters

Issue #3053 reports that running `containerlab exec ... --cmd 'show version'` against a vrnetlab VM kind such as `sonic-vm` fails with rc=127 because the command executes in the launcher container rather than the guest VM. For `linux` kinds the container is the device, so `exec` works as expected; the container-vs-guest distinction for VM kinds was undocumented. A code-level fix forwarding `exec` to the guest over SSH (PR #3054) was closed in favor of documenting the limitation, which the reporter explicitly offered as the path forward. This is a docs-only change with no behavior change.

Fixes #3053

AI was used for assistance.
