### PR TITLE
Check if modules could be built into kernel.

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -503,6 +503,15 @@ func (*CLab) loadKernelModules() error {
 		// trying to load the kernel modules.
 		km, err := kmod.New(opts...)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				log.Debugf(
+					"No loadable kernel module support (%v). Assuming module %q is built into the kernel",
+					err, m,
+				)
+
+				return nil
+			}
+
 			log.Warnf("Unable to init module loader: %v. Skipping...", err)
 
 			return nil
@@ -510,9 +519,9 @@ func (*CLab) loadKernelModules() error {
 
 		err = km.Load(m, "", 0)
 		if err != nil {
-			log.Warnf("Unable to load kernel module %q automatically %q", m, err)
-
-			return nil
+			return fmt.Errorf(
+				"kernel module %q is not loaded, not built-in and could not be loaded: %w", m, err,
+			)
 		}
 
 		log.Debugf("kernel module %q loaded successfully", m)

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -17,20 +17,76 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// IsKernelModuleLoaded checks if a kernel module is loaded by parsing /proc/modules file.
+// IsKernelModuleLoaded checks if a kernel module is available.
+// either built-in to kernel, or loaded.
 func IsKernelModuleLoaded(name string) (bool, error) {
+	loaded, err := isKernelModuleLoadable(name)
+	if err != nil {
+		return false, err
+	}
+	if loaded {
+		return true, nil
+	}
+
+	return isKernelModuleBuiltin(name)
+}
+
+// isKernelModuleLoadable checks if a kernel module is loaded by parsing the
+// /proc/modules file.
+func isKernelModuleLoadable(name string) (bool, error) {
 	f, err := os.Open("/proc/modules")
 	if err != nil {
 		return false, err
 	}
+	defer f.Close() // skipcq: GO-S2307
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		if strings.HasPrefix(strings.Fields(scanner.Text())[0], name) {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		if strings.HasPrefix(fields[0], name) {
 			return true, nil
 		}
 	}
-	return false, f.Close()
+	return false, scanner.Err()
+}
+
+// isKernelModuleBuiltin checks if a kernel module is compiled directly into the
+// kernel by parsing the /lib/modules/<kernel-version>/modules.builtin file.
+func isKernelModuleBuiltin(name string) (bool, error) {
+	ver, err := os.ReadFile(kernelOSReleasePath)
+	if err != nil {
+		return false, err
+	}
+
+	builtinPath := filepath.Join(
+		"/lib/modules", strings.TrimSpace(string(ver)), "modules.builtin",
+	)
+
+	f, err := os.Open(builtinPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	moduleName := strings.TrimSuffix(name, ".ko")
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		base := filepath.Base(strings.TrimSpace(scanner.Text()))
+		base = strings.TrimSuffix(base, filepath.Ext(base)) // catch any compressed, ie. .ko.gz
+		base = strings.TrimSuffix(base, ".ko")
+
+		if base == moduleName {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
 }
 
 const kernelOSReleasePath = "/proc/sys/kernel/osrelease"

--- a/utils/kernel_module.go
+++ b/utils/kernel_module.go
@@ -40,13 +40,15 @@ func isKernelModuleLoadable(name string) (bool, error) {
 	}
 	defer f.Close() // skipcq: GO-S2307
 
+	moduleName := strings.ReplaceAll(name, "-", "_")
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) == 0 {
 			continue
 		}
-		if strings.HasPrefix(fields[0], name) {
+		if fields[0] == moduleName {
 			return true, nil
 		}
 	}
@@ -74,7 +76,7 @@ func isKernelModuleBuiltin(name string) (bool, error) {
 	}
 	defer f.Close()
 
-	moduleName := strings.TrimSuffix(name, ".ko")
+	moduleName := strings.ReplaceAll(strings.TrimSuffix(name, ".ko"), "-", "_")
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -82,7 +84,7 @@ func isKernelModuleBuiltin(name string) (bool, error) {
 		base = strings.TrimSuffix(base, filepath.Ext(base)) // catch any compressed, ie. .ko.gz
 		base = strings.TrimSuffix(base, ".ko")
 
-		if base == moduleName {
+		if strings.ReplaceAll(base, "-", "_") == moduleName {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
For some use case where maybe a custom kernel is required to be used, it might make sense to build the kernel directly into the kernel instead of loading it as needed.

Right now we only support the latter when doing module checks, so if a module is built into kernel we will not catch it and erroneously throw errors if it's not in `/proc/modules`.