### PR TITLE
Fix node-scoped magic vars in inherited extras

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -793,21 +794,26 @@ func (c *CLab) processNodeExecs(nodeCfg *clabtypes.NodeConfig) {
 	}
 }
 
-// processNodeExtras replaces (in place) magic variables in node extras.
+// processNodeExtras replaces magic variables in node extras.
 func (c *CLab) processNodeExtras(nodeCfg *clabtypes.NodeConfig) {
 	if nodeCfg.Extras == nil {
 		return
 	}
 
 	r := c.magicVarReplacer(nodeCfg.ShortName)
+	extras := *nodeCfg.Extras
 
-	for i, e := range nodeCfg.Extras.CeosCopyToFlash {
-		nodeCfg.Extras.CeosCopyToFlash[i] = r.Replace(e)
+	extras.CeosCopyToFlash = slices.Clone(nodeCfg.Extras.CeosCopyToFlash)
+	for i, e := range extras.CeosCopyToFlash {
+		extras.CeosCopyToFlash[i] = r.Replace(e)
 	}
 
-	for i, e := range nodeCfg.Extras.SRLAgents {
-		nodeCfg.Extras.SRLAgents[i] = r.Replace(e)
+	extras.SRLAgents = slices.Clone(nodeCfg.Extras.SRLAgents)
+	for i, e := range extras.SRLAgents {
+		extras.SRLAgents[i] = r.Replace(e)
 	}
+
+	nodeCfg.Extras = &extras
 }
 
 // magicVarReplacer returns a string replacer that replaces all supported magic variables.

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -849,6 +849,48 @@ func TestExtrasInit(t *testing.T) {
 	}
 }
 
+func TestKindExtrasMagicVarsAreNodeScoped(t *testing.T) {
+	opts := []ClabOption{
+		WithTopoPath("test_data/topo16.yml", nil),
+	}
+
+	c, err := NewContainerLab(opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		node         string
+		wantCeosCopy []string
+	}{
+		"node1": {
+			node: "node1",
+			wantCeosCopy: []string{
+				"ceos-configs/node1/ceos-config",
+			},
+		},
+		"node2": {
+			node: "node2",
+			wantCeosCopy: []string{
+				"ceos-configs/node2/ceos-config",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			extras := c.Nodes[tc.node].Config().Extras
+			if extras == nil {
+				t.Fatal("extras is nil")
+			}
+
+			if d := cmp.Diff(extras.CeosCopyToFlash, tc.wantCeosCopy); d != "" {
+				t.Errorf("ceos-copy-to-flash mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
 func TestMagicVarReplacerWithoutNodeName(t *testing.T) {
 	c, err := NewContainerLab(WithTopoPath("test_data/topo14.yml", nil))
 	if err != nil {

--- a/core/test_data/topo16.yml
+++ b/core/test_data/topo16.yml
@@ -1,0 +1,12 @@
+name: topo16
+topology:
+  kinds:
+    arista_ceos:
+      extras:
+        ceos-copy-to-flash:
+          - ceos-configs/__clabNodeName__/ceos-config
+  nodes:
+    node1:
+      kind: arista_ceos
+    node2:
+      kind: arista_ceos


### PR DESCRIPTION
Fixes a regression in magic variable expansion for node extras inherited from `kinds`, `groups`, or `defaults`.

PR #3096 added magic variable expansion for `extras`, but `processNodeExtras` mutated the inherited `*Extras` object in place. When multiple nodes inherited the same kind-level `ceos-copy-to-flash` path containing `__clabNodeName__`, the first node's replacement was reused by later nodes.

This changes `processNodeExtras` to copy the extras value and mutable slices before replacement, keeping expansion node-scoped.

Tested with:

```bash
go test ./core -run 'Test(KindExtrasMagicVarsAreNodeScoped|ExtrasInit)$'
```
