### PR TITLE
feat(srl): cap SSH pubkey provisioning at the 32-key SR Linux limit

### DIFF
--- a/nodes/srl/version.go
+++ b/nodes/srl/version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/charmbracelet/log"
 	clabexec "github.com/srl-labs/containerlab/exec"
 	clabutils "github.com/srl-labs/containerlab/utils"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/mod/semver"
 )
 
@@ -52,6 +54,8 @@ var tlsConfigPre26_3 string
 
 //go:embed version_configs/tls.cfg
 var tlsConfig string
+
+const srlMaxSSHPubKeys = 32
 
 // renderSRLEmbeddedTemplate parses and executes an embedded default-config snippet with the same
 // func map as the main SRL default config template.
@@ -150,7 +154,33 @@ func (n *srl) setVersionSpecificParams(tplData *srlTemplateData) error {
 	// in srlinux >= v23.10+ linuxadmin and admin user ssh keys can only be configured via the cli
 	// so we add the keys to the template data for rendering.
 	if len(n.sshPubKeys) > 0 && (semver.Compare(v, "v23.10") >= 0 || n.swVersion.Major == "0") {
-		tplData.SSHPubKeys = clabutils.MarshalAndCatenateSSHPubKeys(n.sshPubKeys)
+		pubKeys := n.sshPubKeys
+		if len(n.sshPubKeys) > srlMaxSSHPubKeys {
+			log.Warnf(
+				"SR Linux node %q has %d SSH public keys, but SR Linux supports at most %d; "+
+					"only the first %d (sorted deterministically) will be provisioned",
+				n.Cfg.ShortName,
+				len(n.sshPubKeys),
+				srlMaxSSHPubKeys,
+				srlMaxSSHPubKeys,
+			)
+
+			// n.sshPubKeys is gathered from a map in RetrieveSSHPubKeys, so its
+			// order is non-deterministic. Sort a copy by the marshaled key bytes
+			// so the same 32 keys are retained on every deploy and a user does not
+			// randomly lose access to a key between runs.
+			pubKeys = make([]ssh.PublicKey, len(n.sshPubKeys))
+			copy(pubKeys, n.sshPubKeys)
+			sort.Slice(pubKeys, func(i, j int) bool {
+				return bytes.Compare(
+					ssh.MarshalAuthorizedKey(pubKeys[i]),
+					ssh.MarshalAuthorizedKey(pubKeys[j]),
+				) < 0
+			})
+			pubKeys = pubKeys[:srlMaxSSHPubKeys]
+		}
+
+		tplData.SSHPubKeys = clabutils.MarshalAndCatenateSSHPubKeys(pubKeys)
 	}
 
 	// in srlinux >= v24.3+ we add ACL rules to enable http and telnet access

--- a/nodes/srl/version_test.go
+++ b/nodes/srl/version_test.go
@@ -139,7 +139,13 @@ func TestSetVersionSpecificParamsSSHPubKeys(t *testing.T) {
 			keys := testSSHPubKeys(tt.keyCount)
 			n := &srl{
 				sshPubKeys: keys,
-				swVersion:  &SrlVersion{Major: "23", Minor: "10", Patch: "1", Build: "1", Commit: "test"},
+				swVersion: &SrlVersion{
+					Major:  "23",
+					Minor:  "10",
+					Patch:  "1",
+					Build:  "1",
+					Commit: "test",
+				},
 			}
 			n.Cfg = &clabtypes.NodeConfig{ShortName: "srl1"}
 
@@ -163,6 +169,7 @@ func TestSetVersionSpecificParamsSSHPubKeys(t *testing.T) {
 func TestSetVersionSpecificParamsSSHPubKeysDeterministic(t *testing.T) {
 	keys := testSSHPubKeys(46)
 	reversed := make([]ssh.PublicKey, len(keys))
+
 	for i := range keys {
 		reversed[len(keys)-1-i] = keys[i]
 	}
@@ -170,7 +177,13 @@ func TestSetVersionSpecificParamsSSHPubKeysDeterministic(t *testing.T) {
 	render := func(in []ssh.PublicKey) string {
 		n := &srl{
 			sshPubKeys: in,
-			swVersion:  &SrlVersion{Major: "23", Minor: "10", Patch: "1", Build: "1", Commit: "test"},
+			swVersion: &SrlVersion{
+				Major:  "23",
+				Minor:  "10",
+				Patch:  "1",
+				Build:  "1",
+				Commit: "test",
+			},
 		}
 		n.Cfg = &clabtypes.NodeConfig{ShortName: "srl1"}
 
@@ -183,7 +196,11 @@ func TestSetVersionSpecificParamsSSHPubKeysDeterministic(t *testing.T) {
 	}
 
 	if got, want := render(keys), render(reversed); got != want {
-		t.Fatalf("SSHPubKeys not deterministic across input orderings:\n got: %s\nwant: %s", got, want)
+		t.Fatalf(
+			"SSHPubKeys not deterministic across input orderings:\n got: %s\nwant: %s",
+			got,
+			want,
+		)
 	}
 }
 

--- a/nodes/srl/version_test.go
+++ b/nodes/srl/version_test.go
@@ -1,9 +1,14 @@
 package srl
 
 import (
+	"bytes"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	clabutils "github.com/srl-labs/containerlab/utils"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestParseVersionString(t *testing.T) {
@@ -79,4 +84,125 @@ func TestMajorMinorSemverString(t *testing.T) {
 			}
 		})
 	}
+}
+
+type testSSHPubKey struct {
+	id byte
+}
+
+func (k testSSHPubKey) Type() string {
+	return "ssh-test"
+}
+
+func (k testSSHPubKey) Marshal() []byte {
+	return []byte{k.id}
+}
+
+func (k testSSHPubKey) Verify(_ []byte, _ *ssh.Signature) error {
+	return nil
+}
+
+func testSSHPubKeys(count int) []ssh.PublicKey {
+	keys := make([]ssh.PublicKey, count)
+	for i := range keys {
+		keys[i] = testSSHPubKey{id: byte(i)}
+	}
+
+	return keys
+}
+
+func TestSetVersionSpecificParamsSSHPubKeys(t *testing.T) {
+	tests := map[string]struct {
+		keyCount  int
+		wantCount int
+	}{
+		"zero keys": {
+			keyCount:  0,
+			wantCount: 0,
+		},
+		"fewer than max": {
+			keyCount:  3,
+			wantCount: 3,
+		},
+		"exactly max": {
+			keyCount:  srlMaxSSHPubKeys,
+			wantCount: srlMaxSSHPubKeys,
+		},
+		"more than max": {
+			keyCount:  46,
+			wantCount: srlMaxSSHPubKeys,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			keys := testSSHPubKeys(tt.keyCount)
+			n := &srl{
+				sshPubKeys: keys,
+				swVersion:  &SrlVersion{Major: "23", Minor: "10", Patch: "1", Build: "1", Commit: "test"},
+			}
+			n.Cfg = &clabtypes.NodeConfig{ShortName: "srl1"}
+
+			tplData := &srlTemplateData{}
+			if err := n.setVersionSpecificParams(tplData); err != nil {
+				t.Fatalf("setVersionSpecificParams() error = %v", err)
+			}
+
+			want := clabutils.MarshalAndCatenateSSHPubKeys(wantSSHPubKeys(keys))
+			if diff := cmp.Diff(want, tplData.SSHPubKeys); diff != "" {
+				t.Fatalf("SSHPubKeys mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestSetVersionSpecificParamsSSHPubKeysDeterministic verifies that when more
+// than the limit of keys are present, the retained subset does not depend on
+// the order the keys were discovered in (RetrieveSSHPubKeys gathers them from a
+// map, so the input order is non-deterministic).
+func TestSetVersionSpecificParamsSSHPubKeysDeterministic(t *testing.T) {
+	keys := testSSHPubKeys(46)
+	reversed := make([]ssh.PublicKey, len(keys))
+	for i := range keys {
+		reversed[len(keys)-1-i] = keys[i]
+	}
+
+	render := func(in []ssh.PublicKey) string {
+		n := &srl{
+			sshPubKeys: in,
+			swVersion:  &SrlVersion{Major: "23", Minor: "10", Patch: "1", Build: "1", Commit: "test"},
+		}
+		n.Cfg = &clabtypes.NodeConfig{ShortName: "srl1"}
+
+		tplData := &srlTemplateData{}
+		if err := n.setVersionSpecificParams(tplData); err != nil {
+			t.Fatalf("setVersionSpecificParams() error = %v", err)
+		}
+
+		return tplData.SSHPubKeys
+	}
+
+	if got, want := render(keys), render(reversed); got != want {
+		t.Fatalf("SSHPubKeys not deterministic across input orderings:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// wantSSHPubKeys mirrors setVersionSpecificParams: it returns the keys verbatim
+// when at or below the limit, and the deterministically sorted first
+// srlMaxSSHPubKeys keys when above it.
+func wantSSHPubKeys(keys []ssh.PublicKey) []ssh.PublicKey {
+	if len(keys) <= srlMaxSSHPubKeys {
+		return keys
+	}
+
+	sorted := make([]ssh.PublicKey, len(keys))
+	copy(sorted, keys)
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(
+			ssh.MarshalAuthorizedKey(sorted[i]),
+			ssh.MarshalAuthorizedKey(sorted[j]),
+		) < 0
+	})
+
+	return sorted[:srlMaxSSHPubKeys]
 }


### PR DESCRIPTION
## Summary

SR Linux enforces a hard limit of 32 ssh-key entries per user. When the host running containerlab has more than 32 SSH public keys discovered (across `~/.ssh/*.pub` files and the ssh-agent), all of them were pushed into the SR Linux node config during post-deploy. SR Linux rejects the commit with `Too many elements of ssh-key, N present but requires at most 32` and the postdeploy task errors out.

This change, in `nodes/srl/version.go`, caps the keys provisioned to an SR Linux node at 32:

- When more than 32 keys are present, a warning is logged naming the node and the discovered count.
- Only the first 32 keys are provisioned. Because `RetrieveSSHPubKeys` gathers keys from a map (so the slice order is non-deterministic across runs), the keys are sorted by their marshaled authorized-key bytes before truncation. This keeps the retained subset stable between deploys so a user does not randomly lose access to one of their keys.

The change is SR Linux specific and leaves the existing version gate untouched.

## Why this matters

This fixes #3215: on developer machines that accumulate many keys, SR Linux nodes fail to come up cleanly. The maintainer confirmed this is a still-valid SR Linux case (distinct from the SR OS handling) and asked for a warning plus provisioning the first 32 keys. The deterministic ordering additionally guarantees the same 32 keys are chosen on every deploy.

## Testing

`go vet ./nodes/srl/...` and `go build ./nodes/srl/...` pass. Added table-driven tests in `nodes/srl/version_test.go`:

- Zero keys: no panic, empty `SSHPubKeys`.
- Under the limit and exactly 32 keys: all keys provisioned unchanged, no truncation.
- 46 keys: exactly 32 marshaled entries provisioned.
- Deterministic truncation: provisioning two different orderings of the same 46-key set yields identical output.

Fixes #3215
