### PR TITLE
Add components: support for vSIM

### DIFF
--- a/docs/manual/kinds/vr-sros.md
+++ b/docs/manual/kinds/vr-sros.md
@@ -93,8 +93,11 @@ The interface naming convention is: `1/1/X`, where `X` is the port number.
 
 /// admonition
     type: warning
-Nokia SR OS VM nodes currently only support the simplified interface alias `1/1/X`, where X denotes the port number.  
-Multi-chassis, multi-linecard setups, and channelized interfaces are not supported by interface aliasing at the moment, and you must fall back to the old `ethX`-based naming scheme ([see below](#custom-variants)) in these scenarios.
+Nokia SR OS VM nodes currently only support the simplified interface alias `1/1/X`, where X denotes the port number.
+
+Multi-chassis, multi-linecard setups, and channelized interfaces are only supported (in an experimental state) for interface aliasing when using the [components](#components) based variant definition.
+
+For all other cases (such as using TiMOS line based configuration) you must fall back to the old `ethX`-based naming scheme ([see below](#custom-variants)) in these scenarios.
 
 Data port numbering starts at `1`, like one would normally expect in the NOS.
 ///
@@ -217,6 +220,61 @@ type: "cpu=2 ram=4 slot=A chassis=ixr-r6 card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-2
 ```
 
 1. No `cp` nor `lc` markers are needed to define an integrated variant.
+
+#### Components
+
+Instead of hand-writing the TIMOS line, a custom variant can be described with the same structured `components` syntax, similarly to [SR-SIM](./sros.md#grouped-topology).
+
+Components are used to define the cards (slot and type) and sub-components of the card such as XIOMs and MDAs.
+
+When `components` are defined, the `type` for the node defines the chassis type (such as `sr-2s` or `ixr-r6d`) and is NOT a reference to a pre-packaged variant.
+
+See the below example topology of an SR-2s defined using `components`.
+
+```yaml
+name: sr-2s-comp-example
+topology:
+  nodes:
+    R1:
+      kind: nokia_sros
+      image: nokia_sros:24.10.R1
+      type: sr-2s
+      env:
+        NOKIA_SROS_SFM: sfm-2s
+      components:
+        - slot: A
+          type: cpm-2s
+        - slot: 1
+          type: xcm-2s
+          xiom:
+            - slot: 1
+              type: iom-s-3.0t
+              mda:
+                - slot: 1
+                  type: ms18-100gb-qsfp28
+```
+
+The same limitation as the TiMOS line variant definition applies that only a single CPM card can be defined. For dual CPM topologies, use [SR-SIM](./sros.md)
+
+##### Additional parameters
+
+By default `cpu`, `ram` and `max_nics` are derived automatically but can be easily overridden per component through that specific component's `env`.
+
+```yaml
+components:
+  - slot: 1
+    type: xcm-2s
+    env:
+      cpu: "4"        # vCPUs allocated to the card VM
+      ram: "6"        # RAM in GB
+      max_nics: "5"   # Give the card VM only 5 NICs
+    xiom:
+      - slot: 1
+        type: iom-s-3.0t
+        mda:
+          - slot: 1
+            type: ms18-100gb-qsfp28
+```
 
 ### Node configuration
 

--- a/nodes/vr_sros/interface_map.go
+++ b/nodes/vr_sros/interface_map.go
@@ -11,12 +11,17 @@ import (
 	clabutils "github.com/srl-labs/containerlab/utils"
 )
 
+// componentIfaceRegexp matches the SR OS port aliases used by components-based nodes:
+//   - direct MDA:    <slot>/<mda>/<port>                e.g. 2/1/3
+//   - XIOM MDA:      <slot>/x<xiom>/<mda>/<port>        e.g. 1/x1/2/3
+//   - connectorized: <slot>/<mda>/c<conn>/<port>       e.g. 1/1/c1/1  (FP4/FP5 QSFP-DD cages)
+//     (xiom + connector combine: <slot>/x<xiom>/<mda>/c<conn>/<port>)
 var componentIfaceRegexp = regexp.MustCompile(
-	`^(?P<slot>\d+)/(?:x(?P<xiom>\d+)/)?(?P<mda>\d+)/(?P<port>\d+)$`,
+	`^(?P<slot>\d+)/(?:x(?P<xiom>\d+)/)?(?P<mda>\d+)/(?:c(?P<conn>\d+)/)?(?P<port>\d+)$`,
 )
 
-const componentInterfaceHelp = "<slot>/<mda>/<port> or <slot>/x<xiom>/<mda>/<port> " +
-	"(e.g. 2/1/3 or 1/x1/2/3), or ethX"
+const componentInterfaceHelp = "<slot>/<mda>/<port>, <slot>/x<xiom>/<mda>/<port> or " +
+	"<slot>/<mda>/c<conn>/<port> (e.g. 2/1/3, 1/x1/2/3 or 1/1/c1/1), or ethX"
 
 func (s *vrSROS) CalculateInterfaceIndex(ifName string) (int, error) {
 	if len(s.Cfg.Components) == 0 {
@@ -42,30 +47,55 @@ func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (
 		return 0, fmt.Errorf("interface %q has an invalid port number", ifName)
 	}
 
+	// portIndex is the 1-based position of the port within its MDA. On FP4/FP5 cards each connector
+	// (cN) is one physical cage / one ethX, so the connector number is that position and the
+	// trailing port is the breakout sub-port - which doesn't map to a distinct veth.
+	portIndex := port
+	if groups["conn"] != "" {
+		conn, _ := strconv.Atoi(groups["conn"])
+		if port != 1 {
+			return 0, fmt.Errorf(
+				"interface %q uses a breakout sub-port (c%d/%d); breakout ports are not auto-mapped, use the ethX name instead",
+				ifName, conn, port,
+			)
+		}
+		portIndex = conn
+	}
+
 	lcs := make([]*clabtypes.Component, 0, len(components))
 	for _, c := range components {
 		if !isCPMSlot(c.Slot) {
 			lcs = append(lcs, c)
 		}
 	}
-	slices.SortFunc(lcs, func(a, b *clabtypes.Component) int {
-		as, _ := strconv.Atoi(strings.TrimSpace(a.Slot))
-		bs, _ := strconv.Atoi(strings.TrimSpace(b.Slot))
-		return as - bs
-	})
 
 	base := 0
 	var target *clabtypes.Component
-	for _, c := range lcs {
-		cs, _ := strconv.Atoi(strings.TrimSpace(c.Slot))
-		if cs == slot {
-			target = c
-			break
+	if len(lcs) == 0 {
+		// integrated chassis: the (single) card sits in slot A / unset but its data ports are
+		// addressed as slot 1 (e.g. sr-1, ixr-x). Map slot 1 to that card.
+		if slot != 1 {
+			return 0, fmt.Errorf("interface %q references slot %d, but integrated node only has data ports on slot 1", ifName, slot)
 		}
-		base += componentMaxNics(c)
-	}
-	if target == nil {
-		return 0, fmt.Errorf("interface %q references slot %d which has no line card component", ifName, slot)
+		target = components[0]
+	} else {
+		// distributed chassis: line cards own contiguous ethX windows in ascending slot order.
+		slices.SortFunc(lcs, func(a, b *clabtypes.Component) int {
+			as, _ := strconv.Atoi(strings.TrimSpace(a.Slot))
+			bs, _ := strconv.Atoi(strings.TrimSpace(b.Slot))
+			return as - bs
+		})
+		for _, c := range lcs {
+			cs, _ := strconv.Atoi(strings.TrimSpace(c.Slot))
+			if cs == slot {
+				target = c
+				break
+			}
+			base += componentMaxNics(c)
+		}
+		if target == nil {
+			return 0, fmt.Errorf("interface %q references slot %d which has no line card component", ifName, slot)
+		}
 	}
 
 	within, err := withinCardOffset(target, xiom, mda)
@@ -73,19 +103,37 @@ func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (
 		return 0, fmt.Errorf("interface %q: %w", ifName, err)
 	}
 
-	return base + within + port, nil
+	return base + within + portIndex, nil
 }
 
 // withinCardOffset returns the number of ethX ports that precede the requested (xiom, mda) within a
-// single line card. Ordering: direct MDAs (ascending slot) first, then each XIOM (ascending slot)
-// with its MDAs (ascending slot).
+// single card. Ordering: direct MDAs (ascending slot) first, then each XIOM (ascending slot) with
+// its MDAs (ascending slot).
+//
+// The XIOM in the alias is optional: SR OS may name an XIOM MDA's ports either with the xiom marker
+// (1/x1/1/c1/1) or without it (1/1/c1/1). When the alias omits the xiom (xiom == 0) the MDA is
+// matched by its number wherever it lives. Cards with no MDA list (e.g. an embedded IMM card such
+// as cpm-ixr-x/imm6-...) have a single implicit port group, so the offset is 0.
 func withinCardOffset(c *clabtypes.Component, xiom, mda int) (int, error) {
+	if len(c.MDA) == 0 && len(c.XIOM) == 0 {
+		return 0, nil
+	}
+
+	// matches reports whether the iterated MDA is the one the alias refers to. With an explicit
+	// xiom the (xiom, mda) pair must match exactly; without one, the mda number alone matches.
+	matches := func(isXiom bool, xiomSlot, mdaSlot int) bool {
+		if xiom > 0 {
+			return isXiom && xiomSlot == xiom && mdaSlot == mda
+		}
+		return mdaSlot == mda
+	}
+
 	offset := 0
 
 	directMDA := slices.Clone(c.MDA)
 	slices.SortFunc(directMDA, func(a, b clabtypes.MDA) int { return a.Slot - b.Slot })
 	for _, m := range directMDA {
-		if xiom == 0 && m.Slot == mda {
+		if matches(false, 0, m.Slot) {
 			return offset, nil
 		}
 		offset += mdaPortCount(m.Type)
@@ -97,7 +145,7 @@ func withinCardOffset(c *clabtypes.Component, xiom, mda int) (int, error) {
 		xmda := slices.Clone(x.MDA)
 		slices.SortFunc(xmda, func(a, b clabtypes.MDA) int { return a.Slot - b.Slot })
 		for _, m := range xmda {
-			if xiom == x.Slot && m.Slot == mda {
+			if matches(true, x.Slot, m.Slot) {
 				return offset, nil
 			}
 			offset += mdaPortCount(m.Type)

--- a/nodes/vr_sros/interface_map.go
+++ b/nodes/vr_sros/interface_map.go
@@ -11,11 +11,6 @@ import (
 	clabutils "github.com/srl-labs/containerlab/utils"
 )
 
-// componentIfaceRegexp matches the SR OS port aliases used by components-based nodes:
-//   - direct MDA:    <slot>/<mda>/<port>                e.g. 2/1/3
-//   - XIOM MDA:      <slot>/x<xiom>/<mda>/<port>        e.g. 1/x1/2/3
-//   - connectorized: <slot>/<mda>/c<conn>/<port>       e.g. 1/1/c1/1  (FP4/FP5 QSFP-DD cages)
-//     (xiom + connector combine: <slot>/x<xiom>/<mda>/c<conn>/<port>)
 var componentIfaceRegexp = regexp.MustCompile(
 	`^(?P<slot>\d+)/(?:x(?P<xiom>\d+)/)?(?P<mda>\d+)/(?:c(?P<conn>\d+)/)?(?P<port>\d+)$`,
 )
@@ -23,44 +18,70 @@ var componentIfaceRegexp = regexp.MustCompile(
 const componentInterfaceHelp = "<slot>/<mda>/<port>, <slot>/x<xiom>/<mda>/<port> or " +
 	"<slot>/<mda>/c<conn>/<port> (e.g. 2/1/3, 1/x1/2/3 or 1/1/c1/1), or ethX"
 
-func (s *vrSROS) CalculateInterfaceIndex(ifName string) (int, error) {
-	if len(s.Cfg.Components) == 0 {
-		return s.VRNode.DefaultNode.CalculateInterfaceIndex(ifName)
-	}
-	return componentInterfaceIndex(s.Cfg.Components, ifName)
+type srosPortAlias struct {
+	slot, xiom, mda, portIndex int
 }
 
-func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (int, error) {
+func parseSrosPortAlias(ifName string) (srosPortAlias, error) {
 	groups, err := clabutils.GetRegexpCaptureGroups(componentIfaceRegexp, ifName)
 	if err != nil {
-		return 0, err
+		return srosPortAlias{}, err
 	}
 
-	slot, _ := strconv.Atoi(groups["slot"])
-	mda, _ := strconv.Atoi(groups["mda"])
+	p := srosPortAlias{}
+	p.slot, _ = strconv.Atoi(groups["slot"])
+	p.mda, _ = strconv.Atoi(groups["mda"])
 	port, _ := strconv.Atoi(groups["port"])
-	xiom := 0
 	if groups["xiom"] != "" {
-		xiom, _ = strconv.Atoi(groups["xiom"])
+		p.xiom, _ = strconv.Atoi(groups["xiom"])
 	}
 	if port < 1 {
-		return 0, fmt.Errorf("interface %q has an invalid port number", ifName)
+		return p, fmt.Errorf("interface %q has an invalid port number", ifName)
 	}
 
-	// portIndex is the 1-based position of the port within its MDA. On FP4/FP5 cards each connector
-	// (cN) is one physical cage / one ethX, so the connector number is that position and the
-	// trailing port is the breakout sub-port - which doesn't map to a distinct veth.
-	portIndex := port
+	p.portIndex = port
 	if groups["conn"] != "" {
 		conn, _ := strconv.Atoi(groups["conn"])
 		if port != 1 {
-			return 0, fmt.Errorf(
+			return p, fmt.Errorf(
 				"interface %q uses a breakout sub-port (c%d/%d); breakout ports are not auto-mapped, use the ethX name instead",
 				ifName, conn, port,
 			)
 		}
-		portIndex = conn
+		p.portIndex = conn
 	}
+
+	return p, nil
+}
+
+func (s *vrSROS) CalculateInterfaceIndex(ifName string) (int, error) {
+	if len(s.Cfg.Components) == 0 {
+		return simpleInterfaceIndex(ifName)
+	}
+	return componentInterfaceIndex(s.Cfg.Components, ifName)
+}
+
+func simpleInterfaceIndex(ifName string) (int, error) {
+	p, err := parseSrosPortAlias(ifName)
+	if err != nil {
+		return 0, err
+	}
+	if p.slot != 1 || p.mda != 1 {
+		return 0, fmt.Errorf(
+			"interface %q cannot be mapped on a node without components: only slot 1 / mda 1 ports map automatically. "+
+				"Define components: on this node to use XIOM/multi-MDA/multi-slot port names (e.g. 1/x1/2/c24/1 or 4/1/c1/1), or use the ethX name",
+			ifName,
+		)
+	}
+	return p.portIndex, nil
+}
+
+func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (int, error) {
+	p, err := parseSrosPortAlias(ifName)
+	if err != nil {
+		return 0, err
+	}
+	slot, xiom, mda, portIndex := p.slot, p.xiom, p.mda, p.portIndex
 
 	lcs := make([]*clabtypes.Component, 0, len(components))
 	for _, c := range components {
@@ -72,14 +93,11 @@ func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (
 	base := 0
 	var target *clabtypes.Component
 	if len(lcs) == 0 {
-		// integrated chassis: the (single) card sits in slot A / unset but its data ports are
-		// addressed as slot 1 (e.g. sr-1, ixr-x). Map slot 1 to that card.
 		if slot != 1 {
 			return 0, fmt.Errorf("interface %q references slot %d, but integrated node only has data ports on slot 1", ifName, slot)
 		}
 		target = components[0]
 	} else {
-		// distributed chassis: line cards own contiguous ethX windows in ascending slot order.
 		slices.SortFunc(lcs, func(a, b *clabtypes.Component) int {
 			as, _ := strconv.Atoi(strings.TrimSpace(a.Slot))
 			bs, _ := strconv.Atoi(strings.TrimSpace(b.Slot))
@@ -106,21 +124,11 @@ func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (
 	return base + within + portIndex, nil
 }
 
-// withinCardOffset returns the number of ethX ports that precede the requested (xiom, mda) within a
-// single card. Ordering: direct MDAs (ascending slot) first, then each XIOM (ascending slot) with
-// its MDAs (ascending slot).
-//
-// The XIOM in the alias is optional: SR OS may name an XIOM MDA's ports either with the xiom marker
-// (1/x1/1/c1/1) or without it (1/1/c1/1). When the alias omits the xiom (xiom == 0) the MDA is
-// matched by its number wherever it lives. Cards with no MDA list (e.g. an embedded IMM card such
-// as cpm-ixr-x/imm6-...) have a single implicit port group, so the offset is 0.
 func withinCardOffset(c *clabtypes.Component, xiom, mda int) (int, error) {
 	if len(c.MDA) == 0 && len(c.XIOM) == 0 {
 		return 0, nil
 	}
 
-	// matches reports whether the iterated MDA is the one the alias refers to. With an explicit
-	// xiom the (xiom, mda) pair must match exactly; without one, the mda number alone matches.
 	matches := func(isXiom bool, xiomSlot, mdaSlot int) bool {
 		if xiom > 0 {
 			return isXiom && xiomSlot == xiom && mdaSlot == mda

--- a/nodes/vr_sros/interface_map.go
+++ b/nodes/vr_sros/interface_map.go
@@ -1,0 +1,108 @@
+package vr_sros
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+	clabutils "github.com/srl-labs/containerlab/utils"
+)
+
+var componentIfaceRegexp = regexp.MustCompile(
+	`^(?P<slot>\d+)/(?:x(?P<xiom>\d+)/)?(?P<mda>\d+)/(?P<port>\d+)$`,
+)
+
+const componentInterfaceHelp = "<slot>/<mda>/<port> or <slot>/x<xiom>/<mda>/<port> " +
+	"(e.g. 2/1/3 or 1/x1/2/3), or ethX"
+
+func (s *vrSROS) CalculateInterfaceIndex(ifName string) (int, error) {
+	if len(s.Cfg.Components) == 0 {
+		return s.VRNode.DefaultNode.CalculateInterfaceIndex(ifName)
+	}
+	return componentInterfaceIndex(s.Cfg.Components, ifName)
+}
+
+func componentInterfaceIndex(components []*clabtypes.Component, ifName string) (int, error) {
+	groups, err := clabutils.GetRegexpCaptureGroups(componentIfaceRegexp, ifName)
+	if err != nil {
+		return 0, err
+	}
+
+	slot, _ := strconv.Atoi(groups["slot"])
+	mda, _ := strconv.Atoi(groups["mda"])
+	port, _ := strconv.Atoi(groups["port"])
+	xiom := 0
+	if groups["xiom"] != "" {
+		xiom, _ = strconv.Atoi(groups["xiom"])
+	}
+	if port < 1 {
+		return 0, fmt.Errorf("interface %q has an invalid port number", ifName)
+	}
+
+	lcs := make([]*clabtypes.Component, 0, len(components))
+	for _, c := range components {
+		if !isCPMSlot(c.Slot) {
+			lcs = append(lcs, c)
+		}
+	}
+	slices.SortFunc(lcs, func(a, b *clabtypes.Component) int {
+		as, _ := strconv.Atoi(strings.TrimSpace(a.Slot))
+		bs, _ := strconv.Atoi(strings.TrimSpace(b.Slot))
+		return as - bs
+	})
+
+	base := 0
+	var target *clabtypes.Component
+	for _, c := range lcs {
+		cs, _ := strconv.Atoi(strings.TrimSpace(c.Slot))
+		if cs == slot {
+			target = c
+			break
+		}
+		base += componentMaxNics(c)
+	}
+	if target == nil {
+		return 0, fmt.Errorf("interface %q references slot %d which has no line card component", ifName, slot)
+	}
+
+	within, err := withinCardOffset(target, xiom, mda)
+	if err != nil {
+		return 0, fmt.Errorf("interface %q: %w", ifName, err)
+	}
+
+	return base + within + port, nil
+}
+
+// withinCardOffset returns the number of ethX ports that precede the requested (xiom, mda) within a
+// single line card. Ordering: direct MDAs (ascending slot) first, then each XIOM (ascending slot)
+// with its MDAs (ascending slot).
+func withinCardOffset(c *clabtypes.Component, xiom, mda int) (int, error) {
+	offset := 0
+
+	directMDA := slices.Clone(c.MDA)
+	slices.SortFunc(directMDA, func(a, b clabtypes.MDA) int { return a.Slot - b.Slot })
+	for _, m := range directMDA {
+		if xiom == 0 && m.Slot == mda {
+			return offset, nil
+		}
+		offset += mdaPortCount(m.Type)
+	}
+
+	xioms := slices.Clone(c.XIOM)
+	slices.SortFunc(xioms, func(a, b clabtypes.XIOM) int { return a.Slot - b.Slot })
+	for _, x := range xioms {
+		xmda := slices.Clone(x.MDA)
+		slices.SortFunc(xmda, func(a, b clabtypes.MDA) int { return a.Slot - b.Slot })
+		for _, m := range xmda {
+			if xiom == x.Slot && m.Slot == mda {
+				return offset, nil
+			}
+			offset += mdaPortCount(m.Type)
+		}
+	}
+
+	return 0, fmt.Errorf("mda %d (xiom %d) is not present in the slot %s card", mda, xiom, c.Slot)
+}

--- a/nodes/vr_sros/interface_map_test.go
+++ b/nodes/vr_sros/interface_map_test.go
@@ -34,6 +34,19 @@ func TestComponentInterfaceIndex(t *testing.T) {
 		{Slot: "2", Type: "iom4-e", MDA: clabtypes.MDAS{{Slot: 1, Type: "me6-10gb-sfp+"}}},
 	}
 
+	// integrated sr-1 with two direct MDAs, card in the default (unset -> A) slot, ports on slot 1.
+	integratedDirect := []*clabtypes.Component{
+		{MDA: clabtypes.MDAS{
+			{Slot: 1, Type: "me12-100gb-qsfp28"},
+			{Slot: 2, Type: "me16-25gb-sfp28+2-100gb-qsfp28"},
+		}},
+	}
+
+	// integrated ixr-x with an embedded IMM card and no MDA list (single implicit port group).
+	integratedEmbedded := []*clabtypes.Component{
+		{Slot: "A", Type: "cpm-ixr-x/imm6-qsfpdd+48-sfp56"},
+	}
+
 	tests := map[string]struct {
 		components []*clabtypes.Component
 		ifName     string
@@ -48,6 +61,22 @@ func TestComponentInterfaceIndex(t *testing.T) {
 		"xiom lc2 mda2 first port":  {sr2s, "2/x1/2/1", 61, false},
 		"direct lc1 port":           {directLCs, "1/1/3", 3, false},
 		"direct lc2 port offset":    {directLCs, "2/1/1", 7, false},
+		"connector lc1 c1":          {sr2s, "1/x1/1/c1/1", 1, false},
+		"connector lc1 c18":         {sr2s, "1/x1/1/c18/1", 18, false},
+		"connector lc1 mda2 c1":     {sr2s, "1/x1/2/c1/1", 19, false},
+		"connector lc2 c1":          {sr2s, "2/x1/1/c1/1", 43, false},
+		"breakout subport rejected": {sr2s, "1/x1/1/c1/2", 0, true},
+		// xiom omitted in the alias must map the same as the explicit-xiom form.
+		"xiom omitted mda1":         {sr2s, "1/1/c3/1", 3, false},
+		"xiom explicit mda1":        {sr2s, "1/x1/1/c3/1", 3, false},
+		"xiom omitted mda2":         {sr2s, "1/2/c18/1", 36, false},
+		"xiom omitted lc2 mda2":     {sr2s, "2/x1/2/c24/1", 84, false},
+		"integrated direct mda1":    {integratedDirect, "1/1/c1/1", 1, false},
+		"integrated direct mda1b":   {integratedDirect, "1/1/c10/1", 10, false},
+		"integrated direct mda2":    {integratedDirect, "1/2/c1/1", 13, false},
+		"integrated embedded c1":    {integratedEmbedded, "1/1/c1/1", 1, false},
+		"integrated embedded c34":   {integratedEmbedded, "1/1/c34/1", 34, false},
+		"integrated bad slot":       {integratedDirect, "2/1/c1/1", 0, true},
 		"unknown slot":              {directLCs, "3/1/1", 0, true},
 		"unknown mda":               {directLCs, "1/2/1", 0, true},
 		"xiom alias on direct card": {directLCs, "1/x1/1/1", 0, true},

--- a/nodes/vr_sros/interface_map_test.go
+++ b/nodes/vr_sros/interface_map_test.go
@@ -1,0 +1,67 @@
+package vr_sros
+
+import (
+	"testing"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentInterfaceIndex(t *testing.T) {
+	// distributed SR-2s: two line cards, each xcm-2s with one XIOM holding mda1 (18 ports) and
+	// mda2 (24 ports) -> max_nics 42 per line card.
+	sr2s := []*clabtypes.Component{
+		{Slot: "A", Type: "cpm-2s"},
+		{Slot: "1", Type: "xcm-2s", XIOM: clabtypes.XIOMS{
+			{Slot: 1, Type: "iom-s-3.0t", MDA: clabtypes.MDAS{
+				{Slot: 1, Type: "ms18-100gb-qsfp28"},
+				{Slot: 2, Type: "ms24-10/100gb-sfpdd"},
+			}},
+		}},
+		{Slot: "2", Type: "xcm-2s", XIOM: clabtypes.XIOMS{
+			{Slot: 1, Type: "iom-s-3.0t", MDA: clabtypes.MDAS{
+				{Slot: 1, Type: "ms18-100gb-qsfp28"},
+				{Slot: 2, Type: "ms24-10/100gb-sfpdd"},
+			}},
+		}},
+	}
+
+	// distributed chassis with two direct-MDA line cards, 6 ports each.
+	directLCs := []*clabtypes.Component{
+		{Slot: "A", Type: "cpm5"},
+		{Slot: "1", Type: "iom4-e", MDA: clabtypes.MDAS{{Slot: 1, Type: "me6-10gb-sfp+"}}},
+		{Slot: "2", Type: "iom4-e", MDA: clabtypes.MDAS{{Slot: 1, Type: "me6-10gb-sfp+"}}},
+	}
+
+	tests := map[string]struct {
+		components []*clabtypes.Component
+		ifName     string
+		want       int
+		wantErr    bool
+	}{
+		"xiom lc1 mda1 first port":  {sr2s, "1/x1/1/1", 1, false},
+		"xiom lc1 mda1 last port":   {sr2s, "1/x1/1/18", 18, false},
+		"xiom lc1 mda2 first port":  {sr2s, "1/x1/2/1", 19, false},
+		"xiom lc1 mda2 last port":   {sr2s, "1/x1/2/24", 42, false},
+		"xiom lc2 mda1 first port":  {sr2s, "2/x1/1/1", 43, false},
+		"xiom lc2 mda2 first port":  {sr2s, "2/x1/2/1", 61, false},
+		"direct lc1 port":           {directLCs, "1/1/3", 3, false},
+		"direct lc2 port offset":    {directLCs, "2/1/1", 7, false},
+		"unknown slot":              {directLCs, "3/1/1", 0, true},
+		"unknown mda":               {directLCs, "1/2/1", 0, true},
+		"xiom alias on direct card": {directLCs, "1/x1/1/1", 0, true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := componentInterfaceIndex(tc.components, tc.ifName)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/nodes/vr_sros/variant.go
+++ b/nodes/vr_sros/variant.go
@@ -1,0 +1,106 @@
+package vr_sros
+
+import (
+	"fmt"
+	"strings"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+func isCPMSlot(slot string) bool {
+	s := strings.ToUpper(strings.TrimSpace(slot))
+	return s == "" || s == "A" || s == "B"
+}
+
+func buildSrosVariant(chassis string, components []*clabtypes.Component, env map[string]string) (string, error) {
+	// vrnetlab vsim currently only supports single CPM
+	cpms := 0
+	for _, c := range components {
+		if isCPMSlot(c.Slot) {
+			cpms++
+		}
+	}
+	if cpms > 1 {
+		return "", fmt.Errorf("kind nokia_sros (vSIM) only supports a single CPM card, found multiple defined.")
+	}
+
+	distributed := len(components) > 1
+	for _, c := range components {
+		if !isCPMSlot(c.Slot) {
+			distributed = true
+		}
+	}
+
+	// fetch any global SFM env var on the base node
+	sfm := strings.TrimSpace(env["NOKIA_SROS_SFM"])
+
+	if !distributed {
+		return componentTimosLine(chassis, components[0], sfm), nil
+	}
+
+	segments := make([]string, 0, len(components))
+	// order CPM first
+	for _, c := range components {
+		if isCPMSlot(c.Slot) {
+			segments = append(segments, "cp: "+componentTimosLine(chassis, c, sfm))
+		}
+	}
+	// then line cards
+	for _, c := range components {
+		if !isCPMSlot(c.Slot) {
+			segments = append(segments, "lc: "+componentTimosLine(chassis, c, sfm))
+		}
+	}
+	// delimit
+	return strings.Join(segments, " ___ "), nil
+}
+
+func componentTimosLine(chassis string, c *clabtypes.Component, sfm string) string {
+	var parts []string
+
+	// fetch cpu/ram/max_nics from env: under slot:
+	if v := strings.TrimSpace(c.Env["cpu"]); v != "" {
+		parts = append(parts, "cpu="+v)
+	}
+	if v := strings.TrimSpace(c.Env["ram"]); v != "" {
+		parts = append(parts, "ram="+v)
+	}
+	if v := strings.TrimSpace(c.Env["max_nics"]); v != "" {
+		parts = append(parts, "max_nics="+v)
+	}
+
+	parts = append(parts, "chassis="+chassis)
+
+	slot := strings.TrimSpace(c.Slot)
+	if slot == "" {
+		// default to slot A for integrated components: method
+		slot = "A"
+	}
+	parts = append(parts, "slot="+slot)
+
+	// support slot defined sfm
+	// else fallback to SRSIM env var
+	// NOKIA_SROS_SFM.
+	if c.SFM != "" {
+		parts = append(parts, "sfm="+c.SFM)
+	} else if sfm != "" {
+		parts = append(parts, "sfm="+sfm)
+	}
+
+	if c.Type != "" {
+		parts = append(parts, "card="+c.Type)
+	}
+
+	for _, x := range c.XIOM {
+		parts = append(parts, fmt.Sprintf("xiom/x%d=%s", x.Slot, x.Type))
+		for _, m := range x.MDA {
+			parts = append(parts, fmt.Sprintf("mda/x%d/%d=%s", x.Slot, m.Slot, m.Type))
+		}
+	}
+
+	for _, m := range c.MDA {
+		parts = append(parts, fmt.Sprintf("mda/%d=%s", m.Slot, m.Type))
+	}
+
+	return strings.Join(parts, " ")
+}

--- a/nodes/vr_sros/variant.go
+++ b/nodes/vr_sros/variant.go
@@ -2,6 +2,8 @@ package vr_sros
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	clabtypes "github.com/srl-labs/containerlab/types"
@@ -67,6 +69,9 @@ func componentTimosLine(chassis string, c *clabtypes.Component, sfm string) stri
 	}
 	if v := strings.TrimSpace(c.Env["max_nics"]); v != "" {
 		parts = append(parts, "max_nics="+v)
+	} else if n := componentPortCount(c); n > 0 {
+		// else try to automatically derive it
+		parts = append(parts, "max_nics="+strconv.Itoa(n))
 	}
 
 	parts = append(parts, "chassis="+chassis)
@@ -103,4 +108,31 @@ func componentTimosLine(chassis string, c *clabtypes.Component, sfm string) stri
 	}
 
 	return strings.Join(parts, " ")
+}
+
+// figure out the max_nics per slot
+func componentPortCount(c *clabtypes.Component) int {
+	total := 0
+	for _, m := range c.MDA {
+		total += mdaPortCount(m.Type)
+	}
+	for _, x := range c.XIOM {
+		for _, m := range x.MDA {
+			total += mdaPortCount(m.Type)
+		}
+	}
+	return total
+}
+
+// get the first number from the mda type, delimit based on the '+'
+// for mdas with multiple formfactors/speeds.
+func mdaPortCount(mdaType string) int {
+	total := 0
+	for group := range strings.SplitSeq(mdaType, "+") {
+		if m := regexp.MustCompile(`^[a-zA-Z]*(\d+)`).FindStringSubmatch(group); m != nil {
+			n, _ := strconv.Atoi(m[1])
+			total += n
+		}
+	}
+	return total
 }

--- a/nodes/vr_sros/variant.go
+++ b/nodes/vr_sros/variant.go
@@ -67,10 +67,7 @@ func componentTimosLine(chassis string, c *clabtypes.Component, sfm string) stri
 	if v := strings.TrimSpace(c.Env["ram"]); v != "" {
 		parts = append(parts, "ram="+v)
 	}
-	if v := strings.TrimSpace(c.Env["max_nics"]); v != "" {
-		parts = append(parts, "max_nics="+v)
-	} else if n := componentPortCount(c); n > 0 {
-		// else try to automatically derive it
+	if n := componentMaxNics(c); n > 0 {
 		parts = append(parts, "max_nics="+strconv.Itoa(n))
 	}
 
@@ -108,6 +105,15 @@ func componentTimosLine(chassis string, c *clabtypes.Component, sfm string) stri
 	}
 
 	return strings.Join(parts, " ")
+}
+
+func componentMaxNics(c *clabtypes.Component) int {
+	if v := strings.TrimSpace(c.Env["max_nics"]); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return componentPortCount(c)
 }
 
 // figure out the max_nics per slot

--- a/nodes/vr_sros/variant_test.go
+++ b/nodes/vr_sros/variant_test.go
@@ -1,0 +1,99 @@
+package vr_sros
+
+import (
+	"testing"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSrosVariant(t *testing.T) {
+	tests := map[string]struct {
+		chassis    string
+		components []*clabtypes.Component
+		env        map[string]string
+		want       string
+		wantErr    bool
+	}{
+		"node-level-sfm-applied-to-every-segment": {
+			chassis: "sr-2s",
+			env:     map[string]string{"NOKIA_SROS_SFM": "sfm-2s"},
+			components: []*clabtypes.Component{
+				{Slot: "A", Type: "cpm-2s"},
+				{Slot: "1", Type: "xcm-2s", SFM: "sfm-override"},
+			},
+			want: "cp: chassis=sr-2s slot=A sfm=sfm-2s card=cpm-2s ___ " +
+				"lc: chassis=sr-2s slot=1 sfm=sfm-override card=xcm-2s",
+		},
+		"two-cpms-rejected": {
+			chassis: "sr-7",
+			components: []*clabtypes.Component{
+				{Slot: "A", Type: "cpm5"},
+				{Slot: "B", Type: "cpm5"},
+			},
+			wantErr: true,
+		},
+		"integrated-single-component": {
+			chassis: "ixr-r6",
+			components: []*clabtypes.Component{
+				{
+					Slot: "A",
+					Type: "cpiom-ixr-r6",
+					Env:  map[string]string{"cpu": "2", "ram": "4"},
+					MDA:  clabtypes.MDAS{{Slot: 1, Type: "m6-10g-sfp++4-25g-sfp28"}},
+				},
+			},
+			want: "cpu=2 ram=4 chassis=ixr-r6 slot=A card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28",
+		},
+		"integrated-empty-slot-defaults-to-A": {
+			chassis: "sr-1",
+			components: []*clabtypes.Component{
+				{Type: "iom-1", MDA: clabtypes.MDAS{{Slot: 1, Type: "me6-100gb-qsfp28"}}},
+			},
+			want: "chassis=sr-1 slot=A card=iom-1 mda/1=me6-100gb-qsfp28",
+		},
+		"distributed-cpm-and-lc": {
+			chassis: "ixr-e",
+			components: []*clabtypes.Component{
+				{Slot: "A", Type: "cpm-ixr-e", Env: map[string]string{"cpu": "2", "ram": "4"}},
+				{
+					Slot: "1",
+					Type: "imm24-sfp++8-sfp28+2-qsfp28",
+					Env:  map[string]string{"cpu": "2", "ram": "4", "max_nics": "34"},
+					MDA:  clabtypes.MDAS{{Slot: 1, Type: "m24-sfp++8-sfp28+2-qsfp28"}},
+				},
+			},
+			want: "cp: cpu=2 ram=4 chassis=ixr-e slot=A card=cpm-ixr-e ___ " +
+				"lc: cpu=2 ram=4 max_nics=34 chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28",
+		},
+		"distributed-sfm-and-xiom": {
+			chassis: "sr-2s",
+			components: []*clabtypes.Component{
+				{Slot: "A", SFM: "sfm-2s", Type: "cpm-2s"},
+				{
+					Slot: "1",
+					SFM:  "sfm-2s",
+					Type: "xcm-2s",
+					XIOM: clabtypes.XIOMS{
+						{Slot: 1, Type: "iom-s-3.0t", MDA: clabtypes.MDAS{{Slot: 1, Type: "ms8-100gb-sfpdd+2-100gb-qsfp28"}}},
+					},
+				},
+			},
+			want: "cp: chassis=sr-2s slot=A sfm=sfm-2s card=cpm-2s ___ " +
+				"lc: chassis=sr-2s slot=1 sfm=sfm-2s card=xcm-2s xiom/x1=iom-s-3.0t mda/x1/1=ms8-100gb-sfpdd+2-100gb-qsfp28",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildSrosVariant(tc.chassis, tc.components, tc.env)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/nodes/vr_sros/variant_test.go
+++ b/nodes/vr_sros/variant_test.go
@@ -44,14 +44,26 @@ func TestBuildSrosVariant(t *testing.T) {
 					MDA:  clabtypes.MDAS{{Slot: 1, Type: "m6-10g-sfp++4-25g-sfp28"}},
 				},
 			},
-			want: "cpu=2 ram=4 chassis=ixr-r6 slot=A card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28",
+			want: "cpu=2 ram=4 max_nics=10 chassis=ixr-r6 slot=A card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28",
+		},
+		"env-max_nics-overrides-derived": {
+			chassis: "ixr-r6",
+			components: []*clabtypes.Component{
+				{
+					Slot: "A",
+					Type: "cpiom-ixr-r6",
+					Env:  map[string]string{"max_nics": "99"},
+					MDA:  clabtypes.MDAS{{Slot: 1, Type: "m6-10g-sfp++4-25g-sfp28"}},
+				},
+			},
+			want: "max_nics=99 chassis=ixr-r6 slot=A card=cpiom-ixr-r6 mda/1=m6-10g-sfp++4-25g-sfp28",
 		},
 		"integrated-empty-slot-defaults-to-A": {
 			chassis: "sr-1",
 			components: []*clabtypes.Component{
 				{Type: "iom-1", MDA: clabtypes.MDAS{{Slot: 1, Type: "me6-100gb-qsfp28"}}},
 			},
-			want: "chassis=sr-1 slot=A card=iom-1 mda/1=me6-100gb-qsfp28",
+			want: "max_nics=6 chassis=sr-1 slot=A card=iom-1 mda/1=me6-100gb-qsfp28",
 		},
 		"distributed-cpm-and-lc": {
 			chassis: "ixr-e",
@@ -81,7 +93,7 @@ func TestBuildSrosVariant(t *testing.T) {
 				},
 			},
 			want: "cp: chassis=sr-2s slot=A sfm=sfm-2s card=cpm-2s ___ " +
-				"lc: chassis=sr-2s slot=1 sfm=sfm-2s card=xcm-2s xiom/x1=iom-s-3.0t mda/x1/1=ms8-100gb-sfpdd+2-100gb-qsfp28",
+				"lc: max_nics=10 chassis=sr-2s slot=1 sfm=sfm-2s card=xcm-2s xiom/x1=iom-s-3.0t mda/x1/1=ms8-100gb-sfpdd+2-100gb-qsfp28",
 		},
 	}
 
@@ -96,4 +108,36 @@ func TestBuildSrosVariant(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestMdaPortCount(t *testing.T) {
+	cases := map[string]int{
+		"m24-sfp++8-sfp28+2-qsfp28":      34,
+		"m6-10g-sfp++1-100g-qsfp28":      7,
+		"m48-sfp++6-qsfp28":              54,
+		"m32-qsfp28+4-qsfpdd":            36,
+		"m4-1g-tx+20-1g-sfp+6-10g-sfp+":  30,
+		"ms8-100gb-sfpdd+2-100gb-qsfp28": 10,
+		"s36-100gb-qsfp28":               36,
+		"ms24-10/100gb-sfpdd":            24,
+	}
+	for mda, want := range cases {
+		t.Run(mda, func(t *testing.T) {
+			assert.Equal(t, want, mdaPortCount(mda))
+		})
+	}
+}
+
+func TestComponentPortCountSumsDirectAndXiomMdas(t *testing.T) {
+	c := &clabtypes.Component{
+		Slot: "1",
+		Type: "xcm-2s",
+		XIOM: clabtypes.XIOMS{
+			{Slot: 1, Type: "iom-s-3.0t", MDA: clabtypes.MDAS{
+				{Slot: 1, Type: "ms18-100gb-qsfp28"},
+				{Slot: 2, Type: "ms24-10/100gb-sfpdd"},
+			}},
+		},
+	}
+	assert.Equal(t, 42, componentPortCount(c))
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -109,6 +109,17 @@ func (s *vrSROS) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) e
 	if s.Cfg.NodeType == "" {
 		s.Cfg.NodeType = vrsrosDefaultType
 	}
+
+	// if user defined components: are used, parse them.
+	variant := s.Cfg.NodeType
+	if len(s.Cfg.Components) > 0 {
+		var err error
+		variant, err = buildSrosVariant(s.Cfg.NodeType, s.Cfg.Components, s.Cfg.Env)
+		if err != nil {
+			return err
+		}
+	}
+
 	// env vars are used to set launch.py arguments in vrnetlab container
 	defEnv := map[string]string{
 		"CONNECTION_MODE":    clabnodes.VrDefConnMode,
@@ -128,19 +139,12 @@ func (s *vrSROS) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) e
 		"--trace --connection-mode %s --hostname %s --variant %q",
 		s.Cfg.Env["CONNECTION_MODE"],
 		s.Cfg.ShortName,
-		s.Cfg.NodeType,
+		variant,
 	)
 
 	s.InterfaceRegexp = InterfaceRegexp
 	s.InterfaceOffset = InterfaceOffset
 	s.InterfaceHelp = InterfaceHelp
-
-	if len(s.Cfg.Components) > 0 {
-		log.Warnf(
-			"node %q: kind nokia_sros (vrnetlab) does not support components; components are ignored. Use kind nokia_srsim for distributed/chassis topologies with components",
-			s.Cfg.ShortName,
-		)
-	}
 
 	return nil
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -142,14 +142,9 @@ func (s *vrSROS) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) e
 		variant,
 	)
 
-	s.InterfaceRegexp = InterfaceRegexp
+	s.InterfaceRegexp = componentIfaceRegexp
 	s.InterfaceOffset = InterfaceOffset
-	s.InterfaceHelp = InterfaceHelp
-
-	if len(s.Cfg.Components) > 0 {
-		s.InterfaceRegexp = componentIfaceRegexp
-		s.InterfaceHelp = componentInterfaceHelp
-	}
+	s.InterfaceHelp = componentInterfaceHelp
 
 	return nil
 }

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -146,6 +146,11 @@ func (s *vrSROS) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) e
 	s.InterfaceOffset = InterfaceOffset
 	s.InterfaceHelp = InterfaceHelp
 
+	if len(s.Cfg.Components) > 0 {
+		s.InterfaceRegexp = componentIfaceRegexp
+		s.InterfaceHelp = componentInterfaceHelp
+	}
+
 	return nil
 }
 

--- a/nodes/vr_sros/vr-sros_test.go
+++ b/nodes/vr_sros/vr-sros_test.go
@@ -140,7 +140,7 @@ func Test_vrSROS_Init_withComponents_buildsVariant(t *testing.T) {
 	err := s.Init(cfg, clabnodes.WithMgmtNet(mgmt))
 	require.NoError(t, err)
 	assert.Contains(t, s.Cfg.Cmd, "cp: chassis=ixr-e slot=A card=cpm-ixr-e ___ "+
-		"lc: chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28")
+		"lc: max_nics=34 chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28")
 }
 
 func Test_vrSROS_Init_withMultipleCPMs_errors(t *testing.T) {

--- a/nodes/vr_sros/vr-sros_test.go
+++ b/nodes/vr_sros/vr-sros_test.go
@@ -123,19 +123,39 @@ func TestAosCXInterfaceParsing(t *testing.T) {
 	}
 }
 
-func Test_vrSROS_Init_withComponents_warns(t *testing.T) {
+func Test_vrSROS_Init_withComponents_buildsVariant(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &clabtypes.NodeConfig{
-		ShortName:  "sros1",
-		LabDir:     dir,
-		Env:        map[string]string{},
-		Components: []*clabtypes.Component{{Slot: "A"}},
+		ShortName: "sros1",
+		LabDir:    dir,
+		NodeType:  "ixr-e",
+		Env:       map[string]string{},
+		Components: []*clabtypes.Component{
+			{Slot: "A", Type: "cpm-ixr-e"},
+			{Slot: "1", Type: "imm24-sfp++8-sfp28+2-qsfp28", MDA: clabtypes.MDAS{{Slot: 1, Type: "m24-sfp++8-sfp28+2-qsfp28"}}},
+		},
 	}
 	mgmt := &clabtypes.MgmtNet{IPv4Subnet: "172.20.20.0/24", IPv6Subnet: "2001:db8::/64"}
 	s := new(vrSROS)
 	err := s.Init(cfg, clabnodes.WithMgmtNet(mgmt))
 	require.NoError(t, err)
-	assert.NotEmpty(t, s.Cfg.Components)
+	assert.Contains(t, s.Cfg.Cmd, "cp: chassis=ixr-e slot=A card=cpm-ixr-e ___ "+
+		"lc: chassis=ixr-e slot=1 card=imm24-sfp++8-sfp28+2-qsfp28 mda/1=m24-sfp++8-sfp28+2-qsfp28")
+}
+
+func Test_vrSROS_Init_withMultipleCPMs_errors(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &clabtypes.NodeConfig{
+		ShortName:  "sros1",
+		LabDir:     dir,
+		NodeType:   "sr-7",
+		Env:        map[string]string{},
+		Components: []*clabtypes.Component{{Slot: "A", Type: "cpm5"}, {Slot: "B", Type: "cpm5"}},
+	}
+	mgmt := &clabtypes.MgmtNet{IPv4Subnet: "172.20.20.0/24", IPv6Subnet: "2001:db8::/64"}
+	s := new(vrSROS)
+	err := s.Init(cfg, clabnodes.WithMgmtNet(mgmt))
+	require.Error(t, err)
 }
 
 func Test_vrSROS_verifyNokiaSrosImage(t *testing.T) {


### PR DESCRIPTION
Some of us who work with SR OS a lot got addicted a bit to the `components:`, however this is currently SR-SIM only which is only 25.7 onwards.

While some of the older versions of SR OS are within support, we sometimes need to use them in clab, thus meaning we have to use the vSIM which brings the *fun* of building the TiMOS line.

Instead we can parse `components:` and let clab try to build it for us and make life easy.

Few things are wonky since vSIMs are VMs, decided to put the `max_nics`, `cpu` and `ram` parameters as env vars under the slot.