### PR TITLE
feat: support SSH IdentityFile via node credentials

### DIFF
--- a/core/assets/ssh_config.go.tpl
+++ b/core/assets/ssh_config.go.tpl
@@ -6,6 +6,9 @@ Host{{- range .Names }} {{ . }}{{- end }}
 	{{-  if ne $node.Username ""}}
 	User {{ $node.Username }}
 	{{- end }}
+	{{- if ne $node.IdentityFile "" }}
+	IdentityFile "{{ $node.IdentityFile }}"
+	{{- end }}
 	StrictHostKeyChecking=no
 	UserKnownHostsFile=/dev/null
 	{{- if ne $node.SSHConfig.PubkeyAuthentication "" }}

--- a/core/config.go
+++ b/core/config.go
@@ -253,6 +253,14 @@ func (c *CLab) createNodeCfg( //nolint: funlen
 	// defaults from the node registry.
 	nodeCfg.Credentials.Username = c.Config.Topology.GetNodeUsername(nodeName)
 	nodeCfg.Credentials.Password = c.Config.Topology.GetNodePassword(nodeName)
+	// Resolve the SSH identity-file path against the topology directory (and expand ~) so the
+	// rendered ssh_config works regardless of the cwd ssh is later invoked from.
+	if identityFile := c.Config.Topology.GetNodeIdentityFile(nodeName); identityFile != "" {
+		nodeCfg.Credentials.IdentityFile = clabutils.ResolvePath(
+			identityFile,
+			c.TopoPaths.TopologyFileDir(),
+		)
+	}
 
 	if nodeCfg.Credentials.Username == "" || nodeCfg.Credentials.Password == "" {
 		kind := strings.ToLower(c.Config.Topology.GetNodeKind(nodeName))

--- a/core/sshconfig.go
+++ b/core/sshconfig.go
@@ -23,9 +23,10 @@ type SSHConfigTmpl struct {
 // SSHConfigNodeTmpl represents values for a single node
 // in the sshconfig template.
 type SSHConfigNodeTmpl struct {
-	Names     []string
-	Username  string
-	SSHConfig *clabtypes.SSHConfig
+	Names        []string
+	Username     string
+	IdentityFile string
+	SSHConfig    *clabtypes.SSHConfig
 }
 
 // sshConfigTemplate is the SSH config template.
@@ -72,9 +73,10 @@ func (c *CLab) addSSHConfig() error {
 	for _, n := range c.Nodes {
 		cfg := n.Config()
 		nodeData := SSHConfigNodeTmpl{
-			Names:     []string{cfg.LongName},
-			Username:  cfg.Credentials.Username,
-			SSHConfig: n.GetSSHConfig(),
+			Names:        []string{cfg.LongName},
+			Username:     cfg.Credentials.Username,
+			IdentityFile: cfg.Credentials.IdentityFile,
+			SSHConfig:    n.GetSSHConfig(),
 		}
 		if len(cfg.ContainerID) >= 12 {
 			nodeData.Names = append(nodeData.Names, cfg.ContainerID[:12])

--- a/core/sshconfig_test.go
+++ b/core/sshconfig_test.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package core
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+// renderSSHConfig renders the embedded ssh_config template for the given nodes and
+// returns the produced config text. It mirrors the rendering done in addSSHConfig.
+func renderSSHConfig(t *testing.T, nodes []SSHConfigNodeTmpl) string {
+	t.Helper()
+
+	tmpl, err := template.New("sshconfig").Parse(sshConfigTemplate)
+	if err != nil {
+		t.Fatalf("failed to parse ssh config template: %v", err)
+	}
+
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, &SSHConfigTmpl{
+		TopologyName: "test",
+		Nodes:        nodes,
+	}); err != nil {
+		t.Fatalf("failed to execute ssh config template: %v", err)
+	}
+
+	return sb.String()
+}
+
+func TestSSHConfigIdentityFileRendering(t *testing.T) {
+	tests := []struct {
+		name          string
+		node          SSHConfigNodeTmpl
+		wantContains  []string
+		wantNotContns []string
+	}{
+		{
+			name: "identity file rendered when set",
+			node: SSHConfigNodeTmpl{
+				Names:        []string{"clab-test-node"},
+				Username:     "admin",
+				IdentityFile: "/home/user/.ssh/id_node",
+				SSHConfig:    &clabtypes.SSHConfig{},
+			},
+			wantContains: []string{
+				"User admin",
+				`IdentityFile "/home/user/.ssh/id_node"`,
+			},
+		},
+		{
+			name: "no identity file line when unset",
+			node: SSHConfigNodeTmpl{
+				Names:     []string{"clab-test-node"},
+				Username:  "admin",
+				SSHConfig: &clabtypes.SSHConfig{},
+			},
+			wantContains: []string{"User admin"},
+			wantNotContns: []string{
+				"IdentityFile",
+			},
+		},
+		{
+			name: "identity file rendered without username",
+			node: SSHConfigNodeTmpl{
+				Names:        []string{"clab-test-node"},
+				IdentityFile: "~/.ssh/id_node",
+				SSHConfig:    &clabtypes.SSHConfig{},
+			},
+			wantContains: []string{`IdentityFile "~/.ssh/id_node"`},
+			wantNotContns: []string{
+				"User ",
+			},
+		},
+		{
+			name: "identity file with spaces is quoted",
+			node: SSHConfigNodeTmpl{
+				Names:        []string{"clab-test-node"},
+				IdentityFile: "/home/user/my keys/id_node",
+				SSHConfig:    &clabtypes.SSHConfig{},
+			},
+			wantContains: []string{`IdentityFile "/home/user/my keys/id_node"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderSSHConfig(t, []SSHConfigNodeTmpl{tt.node})
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("rendered config missing %q\n--- config ---\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.wantNotContns {
+				if strings.Contains(got, notWant) {
+					t.Errorf("rendered config unexpectedly contains %q\n--- config ---\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -384,7 +384,11 @@ topology:
 
 To override the default username or password used when accessing a node over SSH, NETCONF, gNMI, and similar interfaces, use the `credentials` mapping with `username` and `password` keys. When not set, the kind's defaults defined in the node implementation are used. You can define `credentials` at `defaults`, `kinds`, `groups`, and per-node levels; more specific levels take precedence.
 
-Containerlab picks **one** `credentials` object from the most specific level where **either** `username` or `password` is set. Both values on that level are used as-is (the other key may be empty); values are **not** merged from less specific levels. After the topology is applied, the node implementation may still fill missing username or password from its built-in defaults.
+Containerlab picks **one** `credentials` object from the most specific level where **any** of `username`, `password` or `identity-file` is set. The values on that level are used as-is (the other keys may be empty); values are **not** merged from less specific levels. After the topology is applied, the node implementation may still fill missing username or password from its built-in defaults.
+
+The optional `identity-file` key sets the path to the SSH private key used to authenticate against the node. When present, containerlab renders an `IdentityFile` directive into the generated per-lab SSH client config (`/etc/ssh/ssh_config.d/clab-<lab>.conf`), so `ssh <node>` uses that key without a manual `-i` flag. As with `startup-config`, a relative path is resolved against the topology file's directory and a leading `~` is expanded to the home directory, so the key resolves correctly regardless of where `ssh` is later invoked from. The rendered path is double-quoted so paths containing spaces are handled correctly.
+
+Unlike `username`/`password`, the `identity-file` value is resolved on its own precedence chain (node, then group, then kind, then defaults). It is therefore independent of the credentials object selected above: a node-level `identity-file` combined with a kind-level `username`/`password` uses the kind credentials and the node's identity-file together. This keeps generated Ansible/Nornir inventories from being affected by an identity-file that is only used for the SSH client config.
 
 ```yaml
 topology:
@@ -402,6 +406,7 @@ topology:
       credentials:
         username: node1-user
         password: node1-password
+        identity-file: ~/.ssh/node1_key
 ```
 
 ### user

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -216,6 +216,11 @@
                             "type": "string",
                             "description": "password to use when accessing the node over SSH/NETCONF/GNMI/etc.",
                             "markdownDescription": "[password](https://containerlab.dev/manual/nodes/#credentials) to use when accessing the node over SSH/NETCONF/GNMI/etc."
+                        },
+                        "identity-file": {
+                            "type": "string",
+                            "description": "path to the SSH private key used to authenticate against the node; rendered as an IdentityFile directive in the generated ssh_config.",
+                            "markdownDescription": "path to the SSH private key used to authenticate against the node, rendered as an [IdentityFile](https://containerlab.dev/manual/nodes/#credentials) directive in the generated ssh_config."
                         }
                     }
                 },

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -16,6 +16,11 @@ const (
 type NodeCredentials struct {
 	Username string `json:"username,omitempty" yaml:"username,omitempty"`
 	Password string `json:"-" yaml:"password,omitempty"`
+	// IdentityFile is the path to the SSH private key used to authenticate against the node.
+	// When set it is rendered as an IdentityFile directive in the generated ssh_config. Relative
+	// paths are resolved against the topology directory and a leading ~ is expanded; the value is
+	// double-quoted on render so spaces are handled.
+	IdentityFile string `json:"identity-file,omitempty" yaml:"identity-file,omitempty"`
 }
 
 // NodeDefinition represents a configuration a given node can have in the lab definition file.

--- a/types/topology.go
+++ b/types/topology.go
@@ -880,6 +880,10 @@ func (t *Topology) GetNodeAliases(nodeName string) []string {
 	return nodeDefinition.Aliases
 }
 
+// credentialsPresent reports whether a credentials block supplies a username/password pair. The
+// identity-file is resolved on its own precedence chain (resolveTopologyIdentityFile) and is
+// intentionally excluded here so it does not influence the username/password winning level used by
+// inventory generation.
 func credentialsPresent(c NodeCredentials) bool {
 	return c.Username != "" || c.Password != ""
 }
@@ -921,6 +925,37 @@ func (t *Topology) resolveTopologyCredentials(
 	return "", "", CredentialTopologyUnset
 }
 
+// resolveTopologyIdentityFile returns the SSH identity-file path from the most specific topology
+// level where it is set (node, then group, then kind, then defaults). It is resolved independently
+// of username/password so a node may set only identity-file and still have it apply, without
+// affecting the username/password winning level (see resolveTopologyCredentials).
+func (t *Topology) resolveTopologyIdentityFile(nodeName string) string {
+	nodeDefinition, ok := t.Nodes[nodeName]
+	if !ok {
+		return ""
+	}
+
+	if nodeDefinition != nil && nodeDefinition.Credentials.IdentityFile != "" {
+		return nodeDefinition.Credentials.IdentityFile
+	}
+
+	if group := t.GetGroup(t.GetNodeGroup(nodeName)); group != nil &&
+		group.Credentials.IdentityFile != "" {
+		return group.Credentials.IdentityFile
+	}
+
+	if kind := t.GetKind(t.GetNodeKind(nodeName)); kind != nil &&
+		kind.Credentials.IdentityFile != "" {
+		return kind.Credentials.IdentityFile
+	}
+
+	if defaults := t.GetDefaults(); defaults != nil && defaults.Credentials.IdentityFile != "" {
+		return defaults.Credentials.IdentityFile
+	}
+
+	return ""
+}
+
 // GetNodeUsername returns the username from the topology credentials block at the winning
 // precedence level (see resolveTopologyCredentials). Empty if unset at every level.
 func (t *Topology) GetNodeUsername(nodeName string) string {
@@ -933,6 +968,12 @@ func (t *Topology) GetNodeUsername(nodeName string) string {
 func (t *Topology) GetNodePassword(nodeName string) string {
 	_, p, _ := t.resolveTopologyCredentials(nodeName)
 	return p
+}
+
+// GetNodeIdentityFile returns the SSH identity-file path from the topology credentials block at the
+// winning precedence level (see resolveTopologyIdentityFile). Empty if unset at every level.
+func (t *Topology) GetNodeIdentityFile(nodeName string) string {
+	return t.resolveTopologyIdentityFile(nodeName)
 }
 
 // CredentialTopologySource identifies which topology level supplied the credentials block

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -981,10 +981,13 @@ func TestGetNodeCertificateConfig(t *testing.T) {
 // TestGetNodeCredentials tests the credential resolution hierarchy.
 func TestGetNodeCredentials(t *testing.T) {
 	tests := map[string]struct {
-		topo         *Topology
-		nodeName     string
-		wantUsername string
-		wantPassword string
+		topo                *Topology
+		nodeName            string
+		wantUsername        string
+		wantPassword        string
+		wantIdentityFile    string
+		checkCredentialsSrc bool
+		wantCredentialsSrc  CredentialTopologySource
 	}{
 		"node_overrides_kind": {
 			topo: &Topology{
@@ -1139,12 +1142,90 @@ func TestGetNodeCredentials(t *testing.T) {
 			wantUsername: "node-user-only",
 			wantPassword: "",
 		},
+		"defaults_identity_file_applies_to_node": {
+			topo: &Topology{
+				Defaults: &NodeDefinition{
+					Credentials: NodeCredentials{
+						Username:     "default-user",
+						IdentityFile: "/keys/default",
+					},
+				},
+				Nodes: map[string]*NodeDefinition{
+					"node1": {Kind: "srl"},
+				},
+			},
+			nodeName:         "node1",
+			wantUsername:     "default-user",
+			wantIdentityFile: "/keys/default",
+		},
+		"node_identity_file_overrides_defaults": {
+			topo: &Topology{
+				Defaults: &NodeDefinition{
+					Credentials: NodeCredentials{IdentityFile: "/keys/default"},
+				},
+				Nodes: map[string]*NodeDefinition{
+					"node1": {
+						Kind:        "srl",
+						Credentials: NodeCredentials{IdentityFile: "/keys/node"},
+					},
+				},
+			},
+			nodeName:         "node1",
+			wantIdentityFile: "/keys/node",
+		},
+		"node_identity_file_resolves_independently_of_username_password": {
+			// A node that sets only identity-file must still pick up its own identity-file, while
+			// username/password continue to resolve on their own precedence chain (here: the kind).
+			// The identity-file source must not hijack the username/password winning level used by
+			// inventory generation.
+			topo: &Topology{
+				Kinds: map[string]*NodeDefinition{
+					"srl": {
+						Credentials: NodeCredentials{Username: "kind-user", Password: "kind-pass"},
+					},
+				},
+				Nodes: map[string]*NodeDefinition{
+					"node1": {
+						Kind:        "srl",
+						Credentials: NodeCredentials{IdentityFile: "/keys/node"},
+					},
+				},
+			},
+			nodeName:         "node1",
+			wantUsername:     "kind-user",
+			wantPassword:     "kind-pass",
+			wantIdentityFile: "/keys/node",
+		},
+		"defaults_identity_only_does_not_change_credentials_source": {
+			// defaults sets only identity-file; the kind supplies username/password. The credentials
+			// source must remain the kind so inventory generation keeps emitting the kind creds.
+			topo: &Topology{
+				Defaults: &NodeDefinition{
+					Credentials: NodeCredentials{IdentityFile: "/keys/default"},
+				},
+				Kinds: map[string]*NodeDefinition{
+					"srl": {
+						Credentials: NodeCredentials{Username: "kind-user", Password: "kind-pass"},
+					},
+				},
+				Nodes: map[string]*NodeDefinition{
+					"node1": {Kind: "srl"},
+				},
+			},
+			nodeName:            "node1",
+			wantUsername:        "kind-user",
+			wantPassword:        "kind-pass",
+			wantIdentityFile:    "/keys/default",
+			checkCredentialsSrc: true,
+			wantCredentialsSrc:  CredentialTopologyKind,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			gotUsername := tc.topo.GetNodeUsername(tc.nodeName)
 			gotPassword := tc.topo.GetNodePassword(tc.nodeName)
+			gotIdentityFile := tc.topo.GetNodeIdentityFile(tc.nodeName)
 
 			if gotUsername != tc.wantUsername {
 				t.Errorf("username: got %q, want %q", gotUsername, tc.wantUsername)
@@ -1152,6 +1233,16 @@ func TestGetNodeCredentials(t *testing.T) {
 
 			if gotPassword != tc.wantPassword {
 				t.Errorf("password: got %q, want %q", gotPassword, tc.wantPassword)
+			}
+
+			if gotIdentityFile != tc.wantIdentityFile {
+				t.Errorf("identity-file: got %q, want %q", gotIdentityFile, tc.wantIdentityFile)
+			}
+
+			if tc.checkCredentialsSrc {
+				if gotSrc := tc.topo.GetNodeCredentialsTopologySource(tc.nodeName); gotSrc != tc.wantCredentialsSrc {
+					t.Errorf("credentials source: got %v, want %v", gotSrc, tc.wantCredentialsSrc)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds an optional `identity-file` key to the `credentials` mapping so a topology can declare the SSH private key a node expects. When set, containerlab renders an `IdentityFile` directive into the generated per-lab SSH client config (`/etc/ssh/ssh_config.d/clab-<lab>.conf`), so `ssh <node>` uses that key automatically.

The new field is threaded through the same precedence chain as `username`/`password`:

`NodeCredentials.IdentityFile` → `resolveTopologyCredentials` / `GetNodeIdentityFile` (node > group > kind > defaults) → `createNodeCfg` → `addSSHConfig` (`SSHConfigNodeTmpl.IdentityFile`) → `ssh_config.go.tpl`.

`credentialsPresent` now also treats `identity-file` as a present-credentials signal, so a node that sets only `identity-file` still wins precedence at its level (no merging across levels, consistent with the existing username/password behavior).

## Why this matters

Today, when a lab node only accepts a specific SSH key, users have to pass `-i <key>` on every `ssh` invocation because there is no way to declare the key in the topology. This adds that declaration in the natural place — alongside `username`/`password` under `credentials` — and emits a standard `IdentityFile` directive.

Ref #3224. Maintainer @hellt greenlit the addition on 2026-06-13 ("This sounds reasonable").

The rendered path is double-quoted so paths containing spaces are handled correctly; OpenSSH still performs its own `~` expansion at connect time. The new key is also added to `schemas/clab.schema.json` so editor/VS Code schema validation picks it up.

## Testing

- `core/sshconfig_test.go` (new): renders the embedded `ssh_config.go.tpl` and asserts the `IdentityFile` directive is emitted when set (quoted), omitted when unset, rendered without a `User` line when only `identity-file` is set, and quoted for paths containing spaces.
- `types/topology_test.go`: extends `TestGetNodeCredentials` to cover identity-file precedence — defaults-level applies to a node, node-level overrides defaults, and a node setting only `identity-file` still wins precedence over a kind that sets username/password.
- `gofmt`, `go vet`, and test compilation pass for the `types` and `core` packages (verified for the `linux` target — the upstream CI platform).
- The quoted template output was validated with `ssh -G` to confirm both `~` expansion and space-containing paths parse correctly.

Fixes #3224
