### PR TITLE
fix: skip non point-to-point links in graph generation (dummy link panic)

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -166,6 +166,13 @@ func graphFn(ctx context.Context, o *Options) error {
 
 	for _, l := range c.Links {
 		eps := l.GetEndpoints()
+		// Skip links that are not point-to-point (e.g. dummy, host, macvlan,
+		// mgmt-net links expose a single endpoint). Indexing eps[1] on such
+		// links would panic, so they are not rendered as edges.
+		if len(eps) != 2 {
+			log.Debugf("skipping non point-to-point link with %d endpoint(s) in graph topology", len(eps))
+			continue
+		}
 
 		ifaceDisplayNameA := eps[0].GetIfaceDisplayName()
 		ifaceDisplayNameB := eps[1].GetIfaceDisplayName()

--- a/core/graph.go
+++ b/core/graph.go
@@ -120,6 +120,13 @@ func (c *CLab) GenerateDotGraph(ctx context.Context) error {
 		attr["color"] = black
 
 		eps := link.GetEndpoints()
+		// Skip links that are not point-to-point (e.g. dummy, host, macvlan,
+		// mgmt-net links expose a single endpoint). Indexing eps[1] on such
+		// links would panic, so they are not rendered as edges.
+		if len(eps) != 2 {
+			log.Debugf("skipping non point-to-point link with %d endpoint(s) in dot graph", len(eps))
+			continue
+		}
 		ANodeName := eps[0].GetNode().GetShortName()
 		BNodeName := eps[1].GetNode().GetShortName()
 
@@ -276,6 +283,13 @@ func (c *CLab) GenerateMermaidGraph(direction string) error {
 	// Process the links between Nodes
 	for _, link := range c.Links {
 		eps := link.GetEndpoints()
+		// Skip links that are not point-to-point (e.g. dummy, host, macvlan,
+		// mgmt-net links expose a single endpoint). Indexing eps[1] on such
+		// links would panic, so they are not rendered as edges.
+		if len(eps) != 2 {
+			log.Debugf("skipping non point-to-point link with %d endpoint(s) in mermaid graph", len(eps))
+			continue
+		}
 		fc.AddEdge(eps[0].GetNode().GetShortName(), eps[1].GetNode().GetShortName())
 	}
 

--- a/core/graph_test.go
+++ b/core/graph_test.go
@@ -1,0 +1,224 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	clablinks "github.com/srl-labs/containerlab/links"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabnodesstate "github.com/srl-labs/containerlab/nodes/state"
+	clabtypes "github.com/srl-labs/containerlab/types"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// dotEdgeRe matches an undirected edge line in graphviz dot output, e.g.
+// `node1--node2;` (gographviz may quote the node names).
+var dotEdgeRe = regexp.MustCompile(`(?m)^\s*"?[^"\s]+"?\s*--\s*"?[^"\s;]+"?`)
+
+// mermaidEdgeRe matches an edge line in mermaid flowchart output, e.g.
+// `  node1---node2`.
+var mermaidEdgeRe = regexp.MustCompile(`(?m)^\s+\S+---\S+\s*$`)
+
+// graphTestNode is a minimal clablinks.Node implementation used to construct
+// links in graph generation tests without standing up a real runtime.
+type graphTestNode struct {
+	name string
+}
+
+func (n *graphTestNode) GetShortName() string { return n.name }
+
+func (*graphTestNode) AddLinkToContainer(
+	_ context.Context,
+	_ netlink.Link,
+	_ func(ns.NetNS) error,
+) error {
+	return nil
+}
+
+func (*graphTestNode) AddEndpoint(_ clablinks.Endpoint) error { return nil }
+
+func (*graphTestNode) GetLinkEndpointType() clablinks.LinkEndpointType {
+	return clablinks.LinkEndpointTypeVeth
+}
+
+func (*graphTestNode) GetEndpoints() []clablinks.Endpoint { return nil }
+
+func (*graphTestNode) ExecFunction(_ context.Context, _ func(ns.NetNS) error) error {
+	return nil
+}
+
+func (*graphTestNode) GetState() clabnodesstate.NodeState {
+	return clabnodesstate.NodeState(0)
+}
+
+func (*graphTestNode) Delete(_ context.Context) error { return nil }
+
+// newVethLink builds a real two-endpoint veth link between the named nodes.
+func newVethLink(aNode, bNode string) clablinks.Link {
+	l := clablinks.NewLinkVEth()
+	l.Endpoints = []clablinks.Endpoint{
+		clablinks.NewEndpointVeth(
+			clablinks.NewEndpointGeneric(&graphTestNode{name: aNode}, "eth1", l),
+		),
+		clablinks.NewEndpointVeth(
+			clablinks.NewEndpointGeneric(&graphTestNode{name: bNode}, "eth1", l),
+		),
+	}
+
+	return l
+}
+
+// newDummyLink builds a real single-endpoint dummy link, mirroring the topology
+// in https://github.com/srl-labs/containerlab/issues/3226.
+func newDummyLink(node string) clablinks.Link {
+	l := clablinks.NewLinkDummy()
+	l.Endpoints = []clablinks.Endpoint{
+		clablinks.NewEndpointDummy(
+			clablinks.NewEndpointGeneric(&graphTestNode{name: node}, "eth1", l),
+		),
+	}
+
+	return l
+}
+
+// newZeroEndpointLink builds a dummy link with no endpoints to exercise the
+// defensive guard against links that report zero endpoints.
+func newZeroEndpointLink() clablinks.Link {
+	l := clablinks.NewLinkDummy()
+	l.Endpoints = nil
+
+	return l
+}
+
+// newGraphTestCLab returns a CLab wired with the provided links and a TopoPaths
+// rooted in a temporary lab directory so the generators can write output files.
+func newGraphTestCLab(t *testing.T, links map[int]clablinks.Link) *CLab {
+	t.Helper()
+
+	labDir := t.TempDir()
+	topoFile := filepath.Join(labDir, "graphtest.clab.yml")
+	if err := os.WriteFile(topoFile, []byte("name: graphtest\n"), 0o644); err != nil {
+		t.Fatalf("failed to write temp topology file: %v", err)
+	}
+
+	tp, err := clabtypes.NewTopoPaths(topoFile, nil)
+	if err != nil {
+		t.Fatalf("failed to create TopoPaths: %v", err)
+	}
+
+	if err := tp.SetLabDir(labDir); err != nil {
+		t.Fatalf("failed to set lab dir: %v", err)
+	}
+
+	return &CLab{
+		Config:    &Config{Name: "graphtest"},
+		TopoPaths: tp,
+		Nodes:     map[string]clabnodes.Node{},
+		Links:     links,
+	}
+}
+
+// readGraphFile reads the single graph output file written under the lab's graph
+// directory.
+func readGraphFile(t *testing.T, c *CLab, ext string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(c.TopoPaths.GraphFilename(ext))
+	if err != nil {
+		t.Fatalf("failed to read graph file: %v", err)
+	}
+
+	return string(data)
+}
+
+// TestGenerateDotGraphSkipsNonPointToPointLinks verifies that single- and
+// zero-endpoint links no longer panic the dot generator (issue #3226) and emit
+// no edge. The dot backend requires edge endpoints to be registered as graph
+// nodes first, so node-to-node edges are covered by the mermaid test instead.
+func TestGenerateDotGraphSkipsNonPointToPointLinks(t *testing.T) {
+	tests := []struct {
+		name  string
+		links map[int]clablinks.Link
+	}{
+		{
+			name:  "single dummy link",
+			links: map[int]clablinks.Link{0: newDummyLink("node1")},
+		},
+		{
+			name:  "zero endpoint link",
+			links: map[int]clablinks.Link{0: newZeroEndpointLink()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newGraphTestCLab(t, tt.links)
+
+			if err := c.GenerateDotGraph(context.Background()); err != nil {
+				t.Fatalf("GenerateDotGraph returned error: %v", err)
+			}
+
+			out := readGraphFile(t, c, ".dot")
+			if got := len(dotEdgeRe.FindAllString(out, -1)); got != 0 {
+				t.Fatalf("dot graph edge count = %d, want 0\noutput:\n%s", got, out)
+			}
+		})
+	}
+}
+
+func TestGenerateMermaidGraphSkipsNonPointToPointLinks(t *testing.T) {
+	tests := []struct {
+		name      string
+		links     map[int]clablinks.Link
+		wantEdges int
+	}{
+		{
+			name:      "single veth link renders one edge",
+			links:     map[int]clablinks.Link{0: newVethLink("node1", "node2")},
+			wantEdges: 1,
+		},
+		{
+			name:      "single dummy link renders no edge and does not panic",
+			links:     map[int]clablinks.Link{0: newDummyLink("node1")},
+			wantEdges: 0,
+		},
+		{
+			name:      "zero endpoint link renders no edge and does not panic",
+			links:     map[int]clablinks.Link{0: newZeroEndpointLink()},
+			wantEdges: 0,
+		},
+		{
+			name: "mixed veth and dummy links render only the veth edge",
+			links: map[int]clablinks.Link{
+				0: newVethLink("node1", "node2"),
+				1: newDummyLink("node1"),
+			},
+			wantEdges: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newGraphTestCLab(t, tt.links)
+
+			if err := c.GenerateMermaidGraph("TB"); err != nil {
+				t.Fatalf("GenerateMermaidGraph returned error: %v", err)
+			}
+
+			out := readGraphFile(t, c, ".mermaid")
+			got := len(mermaidEdgeRe.FindAllString(out, -1))
+			if got != tt.wantEdges {
+				t.Fatalf("mermaid graph edge count = %d, want %d\noutput:\n%s", got, tt.wantEdges, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`containerlab graph` panics with `index out of range [1] with length 1` when the topology contains a `dummy` link. A dummy link attaches a single node interface and therefore exposes only one endpoint, but every graph generator iterated `c.Links` and unconditionally indexed `eps[1]`. This adds a point-to-point guard so single-endpoint (and zero-endpoint) links are skipped instead of crashing graph generation.

## Why this matters

A `type: dummy` link makes `link.GetEndpoints()` return a slice of length 1, so indexing the second endpoint panics. The crash affected all three graph code paths:

- `core/graph.go:131` in `GenerateDotGraph` (the default `--dot` output)
- `core/graph.go:293` in `GenerateMermaidGraph` (`--mermaid`)
- `cmd/graph.go:178` in the default HTML topology builder (`containerlab graph` with no flags)

The HTML/drawio renderers already avoided the crash by only enumerating nodes, so the fix mirrors that behavior for the link loops: links that are not point-to-point are logged at debug level and skipped rather than rendered as an edge. This keeps `dummy`, and other single-host link types (`host`, `macvlan`, `mgmt-net`) from breaking graph generation while still rendering every genuine node-to-node edge.

## Testing

- Added `core/graph_test.go` covering single-endpoint (dummy) and zero-endpoint links for both the dot and mermaid generators, plus a two-node veth regression case for mermaid. The tests build the real links and call the real `GenerateDotGraph` / `GenerateMermaidGraph` functions. Without the fix the dummy case reproduces the exact `index out of range [1] with length 1` panic from the issue; with the fix the generators produce output with no edge for the single-endpoint link.
- `go test ./core/`, `go vet ./cmd/ ./core/`, `go build ./cmd/... ./core/...`, and `gofmt -l` all pass (run with GOOS=linux).

Fixes #3226
