### PR TITLE
Improve apply link reconciliation

### DIFF
--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -131,7 +131,7 @@ func vethCreate(o *Options) error {
 
 	// deploy the endpoints of the Link
 	for _, ep := range link.GetEndpoints() {
-		if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
+		if err := link.Deploy(ctx, ep); err != nil {
 			return fmt.Errorf("failed to deploy veth endpoint: %w", err)
 		}
 	}

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -131,12 +131,7 @@ func vethCreate(o *Options) error {
 
 	// deploy the endpoints of the Link
 	for _, ep := range link.GetEndpoints() {
-		deployable, ok := ep.(clablinks.DeployableEndpoint)
-		if !ok {
-			return fmt.Errorf("endpoint %q is not deployable", ep.GetIfaceName())
-		}
-
-		if err := deployable.Deploy(ctx); err != nil {
+		if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
 			return fmt.Errorf("failed to deploy veth endpoint: %w", err)
 		}
 	}

--- a/cmd/tools_vxlan.go
+++ b/cmd/tools_vxlan.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -180,9 +181,9 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 		return err
 	}
 
-	vxl, ok := link.(*clablinks.VxlanStitched)
+	vxl, ok := link.(existingVethDeployer)
 	if !ok {
-		return fmt.Errorf("not a VxlanStitched link")
+		return fmt.Errorf("link does not support deployment with an existing veth")
 	}
 
 	err = vxl.DeployWithExistingVeth(ctx)
@@ -191,6 +192,10 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 	}
 
 	return nil
+}
+
+type existingVethDeployer interface {
+	DeployWithExistingVeth(context.Context) error
 }
 
 func vxlanDelete(o *Options) error {

--- a/cmd/tools_vxlan.go
+++ b/cmd/tools_vxlan.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net"
 
@@ -176,14 +175,9 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 		VxlanIfaceNameOverwrite: o.ToolsVxlan.Link,
 	}
 
-	link, err := vxlraw.Resolve(rp)
+	vxl, err := vxlraw.ResolveStitched(rp)
 	if err != nil {
 		return err
-	}
-
-	vxl, ok := link.(existingVethDeployer)
-	if !ok {
-		return fmt.Errorf("link does not support deployment with an existing veth")
 	}
 
 	err = vxl.DeployWithExistingVeth(ctx)
@@ -192,10 +186,6 @@ func vxlanCreate(cobraCmd *cobra.Command, o *Options) error {
 	}
 
 	return nil
-}
-
-type existingVethDeployer interface {
-	DeployWithExistingVeth(context.Context) error
 }
 
 func vxlanDelete(o *Options) error {

--- a/core/apply.go
+++ b/core/apply.go
@@ -142,6 +142,7 @@ func (c *CLab) Apply(
 	}
 
 	if plan.empty() {
+		c.writeApplyState()
 		return applyResultFromPlan(plan), nil
 	}
 
@@ -198,11 +199,15 @@ func (c *CLab) Apply(
 		return nil, err
 	}
 
+	c.writeApplyState()
+
+	return applyResultFromPlan(plan), nil
+}
+
+func (c *CLab) writeApplyState() {
 	if err := c.WriteState(); err != nil {
 		log.Warnf("failed to write state file: %v", err)
 	}
-
-	return applyResultFromPlan(plan), nil
 }
 
 func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -93,6 +95,10 @@ func (l *applyFakeLink) GetEndpoints() []clablinks.Endpoint {
 	return l.endpoints
 }
 
+func (l *applyFakeLink) GetRuntimeEndpoints() []clablinks.Endpoint {
+	return l.endpoints
+}
+
 func (*applyFakeLink) GetMTU() int {
 	return 0
 }
@@ -145,6 +151,85 @@ func TestApplyDryRunPlansDeployWhenLabMissing(t *testing.T) {
 	}
 	if result.LabName != c.Config.Name {
 		t.Fatalf("planned lab name %q, want %q", result.LabName, c.Config.Name)
+	}
+}
+
+func TestApplyWritesStateForNoChanges(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+	mockNode := clabmocksmocknodes.NewMockNode(ctrl)
+
+	labDir := t.TempDir()
+	topoFile := filepath.Join(labDir, "noop.clab.yml")
+	if err := os.WriteFile(topoFile, []byte("name: noop\n"), 0o644); err != nil {
+		t.Fatalf("failed to write topology file: %v", err)
+	}
+	topoPaths, err := clabtypes.NewTopoPaths(topoFile, nil)
+	if err != nil {
+		t.Fatalf("failed to create topo paths: %v", err)
+	}
+	if err := topoPaths.SetLabDir(labDir); err != nil {
+		t.Fatalf("failed to set lab dir: %v", err)
+	}
+
+	nodeCfg := &clabtypes.NodeConfig{
+		ShortName: "n1",
+		LongName:  "clab-noop-n1",
+	}
+	diff := &clabtypes.TopologyDiff{}
+
+	mockRuntime.EXPECT().
+		ListContainers(gomock.Any(), gomock.Any()).
+		Return([]clabruntime.GenericContainer{
+			{
+				Labels: map[string]string{
+					clabconstants.NodeName:      "n1",
+					clabconstants.NodeMgmtNetBr: "br-test",
+				},
+			},
+		}, nil)
+	mockNode.EXPECT().Config().Return(nodeCfg).AnyTimes()
+	mockNode.EXPECT().CheckDeploymentConditions(gomock.Any()).Return(nil)
+	mockNode.EXPECT().ComputeDiff(gomock.Any(), gomock.Any()).Return(diff)
+	mockNode.EXPECT().
+		GetReconcilePlan(gomock.Any(), diff).
+		Return(&clabnodes.ReconcileResult{Action: clabtypes.TopologyDiffActionNone}, nil)
+	mockNode.EXPECT().GetContainerStatus(gomock.Any()).Return(clabruntime.Running).AnyTimes()
+	mockNode.EXPECT().ExecFunction(gomock.Any(), gomock.Any()).Return(nil)
+	mockNode.EXPECT().
+		Reconcile(gomock.Any(), diff).
+		Return(&clabnodes.ReconcileResult{Action: clabtypes.TopologyDiffActionNone}, nil)
+
+	topo := clabtypes.NewTopology()
+	topo.Nodes["n1"] = &clabtypes.NodeDefinition{Kind: "linux", Image: "alpine:latest"}
+
+	c := &CLab{
+		Config: &Config{
+			Name:     "noop",
+			Mgmt:     &clabtypes.MgmtNet{},
+			Topology: topo,
+		},
+		TopoPaths: topoPaths,
+		Nodes: map[string]clabnodes.Node{
+			"n1": mockNode,
+		},
+		Links: map[int]clablinks.Link{},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: mockRuntime,
+		},
+	}
+
+	result, err := c.Apply(context.Background(), &ApplyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.DeployedLab {
+		t.Fatal("expected no-op apply, got deploy result")
+	}
+	if _, err := os.Stat(topoPaths.StateFile()); err != nil {
+		t.Fatalf("expected no-op apply to write state file: %v", err)
 	}
 }
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -50,6 +50,22 @@ func (n *applyFakeLinkNode) AddEndpoint(e clablinks.Endpoint) error {
 	return nil
 }
 
+func (n *applyFakeLinkNode) AdoptEndpoint(e clablinks.Endpoint) error {
+	n.endpoints = append(n.endpoints, e)
+	e.SetNode(n)
+	return nil
+}
+
+func (n *applyFakeLinkNode) ReleaseEndpoint(e clablinks.Endpoint) error {
+	for i, ep := range n.endpoints {
+		if ep == e {
+			n.endpoints = append(n.endpoints[:i], n.endpoints[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
 func (*applyFakeLinkNode) GetLinkEndpointType() clablinks.LinkEndpointType {
 	return clablinks.LinkEndpointTypeVeth
 }
@@ -80,6 +96,10 @@ type applyFakeLink struct {
 }
 
 func (*applyFakeLink) Deploy(context.Context, clablinks.Endpoint) error {
+	return nil
+}
+
+func (*applyFakeLink) PostDeploy(context.Context) error {
 	return nil
 }
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -28,15 +28,6 @@ type applyFakeLinkNode struct {
 	endpoints []clablinks.Endpoint
 }
 
-type applyLiveMockNode struct {
-	*clabmocksmocknodes.MockNode
-	linkApplyMode clabnodes.LinkApplyMode
-}
-
-func (n *applyLiveMockNode) LinkApplyMode(context.Context) clabnodes.LinkApplyMode {
-	return n.linkApplyMode
-}
-
 func (n *applyFakeLinkNode) AddLinkToContainer(
 	_ context.Context,
 	_ netlink.Link,
@@ -429,34 +420,29 @@ func TestApplyNodeLinkApplyMode(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		hasMode  bool
 		mode     clabnodes.LinkApplyMode
 		override clabnodes.LinkApplyMode
 		want     clabnodes.LinkApplyMode
 	}{
 		{
-			name:    "live node",
-			hasMode: true,
-			mode:    clabnodes.LinkApplyModeLive,
-			want:    clabnodes.LinkApplyModeLive,
+			name: "live node",
+			mode: clabnodes.LinkApplyModeLive,
+			want: clabnodes.LinkApplyModeLive,
 		},
 		{
-			name:    "restart node",
-			hasMode: true,
-			mode:    clabnodes.LinkApplyModeRestart,
-			want:    clabnodes.LinkApplyModeRestart,
+			name: "restart node",
+			mode: clabnodes.LinkApplyModeRestart,
+			want: clabnodes.LinkApplyModeRestart,
 		},
 		{
-			name:    "recreate node",
-			hasMode: true,
-			mode:    clabnodes.LinkApplyModeRecreate,
-			want:    clabnodes.LinkApplyModeRecreate,
+			name: "recreate node",
+			mode: clabnodes.LinkApplyModeRecreate,
+			want: clabnodes.LinkApplyModeRecreate,
 		},
 		{
-			name:    "invalid mode defaults to recreate",
-			hasMode: true,
-			mode:    clabnodes.LinkApplyMode("invalid"),
-			want:    clabnodes.LinkApplyModeRecreate,
+			name: "invalid mode defaults to recreate",
+			mode: clabnodes.LinkApplyMode("invalid"),
+			want: clabnodes.LinkApplyModeRecreate,
 		},
 		{
 			name: "node without mode defaults to recreate",
@@ -464,21 +450,18 @@ func TestApplyNodeLinkApplyMode(t *testing.T) {
 		},
 		{
 			name:     "override upgrades recreate kind to live",
-			hasMode:  true,
 			mode:     clabnodes.LinkApplyModeRecreate,
 			override: clabnodes.LinkApplyModeLive,
 			want:     clabnodes.LinkApplyModeLive,
 		},
 		{
 			name:     "override restricts live kind to recreate",
-			hasMode:  true,
 			mode:     clabnodes.LinkApplyModeLive,
 			override: clabnodes.LinkApplyModeRecreate,
 			want:     clabnodes.LinkApplyModeRecreate,
 		},
 		{
 			name:     "invalid override falls back to kind mode",
-			hasMode:  true,
 			mode:     clabnodes.LinkApplyModeRestart,
 			override: clabnodes.LinkApplyMode("hotplug"),
 			want:     clabnodes.LinkApplyModeRestart,
@@ -498,16 +481,9 @@ func TestApplyNodeLinkApplyMode(t *testing.T) {
 				ShortName:     "n1",
 				LinkApplyMode: tt.override,
 			}).AnyTimes()
+			mockNode.EXPECT().LinkApplyMode(gomock.Any()).Return(tt.mode)
 
-			var node clabnodes.Node = mockNode
-			if tt.hasMode {
-				node = &applyLiveMockNode{
-					MockNode:      mockNode,
-					linkApplyMode: tt.mode,
-				}
-			}
-
-			if got := clabnodes.LinkApplyModeForNode(context.Background(), node); got != tt.want {
+			if got := clabnodes.LinkApplyModeForNode(context.Background(), mockNode); got != tt.want {
 				t.Fatalf("LinkApplyModeForNode() = %v, want %v", got, tt.want)
 			}
 		})
@@ -555,13 +531,11 @@ func TestPlanAffectedApplyNode(t *testing.T) {
 
 			c := &CLab{
 				Nodes: map[string]clabnodes.Node{
-					"n1": &applyLiveMockNode{
-						MockNode:      mockNode,
-						linkApplyMode: tt.mode,
-					},
+					"n1": mockNode,
 				},
 			}
 			mockNode.EXPECT().Config().Return(&clabtypes.NodeConfig{}).AnyTimes()
+			mockNode.EXPECT().LinkApplyMode(gomock.Any()).Return(tt.mode)
 			plan := newApplyPlan(nil, nil)
 
 			c.planAffectedApplyNode(context.Background(), plan, "n1", tt.change)
@@ -658,16 +632,16 @@ func TestRuntimeNodeGroupsDistributedComponents(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
 
 	c := &CLab{
 		Config: &Config{Name: "lab"},
 		Runtimes: map[string]clabruntime.ContainerRuntime{
-			clabruntimedocker.RuntimeName: clabmocksmockruntime.NewMockContainerRuntime(ctrl),
+			clabruntimedocker.RuntimeName: mockRuntime,
 		},
 		globalRuntimeName: clabruntimedocker.RuntimeName,
 	}
 
-	mockRuntime := c.Runtimes[clabruntimedocker.RuntimeName].(*clabmocksmockruntime.MockContainerRuntime)
 	mockRuntime.EXPECT().
 		ListContainers(gomock.Any(), gomock.Any()).
 		Return([]clabruntime.GenericContainer{

--- a/core/clab.go
+++ b/core/clab.go
@@ -618,6 +618,8 @@ func (*CLab) getSpecialLinkNodes() map[string]clablinks.Node {
 
 // ResolveLinks resolves raw links to the actual link types and stores them in the CLab.Links map.
 func (c *CLab) ResolveLinks() error {
+	c.resetResolvedLinks()
+
 	resolveParams := &clablinks.ResolveParams{
 		Nodes:          c.getLinkNodes(),
 		MgmtBridgeName: c.Config.Mgmt.Bridge,
@@ -640,6 +642,22 @@ func (c *CLab) ResolveLinks() error {
 	}
 
 	return nil
+}
+
+func (c *CLab) resetResolvedLinks() {
+	for _, ep := range c.Endpoints {
+		if ep == nil || ep.GetNode() == nil {
+			continue
+		}
+		owner, ok := ep.GetNode().(clablinks.EndpointOwner)
+		if !ok {
+			continue
+		}
+		_ = owner.ReleaseEndpoint(ep)
+	}
+
+	c.Endpoints = nil
+	c.Links = make(map[int]clablinks.Link)
 }
 
 // extractDNSServers extracts DNS servers from the resolv.conf files

--- a/core/clab.go
+++ b/core/clab.go
@@ -649,11 +649,7 @@ func (c *CLab) resetResolvedLinks() {
 		if ep == nil || ep.GetNode() == nil {
 			continue
 		}
-		owner, ok := ep.GetNode().(clablinks.EndpointOwner)
-		if !ok {
-			continue
-		}
-		_ = owner.ReleaseEndpoint(ep)
+		_ = ep.GetNode().ReleaseEndpoint(ep)
 	}
 
 	c.Endpoints = nil

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -350,6 +350,48 @@ func TestVerifyLinks(t *testing.T) {
 	}
 }
 
+func TestResolveLinksIsIdempotent(t *testing.T) {
+	topoContent := []byte(`
+name: resolve-links
+topology:
+  nodes:
+    n1:
+      kind: linux
+      image: alpine:latest
+    n2:
+      kind: linux
+      image: alpine:latest
+  links:
+    - endpoints: ["n1:eth1", "n2:eth1"]
+`)
+
+	topoFile := filepath.Join(t.TempDir(), "resolve-links.clab.yml")
+	if err := os.WriteFile(topoFile, topoContent, 0o644); err != nil {
+		t.Fatalf("failed to write topology file: %v", err)
+	}
+
+	c, err := NewContainerLab(WithTopoPath(topoFile, nil))
+	if err != nil {
+		t.Fatalf("failed to create lab: %v", err)
+	}
+
+	if err := c.ResolveLinks(); err != nil {
+		t.Fatalf("first ResolveLinks() failed: %v", err)
+	}
+	if err := c.ResolveLinks(); err != nil {
+		t.Fatalf("second ResolveLinks() failed: %v", err)
+	}
+
+	if got := len(c.Endpoints); got != 2 {
+		t.Fatalf("endpoint count after repeated ResolveLinks() = %d, want 2", got)
+	}
+	for _, nodeName := range []string{"n1", "n2"} {
+		if got := len(c.Nodes[nodeName].GetEndpoints()); got != 1 {
+			t.Fatalf("%s endpoint count after repeated ResolveLinks() = %d, want 1", nodeName, got)
+		}
+	}
+}
+
 func TestLabelsInit(t *testing.T) {
 	owner := os.Getenv("SUDO_USER")
 

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -93,13 +93,7 @@ func (c *CLab) Deploy( //nolint: funlen
 	// as part of vxlan-stitch links are already deployed before the stitch TC rules are applied.
 	eps := c.getSpecialLinkNodes()["host"].GetEndpoints()
 	for _, ep := range eps {
-		deployable, ok := ep.(clablinks.DeployableEndpoint)
-		if !ok {
-			log.Warnf("skipping non-deployable endpoint %s", ep)
-			continue
-		}
-
-		err = deployable.Deploy(ctx)
+		err = clablinks.DeployEndpoint(ctx, ep)
 		if err != nil {
 			log.Warnf("failed deploying endpoint %s", ep)
 		}
@@ -109,10 +103,8 @@ func (c *CLab) Deploy( //nolint: funlen
 	// The veth pair is already created by node workers and the VxLAN interface is created
 	// by host endpoint deploy; Stitch applies the TC redirect rules to bridge them.
 	for _, link := range c.Links {
-		if stitcher, ok := link.(clablinks.StitchingLink); ok {
-			if err = stitcher.Stitch(); err != nil {
-				log.Warnf("failed stitching vxlan link: %v", err)
-			}
+		if err = link.PostDeploy(ctx); err != nil {
+			log.Warnf("failed post-deploying link: %v", err)
 		}
 	}
 
@@ -462,36 +454,22 @@ func (c *CLab) deployApplyLinks(ctx context.Context, links []clablinks.Link) err
 		}
 
 		for _, ep := range clablinks.ApplyRuntimeEndpoints(link) {
-			deployable, ok := ep.(clablinks.DeployableEndpoint)
-			if !ok {
-				return fmt.Errorf("endpoint %q is not deployable", ep.GetIfaceName())
-			}
-
-			if err := deployable.Deploy(ctx); err != nil {
+			if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
 				return fmt.Errorf("failed deploying link %s: %w", applyLinkName(link), err)
 			}
 		}
 
-		if stitcher, ok := link.(clablinks.StitchingLink); ok {
-			if err := stitcher.Stitch(); err != nil {
-				return fmt.Errorf("failed stitching link %s: %w", applyLinkName(link), err)
-			}
+		if err := link.PostDeploy(ctx); err != nil {
+			return fmt.Errorf("failed post-deploying link %s: %w", applyLinkName(link), err)
 		}
 	}
 
 	return nil
 }
 
-type postDeployEndpointsNode interface {
-	PostDeployEndpoints(context.Context) error
-}
-
 func (c *CLab) postDeployApplyLinks(ctx context.Context, nodeNames []string) error {
 	for _, nodeName := range nodeNames {
-		node, ok := c.Nodes[nodeName].(postDeployEndpointsNode)
-		if !ok {
-			continue
-		}
+		node := c.Nodes[nodeName]
 
 		if err := node.PostDeployEndpoints(ctx); err != nil {
 			return fmt.Errorf("node %q post-deploy links: %w", nodeName, err)

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -93,7 +93,7 @@ func (c *CLab) Deploy( //nolint: funlen
 	// as part of vxlan-stitch links are already deployed before the stitch TC rules are applied.
 	eps := c.getSpecialLinkNodes()["host"].GetEndpoints()
 	for _, ep := range eps {
-		err = clablinks.DeployEndpoint(ctx, ep)
+		err = ep.GetLink().Deploy(ctx, ep)
 		if err != nil {
 			log.Warnf("failed deploying endpoint %s", ep)
 		}
@@ -454,7 +454,7 @@ func (c *CLab) deployApplyLinks(ctx context.Context, links []clablinks.Link) err
 		}
 
 		for _, ep := range clablinks.ApplyRuntimeEndpoints(link) {
-			if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
+			if err := ep.GetLink().Deploy(ctx, ep); err != nil {
 				return fmt.Errorf("failed deploying link %s: %w", applyLinkName(link), err)
 			}
 		}

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -105,12 +105,12 @@ func (c *CLab) Deploy( //nolint: funlen
 		}
 	}
 
-	// Stitch VxlanStitched links after node workers and host endpoints have finished.
+	// Stitch links after node workers and host endpoints have finished.
 	// The veth pair is already created by node workers and the VxLAN interface is created
 	// by host endpoint deploy; Stitch applies the TC redirect rules to bridge them.
 	for _, link := range c.Links {
-		if stitchedLink, ok := link.(*clablinks.VxlanStitched); ok {
-			if err = stitchedLink.Stitch(); err != nil {
+		if stitcher, ok := link.(clablinks.StitchingLink); ok {
+			if err = stitcher.Stitch(); err != nil {
 				log.Warnf("failed stitching vxlan link: %v", err)
 			}
 		}
@@ -472,8 +472,8 @@ func (c *CLab) deployApplyLinks(ctx context.Context, links []clablinks.Link) err
 			}
 		}
 
-		if stitchedLink, ok := link.(*clablinks.VxlanStitched); ok {
-			if err := stitchedLink.Stitch(); err != nil {
+		if stitcher, ok := link.(clablinks.StitchingLink); ok {
+			if err := stitcher.Stitch(); err != nil {
 				return fmt.Errorf("failed stitching link %s: %w", applyLinkName(link), err)
 			}
 		}

--- a/core/graph_test.go
+++ b/core/graph_test.go
@@ -46,6 +46,10 @@ func (*graphTestNode) AddLinkToContainer(
 
 func (*graphTestNode) AddEndpoint(_ clablinks.Endpoint) error { return nil }
 
+func (*graphTestNode) AdoptEndpoint(_ clablinks.Endpoint) error { return nil }
+
+func (*graphTestNode) ReleaseEndpoint(_ clablinks.Endpoint) error { return nil }
+
 func (*graphTestNode) GetLinkEndpointType() clablinks.LinkEndpointType {
 	return clablinks.LinkEndpointTypeVeth
 }

--- a/core/lifecycle.go
+++ b/core/lifecycle.go
@@ -45,12 +45,8 @@ func (c *CLab) parkRecreatedNodes(ctx context.Context, plan *applyPlan) error {
 		if !exists {
 			continue
 		}
-		parker, ok := node.(interface{ ParkEndpoints(context.Context) error })
-		if !ok {
-			return fmt.Errorf("node %q does not support endpoint parking", nodeName)
-		}
 		log.Info("Parking links for recreate", "node", nodeName)
-		if err := parker.ParkEndpoints(ctx); err != nil {
+		if err := node.ParkEndpoints(ctx); err != nil {
 			return fmt.Errorf("failed parking endpoints for node %q: %w", nodeName, err)
 		}
 	}
@@ -64,12 +60,8 @@ func (c *CLab) restoreRecreatedNodes(ctx context.Context, plan *applyPlan) error
 		if !exists {
 			continue
 		}
-		restorer, ok := node.(interface{ RestoreEndpoints(context.Context) error })
-		if !ok {
-			return fmt.Errorf("node %q does not support endpoint restore", nodeName)
-		}
 		log.Info("Restoring links after recreate", "node", nodeName)
-		if err := restorer.RestoreEndpoints(ctx); err != nil {
+		if err := node.RestoreEndpoints(ctx); err != nil {
 			return fmt.Errorf("failed restoring endpoints for node %q: %w", nodeName, err)
 		}
 	}

--- a/docs/cmd/apply.md
+++ b/docs/cmd/apply.md
@@ -49,10 +49,10 @@ The currently declared modes per kind:
 
 | Kind                          | Mode       | Notes                                                            |
 | ----------------------------- | ---------- | ---------------------------------------------------------------- |
-| `nokia_srlinux`       | `live`     | SR Linux detects hot-plugged interfaces                          |
+| `nokia_srlinux`               | `live`     | SR Linux detects hot-plugged interfaces                          |
 | `nokia_srsim`                 | `live`     | SR-SIM detects hot-plugged interfaces                            |
 | `linux`                       | `live`     | plain Linux containers see new interfaces immediately            |
-| `arista_ceos`        | `restart`  | cEOS requires a restart to enumerate new interfaces              |
+| `arista_ceos`                 | `restart`  | cEOS requires a restart to enumerate new interfaces              |
 | vrnetlab-based VM kinds       | `recreate` | VM NIC wiring is fixed at VM boot; live changes cannot work      |
 | images built with Boxen       | `live`     | detected via the `org.opencontainers.image.vendor=Boxen` label   |
 | all other kinds               | `recreate` | conservative default for kinds not yet validated                 |

--- a/links/apply.go
+++ b/links/apply.go
@@ -4,25 +4,11 @@ package links
 // deploy, discover, or remove for a link. Parent and remote-only metadata endpoints are
 // intentionally excluded.
 func ApplyRuntimeEndpoints(l Link) []Endpoint {
-	switch link := l.(type) {
-	case *LinkVEth:
-		return append([]Endpoint(nil), link.Endpoints...)
-	case *LinkMacVlan:
-		return []Endpoint{link.NodeEndpoint}
-	case *LinkVxlan:
-		return []Endpoint{link.localEndpoint}
-	case *VxlanStitched:
-		endpoints := make([]Endpoint, 0, len(link.vethLink.Endpoints)+1)
-		endpoints = append(endpoints, link.vethLink.Endpoints...)
-		endpoints = append(endpoints, link.vxlanLink.localEndpoint)
-		return endpoints
-	case *LinkDummy:
-		return append([]Endpoint(nil), link.Endpoints...)
-	case *Bridge:
-		return []Endpoint{link.endpoint}
-	default:
-		return materialEndpoints(l.GetEndpoints())
+	if l == nil {
+		return nil
 	}
+
+	return materialEndpoints(l.GetRuntimeEndpoints())
 }
 
 func materialEndpoints(endpoints []Endpoint) []Endpoint {

--- a/links/apply_test.go
+++ b/links/apply_test.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"testing"
@@ -30,10 +31,10 @@ func TestApplyRuntimeEndpointsForVxlanStitchedIncludesUnderlyingObjects(t *testi
 
 	node := newFakeNode("n1")
 	host := newFakeNode("host")
-	veth := NewLinkVEth()
+	veth := &applyRuntimeFakeLink{}
 	nodeEp := NewEndpointVeth(NewEndpointGeneric(node, "eth1", veth))
 	hostEp := NewEndpointHost(NewEndpointGeneric(host, "ve-n1_eth1", veth))
-	veth.Endpoints = []Endpoint{nodeEp, hostEp}
+	veth.endpoints = []Endpoint{nodeEp, hostEp}
 
 	vxlan := &LinkVxlan{
 		localEndpoint:  NewEndpointVeth(NewEndpointGeneric(host, "vx-n1_eth1", nil)),
@@ -44,6 +45,59 @@ func TestApplyRuntimeEndpointsForVxlanStitchedIncludesUnderlyingObjects(t *testi
 	if got := endpointTokens(ApplyRuntimeEndpoints(link)); got != "host:ve-n1_eth1,host:vx-n1_eth1,n1:eth1" {
 		t.Fatalf("unexpected runtime endpoints %q", got)
 	}
+}
+
+func TestEndpointByInterfaceName(t *testing.T) {
+	t.Parallel()
+
+	node := newFakeNode("n1")
+	host := newFakeNode("host")
+	nodeEp := NewEndpointVeth(NewEndpointGeneric(node, "eth1", nil))
+	hostEp := NewEndpointHost(NewEndpointGeneric(host, "ve-n1_eth1", nil))
+
+	got, ok := endpointByInterfaceName([]Endpoint{nodeEp, nil, hostEp}, "ve-n1_eth1")
+	if !ok {
+		t.Fatal("expected endpoint to be found")
+	}
+	if got != hostEp {
+		t.Fatalf("unexpected endpoint %v", got)
+	}
+
+	if _, ok := endpointByInterfaceName([]Endpoint{nodeEp, hostEp}, "missing"); ok {
+		t.Fatal("expected missing endpoint not to be found")
+	}
+}
+
+type applyRuntimeFakeLink struct {
+	endpoints []Endpoint
+}
+
+func (*applyRuntimeFakeLink) Deploy(context.Context, Endpoint) error {
+	return nil
+}
+
+func (*applyRuntimeFakeLink) Remove(context.Context) error {
+	return nil
+}
+
+func (*applyRuntimeFakeLink) GetType() LinkType {
+	return LinkTypeVEth
+}
+
+func (l *applyRuntimeFakeLink) GetEndpoints() []Endpoint {
+	return l.endpoints
+}
+
+func (l *applyRuntimeFakeLink) GetRuntimeEndpoints() []Endpoint {
+	return l.endpoints
+}
+
+func (*applyRuntimeFakeLink) GetMTU() int {
+	return 0
+}
+
+func (*applyRuntimeFakeLink) GetVars() map[string]any {
+	return nil
 }
 
 func endpointTokens(endpoints []Endpoint) string {

--- a/links/apply_test.go
+++ b/links/apply_test.go
@@ -76,6 +76,10 @@ func (*applyRuntimeFakeLink) Deploy(context.Context, Endpoint) error {
 	return nil
 }
 
+func (*applyRuntimeFakeLink) PostDeploy(context.Context) error {
+	return nil
+}
+
 func (*applyRuntimeFakeLink) Remove(context.Context) error {
 	return nil
 }

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -33,8 +33,6 @@ type Endpoint interface {
 	// has the same node and interface name as the given endpoint.
 	HasSameNodeAndInterface(ept Endpoint) bool
 	Remove(context.Context) error
-	// MoveTo moves this endpoint's interface to the destination node's namespace and transfers ownership.
-	MoveTo(context.Context, Node) error
 	// Activate brings this endpoint's interface up in its current namespace.
 	Activate(context.Context) error
 	// IsNodeless returns true for the endpoints that has no explicit node defined in the topology.

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -221,6 +221,7 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 	return nil
 }
 
+// DeployEndpoint deploys the link associated with the endpoint.
 func DeployEndpoint(ctx context.Context, ep Endpoint) error {
 	if ep == nil {
 		return fmt.Errorf("cannot deploy nil endpoint")

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -160,7 +160,7 @@ func (e *EndpointGeneric) Remove(ctx context.Context) error {
 
 // moveEndpoint moves the endpoint's interface into dst's namespace and transfers ownership.
 // The interface is left in the DOWN state; callers that need it active should follow up with
-// activateEndpoint once all endpoints are in place.
+// Endpoint.Activate once all endpoints are in place.
 func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 	src := e.GetNode()
 	if src == nil {
@@ -221,8 +221,8 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 	return nil
 }
 
-// activateEndpoint brings the endpoint's interface up in its current namespace.
-func activateEndpoint(ctx context.Context, e Endpoint) error {
+// Activate brings the endpoint's interface up in its current namespace.
+func (e *EndpointGeneric) Activate(ctx context.Context) error {
 	return e.GetNode().ExecFunction(ctx, func(_ ns.NetNS) error {
 		link, err := netlink.LinkByName(e.GetIfaceName())
 		if err != nil {

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -221,20 +221,6 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 	return nil
 }
 
-// DeployEndpoint deploys the link associated with the endpoint.
-func DeployEndpoint(ctx context.Context, ep Endpoint) error {
-	if ep == nil {
-		return fmt.Errorf("cannot deploy nil endpoint")
-	}
-
-	link := ep.GetLink()
-	if link == nil {
-		return fmt.Errorf("endpoint %q has no link", ep.GetIfaceName())
-	}
-
-	return link.Deploy(ctx, ep)
-}
-
 // activateEndpoint brings the endpoint's interface up in its current namespace.
 func activateEndpoint(ctx context.Context, e Endpoint) error {
 	return e.GetNode().ExecFunction(ctx, func(_ ns.NetNS) error {

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -51,15 +51,6 @@ type Endpoint interface {
 	GetVars() map[string]any
 }
 
-// DeployableEndpoint is implemented by endpoint kinds that participate in initial lab deployment.
-type DeployableEndpoint interface {
-	Endpoint
-	// Deploy deploys the endpoint by calling the Deploy method of the link it is assigned to
-	// and passing the endpoint as an argument so that the link that consists of A and B endpoints
-	// can deploy them independently.
-	Deploy(context.Context) error
-}
-
 // EndpointGeneric is the generic endpoint struct that is used by all endpoint types.
 type EndpointGeneric struct {
 	Node       Node
@@ -184,16 +175,6 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 		return nil
 	}
 
-	srcOwner, ok := src.(EndpointOwner)
-	if !ok {
-		return fmt.Errorf("node %q does not support endpoint ownership moves", src.GetShortName())
-	}
-
-	dstOwner, ok := dst.(EndpointOwner)
-	if !ok {
-		return fmt.Errorf("node %q does not support endpoint ownership moves", dst.GetShortName())
-	}
-
 	if !slices.Contains(src.GetEndpoints(), e) {
 		return fmt.Errorf("node %q does not own endpoint %q", src.GetShortName(), e.GetIfaceName())
 	}
@@ -223,13 +204,13 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 		return err
 	}
 
-	if err := srcOwner.ReleaseEndpoint(e); err != nil {
+	if err := src.ReleaseEndpoint(e); err != nil {
 		return err
 	}
 	e.SetNode(dst)
-	if err := dstOwner.AdoptEndpoint(e); err != nil {
+	if err := dst.AdoptEndpoint(e); err != nil {
 		e.SetNode(src)
-		_ = srcOwner.AdoptEndpoint(e)
+		_ = src.AdoptEndpoint(e)
 		return fmt.Errorf(
 			"endpoint %q moved but destination ownership update failed: %w",
 			e.GetIfaceName(),
@@ -238,6 +219,19 @@ func moveEndpoint(ctx context.Context, e Endpoint, dst Node) error {
 	}
 
 	return nil
+}
+
+func DeployEndpoint(ctx context.Context, ep Endpoint) error {
+	if ep == nil {
+		return fmt.Errorf("cannot deploy nil endpoint")
+	}
+
+	link := ep.GetLink()
+	if link == nil {
+		return fmt.Errorf("endpoint %q has no link", ep.GetIfaceName())
+	}
+
+	return link.Deploy(ctx, ep)
 }
 
 // activateEndpoint brings the endpoint's interface up in its current namespace.

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -54,10 +54,6 @@ func (e *EndpointBridge) IsNodeless() bool {
 	return e.isMgmtBridgeEndpoint
 }
 
-func (e *EndpointBridge) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}
-
 // CheckBridgeExists verifies that the given bridge is present in the
 // network namespace referenced via the provided nspath handle.
 func CheckBridgeExists(ctx context.Context, n Node) error {

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -48,10 +48,6 @@ func (e *EndpointBridge) Verify(ctx context.Context, p *VerifyLinkParams) error 
 	return nil
 }
 
-func (e *EndpointBridge) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 func (e *EndpointBridge) IsNodeless() bool {
 	// the mgmt bridge is nodeless.
 	// If this is a regular bridge, then it should trigger BEnd deployment.

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -58,10 +58,6 @@ func (e *EndpointBridge) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
 
-func (e *EndpointBridge) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}
-
 // CheckBridgeExists verifies that the given bridge is present in the
 // network namespace referenced via the provided nspath handle.
 func CheckBridgeExists(ctx context.Context, n Node) error {

--- a/links/endpoint_dummy.go
+++ b/links/endpoint_dummy.go
@@ -24,7 +24,3 @@ func (*EndpointDummy) IsNodeless() bool {
 func (e *EndpointDummy) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointDummy) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_dummy.go
+++ b/links/endpoint_dummy.go
@@ -17,10 +17,6 @@ func (e *EndpointDummy) Verify(_ context.Context, _ *VerifyLinkParams) error {
 	return CheckEndpointUniqueness(e)
 }
 
-func (e *EndpointDummy) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 func (*EndpointDummy) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_dummy.go
+++ b/links/endpoint_dummy.go
@@ -20,7 +20,3 @@ func (e *EndpointDummy) Verify(_ context.Context, _ *VerifyLinkParams) error {
 func (*EndpointDummy) IsNodeless() bool {
 	return false
 }
-
-func (e *EndpointDummy) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -15,10 +15,6 @@ func NewEndpointHost(eg *EndpointGeneric) *EndpointHost {
 	}
 }
 
-func (e *EndpointHost) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 func (e *EndpointHost) Verify(ctx context.Context, _ *VerifyLinkParams) error {
 	var errs []error
 	err := CheckEndpointUniqueness(e)

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -38,7 +38,3 @@ func (e *EndpointHost) IsNodeless() bool {
 func (e *EndpointHost) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointHost) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -34,7 +34,3 @@ func (e *EndpointHost) Verify(ctx context.Context, _ *VerifyLinkParams) error {
 func (e *EndpointHost) IsNodeless() bool {
 	return true
 }
-
-func (e *EndpointHost) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -20,7 +20,3 @@ func (e *EndpointMacVlan) Verify(ctx context.Context, _ *VerifyLinkParams) error
 func (e *EndpointMacVlan) IsNodeless() bool {
 	return false
 }
-
-func (e *EndpointMacVlan) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -24,7 +24,3 @@ func (e *EndpointMacVlan) IsNodeless() bool {
 func (e *EndpointMacVlan) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointMacVlan) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_macvlan.go
+++ b/links/endpoint_macvlan.go
@@ -12,10 +12,6 @@ func NewEndpointMacVlan(eg *EndpointGeneric) *EndpointMacVlan {
 	}
 }
 
-func (e *EndpointMacVlan) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 // Verify runs verification to check if the endpoint can be deployed.
 func (e *EndpointMacVlan) Verify(ctx context.Context, _ *VerifyLinkParams) error {
 	return CheckEndpointExists(ctx, e)

--- a/links/endpoint_runtime.go
+++ b/links/endpoint_runtime.go
@@ -33,7 +33,3 @@ func (*EndpointRuntime) IsNodeless() bool {
 func (e *EndpointRuntime) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointRuntime) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_runtime.go
+++ b/links/endpoint_runtime.go
@@ -29,7 +29,3 @@ func (*EndpointRuntime) IsRuntimeDiscovered() bool {
 func (*EndpointRuntime) IsNodeless() bool {
 	return false
 }
-
-func (e *EndpointRuntime) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -17,10 +17,6 @@ func (e *EndpointVeth) Verify(_ context.Context, _ *VerifyLinkParams) error {
 	return CheckEndpointUniqueness(e)
 }
 
-func (e *EndpointVeth) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 func (e *EndpointVeth) IsNodeless() bool {
 	return false
 }

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -24,7 +24,3 @@ func (e *EndpointVeth) IsNodeless() bool {
 func (e *EndpointVeth) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointVeth) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_veth.go
+++ b/links/endpoint_veth.go
@@ -20,7 +20,3 @@ func (e *EndpointVeth) Verify(_ context.Context, _ *VerifyLinkParams) error {
 func (e *EndpointVeth) IsNodeless() bool {
 	return false
 }
-
-func (e *EndpointVeth) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -42,7 +42,3 @@ func (e *EndpointVxlan) IsNodeless() bool {
 func (e *EndpointVxlan) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
-
-func (e *EndpointVxlan) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -38,7 +38,3 @@ func (e *EndpointVxlan) Verify(_ context.Context, _ *VerifyLinkParams) error {
 func (e *EndpointVxlan) IsNodeless() bool {
 	return false
 }
-
-func (e *EndpointVxlan) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}

--- a/links/endpoint_vxlan.go
+++ b/links/endpoint_vxlan.go
@@ -35,10 +35,6 @@ func (e *EndpointVxlan) Verify(_ context.Context, _ *VerifyLinkParams) error {
 	return CheckEndpointUniqueness(e)
 }
 
-func (e *EndpointVxlan) Deploy(ctx context.Context) error {
-	return e.GetLink().Deploy(ctx, e)
-}
-
 func (e *EndpointVxlan) IsNodeless() bool {
 	return false
 }

--- a/links/generic_link_node_test.go
+++ b/links/generic_link_node_test.go
@@ -25,10 +25,6 @@ func (e *deleteTestEndpoint) MoveTo(ctx context.Context, dst Node) error {
 	return moveEndpoint(ctx, e, dst)
 }
 
-func (e *deleteTestEndpoint) Activate(ctx context.Context) error {
-	return activateEndpoint(ctx, e)
-}
-
 func TestGenericLinkNodeDeleteHandlesEndpointsWithoutLink(t *testing.T) {
 	node := &GenericLinkNode{
 		shortname: "test-node",

--- a/links/generic_link_node_test.go
+++ b/links/generic_link_node_test.go
@@ -14,8 +14,6 @@ func (*deleteTestEndpoint) Verify(context.Context, *VerifyLinkParams) error { re
 
 func (*deleteTestEndpoint) HasSameNodeAndInterface(Endpoint) bool { return false }
 
-func (*deleteTestEndpoint) Deploy(context.Context) error { return nil }
-
 func (*deleteTestEndpoint) IsNodeless() bool { return false }
 
 func (e *deleteTestEndpoint) Remove(context.Context) error {

--- a/links/generic_link_node_test.go
+++ b/links/generic_link_node_test.go
@@ -21,10 +21,6 @@ func (e *deleteTestEndpoint) Remove(context.Context) error {
 	return nil
 }
 
-func (e *deleteTestEndpoint) MoveTo(ctx context.Context, dst Node) error {
-	return moveEndpoint(ctx, e, dst)
-}
-
 func TestGenericLinkNodeDeleteHandlesEndpointsWithoutLink(t *testing.T) {
 	node := &GenericLinkNode{
 		shortname: "test-node",

--- a/links/link.go
+++ b/links/link.go
@@ -347,10 +347,18 @@ type Link interface {
 	GetType() LinkType
 	// GetEndpoints returns the endpoints of the link.
 	GetEndpoints() []Endpoint
+	// GetRuntimeEndpoints returns endpoints apply/deploy may create, discover, or remove.
+	// Parent-only and remote metadata endpoints are excluded where applicable.
+	GetRuntimeEndpoints() []Endpoint
 	// GetMTU returns the Link MTU.
 	GetMTU() int
 	// GetVars returns the link-level vars.
 	GetVars() map[string]any
+}
+
+// StitchingLink is implemented by links that apply a post-deploy stitching step.
+type StitchingLink interface {
+	Stitch() error
 }
 
 func extractHostNodeInterfaceData(

--- a/links/link.go
+++ b/links/link.go
@@ -341,6 +341,8 @@ type RawLink interface {
 type Link interface {
 	// Deploy deploys the link. Endpoint is the endpoint that triggers the creation of the link.
 	Deploy(context.Context, Endpoint) error
+	// PostDeploy runs link work that must happen after endpoint deployment.
+	PostDeploy(context.Context) error
 	// Remove removes the link.
 	Remove(context.Context) error
 	// GetType returns the type of the link.
@@ -354,11 +356,6 @@ type Link interface {
 	GetMTU() int
 	// GetVars returns the link-level vars.
 	GetVars() map[string]any
-}
-
-// StitchingLink is implemented by links that apply a post-deploy stitching step.
-type StitchingLink interface {
-	Stitch() error
 }
 
 func extractHostNodeInterfaceData(
@@ -481,20 +478,14 @@ type Node interface {
 	// AddEndpoint attaches an endpoint discovered from topology resolution and may normalize
 	// endpoint identity first, such as interface-name remapping.
 	AddEndpoint(e Endpoint) error
+	AdoptEndpoint(e Endpoint) error
+	ReleaseEndpoint(e Endpoint) error
 	GetLinkEndpointType() LinkEndpointType
 	GetShortName() string
 	GetEndpoints() []Endpoint
 	ExecFunction(context.Context, func(ns.NetNS) error) error
 	GetState() clabnodesstate.NodeState
 	Delete(ctx context.Context) error
-}
-
-// EndpointOwner is implemented by nodes that keep runtime endpoint ownership in sync with the
-// actual namespace that owns an interface.
-type EndpointOwner interface {
-	Node
-	AdoptEndpoint(e Endpoint) error
-	ReleaseEndpoint(e Endpoint) error
 }
 
 type LinkEndpointType string

--- a/links/link_bridge.go
+++ b/links/link_bridge.go
@@ -71,6 +71,10 @@ func (b *Bridge) GetEndpoints() []Endpoint {
 	return []Endpoint{b.endpoint}
 }
 
+func (b *Bridge) GetRuntimeEndpoints() []Endpoint {
+	return b.GetEndpoints()
+}
+
 // GetMTU returns the Link MTU.
 func (b *Bridge) GetMTU() int {
 	return b.MTU

--- a/links/link_bridge.go
+++ b/links/link_bridge.go
@@ -44,6 +44,10 @@ func (b *Bridge) Deploy(ctx context.Context, endpoint Endpoint) error {
 	return err
 }
 
+func (*Bridge) PostDeploy(context.Context) error {
+	return nil
+}
+
 // Remove removes the link.
 func (b *Bridge) Remove(ctx context.Context) error {
 	// check Deployment state, if the Link was already

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -101,6 +101,10 @@ func (l *LinkDummy) Deploy(ctx context.Context, ep Endpoint) error {
 	return nil
 }
 
+func (*LinkDummy) PostDeploy(context.Context) error {
+	return nil
+}
+
 func (l *LinkDummy) Remove(ctx context.Context) error {
 	if l.DeploymentState == LinkDeploymentStateRemoved {
 		return nil

--- a/links/link_dummy.go
+++ b/links/link_dummy.go
@@ -118,3 +118,7 @@ func (l *LinkDummy) Remove(ctx context.Context) error {
 func (l *LinkDummy) GetEndpoints() []Endpoint {
 	return l.Endpoints
 }
+
+func (l *LinkDummy) GetRuntimeEndpoints() []Endpoint {
+	return l.GetEndpoints()
+}

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -200,6 +200,10 @@ func (l *LinkMacVlan) GetEndpoints() []Endpoint {
 	}
 }
 
+func (l *LinkMacVlan) GetRuntimeEndpoints() []Endpoint {
+	return []Endpoint{l.NodeEndpoint}
+}
+
 type MacVlanMode string
 
 const (

--- a/links/link_macvlan.go
+++ b/links/link_macvlan.go
@@ -177,6 +177,10 @@ func (l *LinkMacVlan) Deploy(ctx context.Context, _ Endpoint) error {
 	return err
 }
 
+func (*LinkMacVlan) PostDeploy(context.Context) error {
+	return nil
+}
+
 func (l *LinkMacVlan) Remove(ctx context.Context) error {
 	// check Deployment state, if the Link was already
 	// removed via e.g. the peer node

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -320,6 +320,10 @@ func (l *LinkVEth) Deploy(ctx context.Context, ep Endpoint) error {
 	return lastErr
 }
 
+func (*LinkVEth) PostDeploy(context.Context) error {
+	return nil
+}
+
 func (l *LinkVEth) Remove(ctx context.Context) error {
 	l.deployMutex.Lock()
 	defer l.deployMutex.Unlock()

--- a/links/link_veth.go
+++ b/links/link_veth.go
@@ -339,3 +339,7 @@ func (l *LinkVEth) Remove(ctx context.Context) error {
 func (l *LinkVEth) GetEndpoints() []Endpoint {
 	return l.Endpoints
 }
+
+func (l *LinkVEth) GetRuntimeEndpoints() []Endpoint {
+	return l.GetEndpoints()
+}

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -47,6 +47,10 @@ func (lr *LinkVxlanRaw) Resolve(params *ResolveParams) (Link, error) {
 	}
 }
 
+func (lr *LinkVxlanRaw) ResolveStitched(params *ResolveParams) (*VxlanStitched, error) {
+	return lr.resolveStitchedVxlan(params)
+}
+
 // resolveStitchedVEthComponent creates the veth link and returns it, the endpoint that is
 // supposed to be stitched is returned separately for further processing.
 func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(
@@ -110,7 +114,7 @@ func endpointByInterfaceName(endpoints []Endpoint, ifaceName string) (Endpoint, 
 }
 
 // resolveStitchedVxlan resolves the stitched raw vxlan link.
-func (lr *LinkVxlanRaw) resolveStitchedVxlan(params *ResolveParams) (Link, error) {
+func (lr *LinkVxlanRaw) resolveStitchedVxlan(params *ResolveParams) (*VxlanStitched, error) {
 	// prepare the vxlan struct
 	vxlanLink, err := lr.resolveVxlan(params, true)
 	if err != nil {
@@ -264,6 +268,10 @@ func (l *LinkVxlan) Deploy(ctx context.Context, _ Endpoint) error {
 	err = l.localEndpoint.GetNode().AddLinkToContainer(ctx, mvInterface,
 		SetNameMACAndUpInterface(mvInterface, l.localEndpoint))
 	return err
+}
+
+func (*LinkVxlan) PostDeploy(context.Context) error {
+	return nil
 }
 
 // deployVxlanInterface internal function to create the vxlan interface in the host namespace.

--- a/links/link_vxlan.go
+++ b/links/link_vxlan.go
@@ -51,7 +51,7 @@ func (lr *LinkVxlanRaw) Resolve(params *ResolveParams) (Link, error) {
 // supposed to be stitched is returned separately for further processing.
 func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(
 	params *ResolveParams,
-) (*LinkVEth, Endpoint, error) {
+) (Link, Endpoint, error) {
 	var err error
 
 	// hostIface is the name of the host interface that will be created
@@ -77,10 +77,36 @@ func (lr *LinkVxlanRaw) resolveStitchedVEthComponent(
 		return nil, nil, err
 	}
 
-	vethLink := hl.(*LinkVEth)
+	if hl == nil {
+		return nil, nil, fmt.Errorf("failed to resolve host veth component for vxlan-stitch")
+	}
 
-	// host endpoint is always the 2nd element in the Endpoints slice
-	return vethLink, vethLink.Endpoints[1], nil
+	eps := hl.GetEndpoints()
+	if len(eps) != 2 {
+		return nil, nil, fmt.Errorf(
+			"expected host veth component to resolve to 2 endpoints, got %d",
+			len(eps),
+		)
+	}
+
+	stitchEp, ok := endpointByInterfaceName(eps, hostIface)
+	if !ok {
+		return nil, nil, fmt.Errorf(
+			"expected host veth component to include endpoint %q",
+			hostIface,
+		)
+	}
+
+	return hl, stitchEp, nil
+}
+
+func endpointByInterfaceName(endpoints []Endpoint, ifaceName string) (Endpoint, bool) {
+	for _, ep := range endpoints {
+		if ep != nil && ep.GetIfaceName() == ifaceName {
+			return ep, true
+		}
+	}
+	return nil, false
 }
 
 // resolveStitchedVxlan resolves the stitched raw vxlan link.
@@ -316,6 +342,10 @@ func (l *LinkVxlan) Remove(ctx context.Context) error {
 
 func (l *LinkVxlan) GetEndpoints() []Endpoint {
 	return []Endpoint{l.localEndpoint, l.remoteEndpoint}
+}
+
+func (l *LinkVxlan) GetRuntimeEndpoints() []Endpoint {
+	return []Endpoint{l.localEndpoint}
 }
 
 func (*LinkVxlan) GetType() LinkType {

--- a/links/link_vxlan_stitched.go
+++ b/links/link_vxlan_stitched.go
@@ -58,6 +58,10 @@ func (l *VxlanStitched) Deploy(ctx context.Context, ep Endpoint) error {
 	return l.internalDeploy(ctx, ep, false)
 }
 
+func (l *VxlanStitched) PostDeploy(context.Context) error {
+	return l.Stitch()
+}
+
 func (l *VxlanStitched) internalDeploy(
 	ctx context.Context,
 	ep Endpoint,

--- a/links/link_vxlan_stitched.go
+++ b/links/link_vxlan_stitched.go
@@ -13,7 +13,7 @@ import (
 type VxlanStitched struct {
 	LinkCommonParams
 	vxlanLink *LinkVxlan
-	vethLink  *LinkVEth
+	vethLink  Link
 	// the veth does not distinguish between endpoints. but we
 	// need to know which endpoint is the one used for
 	// stitching therefore we get that endpoint separately
@@ -21,7 +21,7 @@ type VxlanStitched struct {
 }
 
 // NewVxlanStitched constructs a new VxlanStitched object.
-func NewVxlanStitched(vxlan *LinkVxlan, veth *LinkVEth, vethStitchEp Endpoint) *VxlanStitched {
+func NewVxlanStitched(vxlan *LinkVxlan, veth Link, vethStitchEp Endpoint) *VxlanStitched {
 	// init the VxlanStitched struct
 	vxlanStitched := &VxlanStitched{
 		LinkCommonParams: vxlan.LinkCommonParams,
@@ -112,6 +112,14 @@ func (l *VxlanStitched) Remove(ctx context.Context) error {
 // GetEndpoints returns the endpoints that are part of the link.
 func (l *VxlanStitched) GetEndpoints() []Endpoint {
 	return []Endpoint{l.vxlanLink.localEndpoint, l.vxlanLink.remoteEndpoint}
+}
+
+func (l *VxlanStitched) GetRuntimeEndpoints() []Endpoint {
+	eps := l.vethLink.GetRuntimeEndpoints()
+	endpoints := make([]Endpoint, 0, len(eps)+1)
+	endpoints = append(endpoints, eps...)
+	endpoints = append(endpoints, l.vxlanLink.localEndpoint)
+	return endpoints
 }
 
 // GetType returns the LinkType enum.

--- a/links/parking_node.go
+++ b/links/parking_node.go
@@ -30,7 +30,7 @@ func (p *ParkingNode) RepointSymlink() error {
 	return clabutils.LinkContainerNS(p.nspath, p.containerName)
 }
 
-func (p *ParkingNode) CaptureFrom(ctx context.Context, src EndpointOwner) error {
+func (p *ParkingNode) CaptureFrom(ctx context.Context, src Node) error {
 	endpoints, err := p.captureCandidates(ctx, src)
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func (p *ParkingNode) CaptureFrom(ctx context.Context, src EndpointOwner) error 
 	return nil
 }
 
-func (p *ParkingNode) RestoreTo(ctx context.Context, dst EndpointOwner) ([]Endpoint, error) {
+func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, error) {
 	if err := p.DiscoverOwnedEndpoints(ctx, dst); err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (p *ParkingNode) RestoreTo(ctx context.Context, dst EndpointOwner) ([]Endpo
 	return moved, nil
 }
 
-func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original EndpointOwner) error {
+func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original Node) error {
 	ifaceNames, err := listOwnedInterfaceNames(
 		ctx,
 		p,
@@ -142,15 +142,7 @@ func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original Endpo
 				continue
 			}
 
-			currentOwner, ok := ep.GetNode().(EndpointOwner)
-			if !ok {
-				return fmt.Errorf(
-					"node %q does not support endpoint ownership moves",
-					ep.GetNode().GetShortName(),
-				)
-			}
-
-			if err := currentOwner.ReleaseEndpoint(ep); err != nil {
+			if err := ep.GetNode().ReleaseEndpoint(ep); err != nil {
 				return err
 			}
 			ep.SetNode(p)
@@ -171,7 +163,7 @@ func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original Endpo
 
 func (p *ParkingNode) captureCandidates(
 	ctx context.Context,
-	src EndpointOwner,
+	src Node,
 ) ([]Endpoint, error) {
 	trackedEndpoints := src.GetEndpoints()
 	tracked := make(map[string]Endpoint, len(trackedEndpoints))

--- a/links/parking_node.go
+++ b/links/parking_node.go
@@ -38,9 +38,9 @@ func (p *ParkingNode) CaptureFrom(ctx context.Context, src Node) error {
 
 	moved := make([]Endpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
-		if err := ep.MoveTo(ctx, p); err != nil {
+		if err := moveEndpoint(ctx, ep, p); err != nil {
 			for i := len(moved) - 1; i >= 0; i-- {
-				if err := moved[i].MoveTo(ctx, src); err == nil {
+				if err := moveEndpoint(ctx, moved[i], src); err == nil {
 					_ = moved[i].Activate(ctx)
 				}
 			}
@@ -66,9 +66,9 @@ func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, erro
 	moved := make([]Endpoint, 0, len(endpoints))
 
 	for _, ep := range endpoints {
-		if err := ep.MoveTo(ctx, dst); err != nil {
+		if err := moveEndpoint(ctx, ep, dst); err != nil {
 			for i := len(moved) - 1; i >= 0; i-- {
-				_ = moved[i].MoveTo(ctx, p)
+				_ = moveEndpoint(ctx, moved[i], p)
 			}
 			return nil, fmt.Errorf(
 				"failed to restore interface %q for node %q: %w",
@@ -78,9 +78,9 @@ func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, erro
 			)
 		}
 		if err := ep.Activate(ctx); err != nil {
-			_ = ep.MoveTo(ctx, p)
+			_ = moveEndpoint(ctx, ep, p)
 			for i := len(moved) - 1; i >= 0; i-- {
-				_ = moved[i].MoveTo(ctx, p)
+				_ = moveEndpoint(ctx, moved[i], p)
 			}
 			return nil, fmt.Errorf(
 				"failed to activate interface %q for node %q: %w",

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -465,6 +465,20 @@ func (mr *MockNodeMockRecorder) IsHealthy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHealthy", reflect.TypeOf((*MockNode)(nil).IsHealthy), ctx)
 }
 
+// LinkApplyMode mocks base method.
+func (m *MockNode) LinkApplyMode(arg0 context.Context) nodes.LinkApplyMode {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkApplyMode", arg0)
+	ret0, _ := ret[0].(nodes.LinkApplyMode)
+	return ret0
+}
+
+// LinkApplyMode indicates an expected call of LinkApplyMode.
+func (mr *MockNodeMockRecorder) LinkApplyMode(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkApplyMode", reflect.TypeOf((*MockNode)(nil).LinkApplyMode), arg0)
+}
+
 // PostDeploy mocks base method.
 func (m *MockNode) PostDeploy(ctx context.Context, params *nodes.PostDeployParams) error {
 	m.ctrl.T.Helper()
@@ -491,6 +505,20 @@ func (m *MockNode) PostDeployEndpoints(ctx context.Context) error {
 func (mr *MockNodeMockRecorder) PostDeployEndpoints(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeployEndpoints", reflect.TypeOf((*MockNode)(nil).PostDeployEndpoints), ctx)
+}
+
+// ParkEndpoints mocks base method.
+func (m *MockNode) ParkEndpoints(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParkEndpoints", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ParkEndpoints indicates an expected call of ParkEndpoints.
+func (mr *MockNodeMockRecorder) ParkEndpoints(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParkEndpoints", reflect.TypeOf((*MockNode)(nil).ParkEndpoints), ctx)
 }
 
 // PreDeploy mocks base method.
@@ -534,6 +562,20 @@ func (m *MockNode) Reconcile(ctx context.Context, diff *types.TopologyDiff) (*no
 func (mr *MockNodeMockRecorder) Reconcile(ctx, diff any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockNode)(nil).Reconcile), ctx, diff)
+}
+
+// RestoreEndpoints mocks base method.
+func (m *MockNode) RestoreEndpoints(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreEndpoints", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreEndpoints indicates an expected call of RestoreEndpoints.
+func (mr *MockNodeMockRecorder) RestoreEndpoints(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreEndpoints", reflect.TypeOf((*MockNode)(nil).RestoreEndpoints), ctx)
 }
 
 // RunExec mocks base method.

--- a/mocks/mocknodes/node.go
+++ b/mocks/mocknodes/node.go
@@ -62,6 +62,20 @@ func (mr *MockNodeMockRecorder) AddEndpoint(e any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockNode)(nil).AddEndpoint), e)
 }
 
+// AdoptEndpoint mocks base method.
+func (m *MockNode) AdoptEndpoint(e links.Endpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AdoptEndpoint", e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AdoptEndpoint indicates an expected call of AdoptEndpoint.
+func (mr *MockNodeMockRecorder) AdoptEndpoint(e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdoptEndpoint", reflect.TypeOf((*MockNode)(nil).AdoptEndpoint), e)
+}
+
 // AddLinkToContainer mocks base method.
 func (m *MockNode) AddLinkToContainer(ctx context.Context, link netlink.Link, f func(ns.NetNS) error) error {
 	m.ctrl.T.Helper()
@@ -289,6 +303,20 @@ func (mr *MockNodeMockRecorder) GetHostsEntries(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostsEntries", reflect.TypeOf((*MockNode)(nil).GetHostsEntries), ctx)
 }
 
+// ReleaseEndpoint mocks base method.
+func (m *MockNode) ReleaseEndpoint(e links.Endpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReleaseEndpoint", e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReleaseEndpoint indicates an expected call of ReleaseEndpoint.
+func (mr *MockNodeMockRecorder) ReleaseEndpoint(e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseEndpoint", reflect.TypeOf((*MockNode)(nil).ReleaseEndpoint), e)
+}
+
 // GetImages mocks base method.
 func (m *MockNode) GetImages(arg0 context.Context) map[string]string {
 	m.ctrl.T.Helper()
@@ -449,6 +477,20 @@ func (m *MockNode) PostDeploy(ctx context.Context, params *nodes.PostDeployParam
 func (mr *MockNodeMockRecorder) PostDeploy(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeploy", reflect.TypeOf((*MockNode)(nil).PostDeploy), ctx, params)
+}
+
+// PostDeployEndpoints mocks base method.
+func (m *MockNode) PostDeployEndpoints(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostDeployEndpoints", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PostDeployEndpoints indicates an expected call of PostDeployEndpoints.
+func (mr *MockNodeMockRecorder) PostDeployEndpoints(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeployEndpoints", reflect.TypeOf((*MockNode)(nil).PostDeployEndpoints), ctx)
 }
 
 // PreDeploy mocks base method.

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -1052,7 +1052,7 @@ func (d *DefaultNode) DeployEndpoints(ctx context.Context) error {
 			continue
 		}
 
-		if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
+		if err := ep.GetLink().Deploy(ctx, ep); err != nil {
 			return err
 		}
 	}

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -1052,17 +1052,15 @@ func (d *DefaultNode) DeployEndpoints(ctx context.Context) error {
 			continue
 		}
 
-		deployable, ok := ep.(clablinks.DeployableEndpoint)
-		if !ok {
-			return fmt.Errorf("endpoint %q is not deployable", ep.GetIfaceName())
-		}
-
-		err := deployable.Deploy(ctx)
-		if err != nil {
+		if err := clablinks.DeployEndpoint(ctx, ep); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+func (*DefaultNode) PostDeployEndpoints(context.Context) error {
 	return nil
 }
 

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -224,11 +224,15 @@ type Node interface {
 	// AddEndpoint attaches an endpoint discovered from topology resolution and may normalize
 	// endpoint identity first, such as interface-name remapping.
 	AddEndpoint(e clablinks.Endpoint) error
+	AdoptEndpoint(e clablinks.Endpoint) error
+	ReleaseEndpoint(e clablinks.Endpoint) error
 	GetEndpoints() []clablinks.Endpoint
 	GetLinkEndpointType() clablinks.LinkEndpointType
 	GetShortName() string
 	// DeployEndpoints deploys the links for the node.
 	DeployEndpoints(ctx context.Context) error
+	// PostDeployEndpoints runs endpoint fixups after dataplane links exist.
+	PostDeployEndpoints(ctx context.Context) error
 	// ExecFunction executes the given function within the nodes network namespace
 	ExecFunction(context.Context, func(ns.NetNS) error) error
 	GetState() clabnodesstate.NodeState

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -45,10 +45,6 @@ const (
 	LinkApplyModeLive LinkApplyMode = clabtypes.LinkApplyModeLive
 )
 
-type linkApplyModeNode interface {
-	LinkApplyMode(context.Context) LinkApplyMode
-}
-
 // linkApplyModePermissiveness orders modes from most disruptive to least
 // disruptive; a higher rank means apply touches the node lifecycle less.
 var linkApplyModePermissiveness = map[LinkApplyMode]int{
@@ -66,11 +62,9 @@ func LinkApplyModeForNode(ctx context.Context, node Node) LinkApplyMode {
 	}
 
 	kindMode := LinkApplyModeRecreate
-	if modeNode, ok := node.(linkApplyModeNode); ok {
-		switch mode := modeNode.LinkApplyMode(ctx); mode {
-		case LinkApplyModeLive, LinkApplyModeRestart, LinkApplyModeRecreate:
-			kindMode = mode
-		}
+	switch mode := node.LinkApplyMode(ctx); mode {
+	case LinkApplyModeLive, LinkApplyModeRestart, LinkApplyModeRecreate:
+		kindMode = mode
 	}
 
 	override := LinkApplyModeOverrideForNode(node)
@@ -202,6 +196,8 @@ type Node interface {
 	// VerifyStartupConfig checks for existence of the referenced file and maybe performs additional
 	// config checks
 	VerifyStartupConfig(topoDir string) error
+	// LinkApplyMode returns how apply handles dataplane link changes for this node.
+	LinkApplyMode(context.Context) LinkApplyMode
 	SaveConfig(
 		context.Context,
 	) (*SaveConfigResult, error) // SaveConfig saves the nodes configuration to an external file
@@ -233,6 +229,10 @@ type Node interface {
 	DeployEndpoints(ctx context.Context) error
 	// PostDeployEndpoints runs endpoint fixups after dataplane links exist.
 	PostDeployEndpoints(ctx context.Context) error
+	// ParkEndpoints parks dataplane interfaces before node recreation.
+	ParkEndpoints(ctx context.Context) error
+	// RestoreEndpoints restores parked dataplane interfaces after node recreation.
+	RestoreEndpoints(ctx context.Context) error
 	// ExecFunction executes the given function within the nodes network namespace
 	ExecFunction(context.Context, func(ns.NetNS) error) error
 	GetState() clabnodesstate.NodeState

--- a/nodes/node.go
+++ b/nodes/node.go
@@ -220,7 +220,9 @@ type Node interface {
 	// AddEndpoint attaches an endpoint discovered from topology resolution and may normalize
 	// endpoint identity first, such as interface-name remapping.
 	AddEndpoint(e clablinks.Endpoint) error
+	// AdoptEndpoint adds an endpoint already owned by this node to its endpoint list.
 	AdoptEndpoint(e clablinks.Endpoint) error
+	// ReleaseEndpoint removes an endpoint owned by this node from its endpoint list.
 	ReleaseEndpoint(e clablinks.Endpoint) error
 	GetEndpoints() []clablinks.Endpoint
 	GetLinkEndpointType() clablinks.LinkEndpointType

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -619,17 +619,11 @@ func (n *sros) setupComponentNodes() error {
 
 	rootCtrName := n.calcComponentName(n.Cfg.LongName, n.Cfg.Components[0].Slot)
 
-	// Registry, because it is not a package Var
-	nr := clabnodes.NewNodeRegistry()
-	Register(nr)
-
 	// loop through the components, creating them
 	for idx, c := range n.Cfg.Components {
 		// instantiate a new nokia_srsim instance
-		componentNode, err := nr.NewNodeOfKind("nokia_srsim")
-		if err != nil {
-			return err
-		}
+		srosNode := new(sros)
+		componentNode := clabnodes.Node(srosNode)
 
 		// copy the original node's NodeConfig to the component
 		componentConfig, err := deep.Copy(n.Cfg)
@@ -688,13 +682,11 @@ func (n *sros) setupComponentNodes() error {
 		componentNode.WithRuntime(n.GetRuntime())
 
 		// store root components for cpms, for config gen
-		if srosNode, ok := componentNode.(*sros); ok {
-			srosNode.rootComponents = n.Cfg.Components
-			// store base node name
-			srosNode.baseShortName = n.Cfg.ShortName
-			srosNode.baseLongName = n.Cfg.LongName
-			srosNode.rootCtrName = rootCtrName
-		}
+		srosNode.rootComponents = n.Cfg.Components
+		// store base node name
+		srosNode.baseShortName = n.Cfg.ShortName
+		srosNode.baseLongName = n.Cfg.LongName
+		srosNode.rootCtrName = rootCtrName
 
 		// store the node in the componentNodes
 		n.componentNodes = append(n.componentNodes, componentNode)


### PR DESCRIPTION
## Summary
- move apply runtime endpoint selection onto the `links.Link` contract with `GetRuntimeEndpoints()`
- keep stitched-link capability in the `links` package and update apply/deploy callers
- persist apply state and reset resolved links for idempotent apply paths
- remove short kind aliases from the apply docs table
- select the VXLAN stitch endpoint by interface name instead of endpoint slice order

## Validation
- `go test ./links ./core ./cmd`

Split out from #3256 so that PR can stay focused on agent skills only.