### PR TITLE
sonic-vm: bind-mount authorized_keys into container for SSH key injection

### DIFF
--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -102,6 +102,17 @@ func (n *sonic_vm) PreDeploy(_ context.Context, params *clabnodes.PreDeployParam
 		return err
 	}
 
+	// Bind-mount the lab's authorized_keys file to /authorized_keys inside the
+	// container so that the vrnetlab launch.py bootstrap can inject it into the
+	// QEMU guest via the serial console, enabling passwordless SSH on first boot.
+	authzKeysFile := params.TopoPaths.AuthorizedKeysFilename()
+	if clabutils.FileExists(authzKeysFile) {
+		n.Cfg.Binds = append(
+			n.Cfg.Binds,
+			fmt.Sprintf("%s:/authorized_keys:ro", authzKeysFile),
+		)
+	}
+
 	return clabnodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
 }
 


### PR DESCRIPTION
## Summary

When a `sonic-vm` node is deployed, the host's SSH public keys are collected by containerlab into `authorized_keys` in the lab directory but never reach the QEMU guest VM. This means `ssh admin@<node>` always requires a password, unlike other containerlab kinds (SR Linux, SR OS, etc.) where passwordless SSH works out of the box.

This PR mounts the lab's `authorized_keys` file to `/authorized_keys:ro` inside the sonic-vm container in `PreDeploy()`. The vrnetlab `launch.py` bootstrap script reads this path during first-boot and writes the keys into `/home/admin/.ssh/authorized_keys` inside the QEMU guest via the already-open serial console session.

The bind is skipped when the file does not exist (e.g. no SSH keys found on the host), preserving current behaviour.

## Companion PR

This change requires a companion PR in **srl-labs/vrnetlab** that adds the `inject_authorized_keys()` function to `sonic/docker/launch.py` to consume the mounted file and inject the keys via serial console:

➡️ srl-labs/vrnetlab#502

## Test plan

- [x] Deploy a `sonic-vm` lab with containerlab
- [x] Verify `ssh admin@<node>` connects without a password prompt
- [x] Verify deployment without SSH keys on host completes without error (bind skipped)