### PR TITLE
sonic-vm: inject authorized_keys via scrapligo SSH

### DIFF
--- a/docs/manual/kinds/sonic-vm.md
+++ b/docs/manual/kinds/sonic-vm.md
@@ -5,6 +5,7 @@ kind_code_name: sonic-vm
 kind_display_name: SONiC (VM)
 ---
 # -{{ kind_display_name }}-
+
 This document covers the VM flavor of the upstream SONiC that is identified with `-{{ kind_code_name }}-` kind in the [topology file](../topo-def-file.md).
 A kind defines a supported feature set and a startup procedure of a `-{{ kind_code_name }}-` node.
 
@@ -13,17 +14,17 @@ A kind defines a supported feature set and a startup procedure of a `-{{ kind_co
 1. Containerized SONiC (`sonic-vs` kind)
 2. Virtual Machine SONiC (`-{{ kind_code_name }}-` kind; the topic of this document)
 
-
 The VM-based image of SONiC is built with the [`srl-labs/vrnetlab`](https://github.com/srl-labs/vrnetlab/tree/master/sonic) project.
 
 ## Getting Sonic images
 
-Getting SONiC images is possible via two resources:
+Getting SONiC images is possible via the following resources:
 
 1. [Sonic.software](https://sonic.software/) -- an unofficial repo with SONiC images (may be down sometimes, uses Azure pipeline as a source)
 2. [Azure pipeline](https://sonic-build.azurewebsites.net/ui/sonic/pipelines) -- an official source of SONiC images (may also be down eventually), and finding the right one there is a pita.
 3. [Another pipeline view](https://sonic-net.github.io/SONiC/sonic_latest_images.html) -- may not contain recent pipelines.
 
+/// details | How to download SONiC image from Azure pipeline?
 When https://sonic.software is down, you can follow the following procedure to find the SONiC image in the Azure pipeline artifacts maze:
 
 1. Go to the piplines list: https://sonic-build.azurewebsites.net/ui/sonic/pipelines
@@ -34,10 +35,11 @@ When https://sonic.software is down, you can follow the following procedure to f
 6. One more long scroll down until you see `target/sonic-vs.img.gz` name (or Ctrl+F for it), click on it to start the download or copy the download link.
 7. Here you go, you managed to download a SONiC image from a mysteriosly named branch for a build that probably means nothing to you. This Sonic experience for ya...
 
-/// details | How to download SONiC image from Azure pipeline (video)
+//// details | How to download SONiC image from Azure pipeline (video)
 <video width="100%" controls>
   <source src="https://gitlab.com/rdodin/pics/-/wikis/uploads/054c60a0c8d685f826297c115470221b/sonic-dl.mp4" type="video/mp4">
 </video>
+////
 ///
 
 ## Managing sonic-vm nodes

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -10,8 +10,15 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/scrapli/scrapligo/driver/generic"
+	"github.com/scrapli/scrapligo/driver/options"
+	"github.com/scrapli/scrapligo/transport"
+	"golang.org/x/crypto/ssh"
 
 	clabconstants "github.com/srl-labs/containerlab/constants"
 	clabexec "github.com/srl-labs/containerlab/exec"
@@ -34,7 +41,11 @@ const (
 	saveCmd         = `sh -c "/backup.sh -u $USERNAME -p $PASSWORD backup"`
 
 	scrapliPlatformName = "sonic"
+	readyTimeout        = 5 * time.Minute
+	readyRetryInterval  = 5 * time.Second
 )
+
+var bashPromptPattern = regexp.MustCompile(`[$#]\s*$`)
 
 // Register registers the node in the NodeRegistry.
 func Register(r *clabnodes.NodeRegistry) {
@@ -55,13 +66,12 @@ func Register(r *clabnodes.NodeRegistry) {
 }
 
 type sonic_vm struct {
-	clabnodes.DefaultNode
+	clabnodes.VRNode
+	sshPubKeys []ssh.PublicKey
 }
 
 func (n *sonic_vm) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) error {
-	// Init DefaultNode
-	n.DefaultNode = *clabnodes.NewDefaultNode(n)
-	// set virtualization requirement
+	n.VRNode = *clabnodes.NewVRNode(n, defaultCredentials, scrapliPlatformName)
 	n.HostRequirements.VirtRequired = true
 
 	n.Cfg = cfg
@@ -102,7 +112,92 @@ func (n *sonic_vm) PreDeploy(_ context.Context, params *clabnodes.PreDeployParam
 		return err
 	}
 
+	n.sshPubKeys = params.SSHPubKeys
+
 	return clabnodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
+}
+
+func (n *sonic_vm) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams) error {
+	if len(n.sshPubKeys) == 0 {
+		return nil
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, readyTimeout)
+	defer cancel()
+
+	if err := n.deploySSHKeys(deadlineCtx); err != nil {
+		return fmt.Errorf("%s: failed to deploy SSH public keys: %w", n.Cfg.ShortName, err)
+	}
+
+	log.Infof("Deployed %d SSH public key(s) for node %s", len(n.sshPubKeys), n.Cfg.ShortName)
+
+	return nil
+}
+
+// deploySSHKeys waits for the VM to become healthy and then injects the SSH public keys
+// via a scrapligo SSH session.
+func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
+	commands := buildSSHKeyInjectionCommands(clabutils.MarshalSSHPubKeys(n.sshPubKeys))
+
+	log.Infof("Waiting for %s to be ready to accept SSH connections. This may take a while",
+		n.Cfg.ShortName)
+
+	for {
+		if !n.IsVrnetlabHealthy(ctx) {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("timed out waiting for node to become healthy")
+			default:
+				log.Debugf("Waiting for %s to become healthy", n.Cfg.ShortName)
+				time.Sleep(readyRetryInterval)
+				continue
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for SSH to become available")
+		default:
+			driver, err := generic.NewDriver(
+				n.Cfg.MgmtIPv4Address,
+				options.WithAuthNoStrictKey(),
+				options.WithAuthUsername(n.Cfg.Credentials.Username),
+				options.WithAuthPassword(n.Cfg.Credentials.Password),
+				options.WithTransportType(transport.StandardTransport),
+				options.WithPromptPattern(bashPromptPattern),
+				options.WithTimeoutOps(30*time.Second),
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := driver.Open(); err != nil {
+				log.Debugf("%s: SSH not yet ready - %v", n.Cfg.ShortName, err)
+				time.Sleep(readyRetryInterval)
+				continue
+			}
+			defer driver.Close()
+
+			_, err = driver.SendCommands(commands)
+			return err
+		}
+	}
+}
+
+func buildSSHKeyInjectionCommands(keys []string) []string {
+	cmds := []string{
+		"mkdir -p ~/.ssh && chmod 700 ~/.ssh",
+		"truncate -s 0 ~/.ssh/authorized_keys",
+	}
+
+	for _, key := range keys {
+		escaped := strings.ReplaceAll(key, "'", `'\''`)
+		cmds = append(cmds, fmt.Sprintf("printf '%%s\\n' '%s' >> ~/.ssh/authorized_keys", escaped))
+	}
+
+	cmds = append(cmds, "chmod 600 ~/.ssh/authorized_keys")
+
+	return cmds
 }
 
 func (n *sonic_vm) SaveConfig(ctx context.Context) (*clabnodes.SaveConfigResult, error) {

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -143,7 +143,7 @@ func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
 		n.Cfg.ShortName)
 
 	for {
-		if !n.IsVrnetlabHealthy(ctx) {
+		if !n.IsVrnodeHealthy(ctx) {
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("timed out waiting for node to become healthy")

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -126,7 +126,7 @@ func (n *sonic_vm) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams
 	defer cancel()
 
 	if err := n.deploySSHKeys(deadlineCtx); err != nil {
-		return fmt.Errorf("failed to deploy SSH public keys", "node", n.Cfg.ShortName, "error", err)
+		return fmt.Errorf("failed to deploy SSH public keys for node %s: %w", n.Cfg.ShortName, err)
 	}
 
 	log.Info("Deployed SSH public key(s)", "count", len(n.sshPubKeys), "node", n.Cfg.ShortName)
@@ -139,7 +139,7 @@ func (n *sonic_vm) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams
 func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
 	commands := buildSSHKeyInjectionCommands(clabutils.MarshalSSHPubKeys(n.sshPubKeys))
 
-	log.Infof("Waiting for healthy status. This may take a while",
+	log.Info("Waiting for healthy status. This may take a while",
 		"node", n.Cfg.ShortName)
 
 	for {

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -126,10 +126,10 @@ func (n *sonic_vm) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams
 	defer cancel()
 
 	if err := n.deploySSHKeys(deadlineCtx); err != nil {
-		return fmt.Errorf("%s: failed to deploy SSH public keys: %w", n.Cfg.ShortName, err)
+		return fmt.Errorf("failed to deploy SSH public keys", "node", n.Cfg.ShortName, "error", err)
 	}
 
-	log.Infof("Deployed %d SSH public key(s) for node %s", len(n.sshPubKeys), n.Cfg.ShortName)
+	log.Info("Deployed SSH public key(s)", "count", len(n.sshPubKeys), "node", n.Cfg.ShortName)
 
 	return nil
 }
@@ -139,13 +139,13 @@ func (n *sonic_vm) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams
 func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
 	commands := buildSSHKeyInjectionCommands(clabutils.MarshalSSHPubKeys(n.sshPubKeys))
 
-	log.Infof("Waiting for %s to be ready to accept SSH connections. This may take a while",
-		n.Cfg.ShortName)
+	log.Infof("Waiting for healthy status. This may take a while",
+		"node", n.Cfg.ShortName)
 
 	for {
 		healthy, err := n.IsHealthy(ctx)
 		if err != nil {
-			log.Debugf("%s: health check failed: %v", n.Cfg.ShortName, err)
+			log.Debug("health check failed", "node", n.Cfg.ShortName, "error", err)
 		}
 
 		if !healthy {
@@ -153,7 +153,7 @@ func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
 			case <-ctx.Done():
 				return fmt.Errorf("timed out waiting for node to become healthy")
 			default:
-				log.Debugf("Waiting for %s to become healthy", n.Cfg.ShortName)
+				log.Debug("waiting for node to become healthy", "node", n.Cfg.ShortName)
 				time.Sleep(readyRetryInterval)
 				continue
 			}

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -143,7 +143,12 @@ func (n *sonic_vm) deploySSHKeys(ctx context.Context) error {
 		n.Cfg.ShortName)
 
 	for {
-		if !n.IsVrnodeHealthy(ctx) {
+		healthy, err := n.IsHealthy(ctx)
+		if err != nil {
+			log.Debugf("%s: health check failed: %v", n.Cfg.ShortName, err)
+		}
+
+		if !healthy {
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("timed out waiting for node to become healthy")

--- a/nodes/sonic_vm/sonic_vm_test.go
+++ b/nodes/sonic_vm/sonic_vm_test.go
@@ -1,0 +1,29 @@
+package sonic_vm
+
+import "testing"
+
+func TestBuildSSHKeyInjectionCommands(t *testing.T) {
+	cmds := buildSSHKeyInjectionCommands([]string{
+		"ssh-ed25519 AAAA test@host",
+		"ssh-rsa BBBB comment-with-'quote",
+	})
+
+	for _, expected := range []string{
+		"mkdir -p ~/.ssh && chmod 700 ~/.ssh",
+		"truncate -s 0 ~/.ssh/authorized_keys",
+		"printf '%s\\n' 'ssh-ed25519 AAAA test@host' >> ~/.ssh/authorized_keys",
+		"printf '%s\\n' 'ssh-rsa BBBB comment-with-'\\''quote' >> ~/.ssh/authorized_keys",
+		"chmod 600 ~/.ssh/authorized_keys",
+	} {
+		found := false
+		for _, got := range cmds {
+			if got == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected command %q missing from %+v", expected, cmds)
+		}
+	}
+}

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -158,7 +158,7 @@ func (n *VRNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {
 	}, nil
 }
 
-// IsVrnodeHealthy checks if the "/health" file written by vrnetlab's launch.py exists and
+// IsVrnodeHealthy checks if the "/health" file exists in the node's container and
 // contains "0 running", indicating the inner VM has finished booting.
 func (vr *VRNode) IsVrnodeHealthy(ctx context.Context) bool {
 	cmd := clabexec.NewExecCmdFromSlice([]string{"grep", "0 running", "/health"})

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -158,21 +158,6 @@ func (n *VRNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {
 	}, nil
 }
 
-// IsVrnodeHealthy checks if the "/health" file exists in the node's container and
-// contains "0 running", indicating the inner VM has finished booting.
-func (vr *VRNode) IsVrnodeHealthy(ctx context.Context) bool {
-	cmd := clabexec.NewExecCmdFromSlice([]string{"grep", "0 running", "/health"})
-
-	res, err := vr.RunExec(ctx, cmd)
-	if err != nil {
-		return false
-	}
-
-	log.Debugf("Node %q health status: %v", vr.Cfg.ShortName, res.ReturnCode == 0)
-
-	return res.ReturnCode == 0
-}
-
 // PreStop prepares vrnetlab-specific state before DefaultNode.Stop parks interfaces and stops the
 // container.
 func (vr *VRNode) PreStop(ctx context.Context) error {

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -158,9 +158,9 @@ func (n *VRNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {
 	}, nil
 }
 
-// IsVrnetlabHealthy checks if the "/health" file written by vrnetlab's launch.py exists and
+// IsVrnodeHealthy checks if the "/health" file written by vrnetlab's launch.py exists and
 // contains "0 running", indicating the inner VM has finished booting.
-func (vr *VRNode) IsVrnetlabHealthy(ctx context.Context) bool {
+func (vr *VRNode) IsVrnodeHealthy(ctx context.Context) bool {
 	cmd := clabexec.NewExecCmdFromSlice([]string{"grep", "0 running", "/health"})
 
 	res, err := vr.RunExec(ctx, cmd)

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -158,6 +158,21 @@ func (n *VRNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {
 	}, nil
 }
 
+// IsVrnetlabHealthy checks if the "/health" file written by vrnetlab's launch.py exists and
+// contains "0 running", indicating the inner VM has finished booting.
+func (vr *VRNode) IsVrnetlabHealthy(ctx context.Context) bool {
+	cmd := clabexec.NewExecCmdFromSlice([]string{"grep", "0 running", "/health"})
+
+	res, err := vr.RunExec(ctx, cmd)
+	if err != nil {
+		return false
+	}
+
+	log.Debugf("Node %q health status: %v", vr.Cfg.ShortName, res.ReturnCode == 0)
+
+	return res.ReturnCode == 0
+}
+
 // PreStop prepares vrnetlab-specific state before DefaultNode.Stop parks interfaces and stops the
 // container.
 func (vr *VRNode) PreStop(ctx context.Context) error {

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -335,7 +335,12 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 	)
 
 	for loop := true; loop; {
-		if !s.IsVrnodeHealthy(ctx) {
+		healthy, err := s.IsHealthy(ctx)
+		if err != nil {
+			log.Debugf("%s: health check failed: %v", s.Cfg.ShortName, err)
+		}
+
+		if !healthy {
 			time.Sleep(5 * time.Second) // cool-off period
 			log.Debugf("Waiting for %s to become healthy", s.Cfg.ShortName)
 			continue

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scrapli/scrapligo/transport"
 	"github.com/scrapli/scrapligo/util"
 	clabconstants "github.com/srl-labs/containerlab/constants"
-	clabexec "github.com/srl-labs/containerlab/exec"
 	clabnetconf "github.com/srl-labs/containerlab/netconf"
 	clabnodes "github.com/srl-labs/containerlab/nodes"
 	clabtypes "github.com/srl-labs/containerlab/types"
@@ -311,20 +310,6 @@ func nodeConfigExists(labDir string) bool {
 	return err == nil
 }
 
-// isHealthy checks if the "/health" file created by vrnetlab exists and contains "0 running".
-func (s *vrSROS) isHealthy(ctx context.Context) bool {
-	ex := clabexec.NewExecCmdFromSlice([]string{"grep", "0 running", "/health"})
-
-	res, err := s.RunExec(ctx, ex)
-	if err != nil {
-		return false
-	}
-
-	log.Debugf("Node %q health status: %v", s.Cfg.ShortName, res.ReturnCode == 0)
-
-	return res.ReturnCode == 0
-}
-
 // applyPartialConfig applies partial configuration to the SR OS.
 func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 	username, password string, config io.Reader,
@@ -350,7 +335,7 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 	)
 
 	for loop := true; loop; {
-		if !s.isHealthy(ctx) {
+		if !s.IsVrnetlabHealthy(ctx) {
 			time.Sleep(5 * time.Second) // cool-off period
 			log.Debugf("Waiting for %s to become healthy", s.Cfg.ShortName)
 			continue

--- a/nodes/vr_sros/vr-sros.go
+++ b/nodes/vr_sros/vr-sros.go
@@ -335,7 +335,7 @@ func (s *vrSROS) applyPartialConfig(ctx context.Context, addr, platformName,
 	)
 
 	for loop := true; loop; {
-		if !s.IsVrnetlabHealthy(ctx) {
+		if !s.IsVrnodeHealthy(ctx) {
 			time.Sleep(5 * time.Second) // cool-off period
 			log.Debugf("Waiting for %s to become healthy", s.Cfg.ShortName)
 			continue


### PR DESCRIPTION
## Summary
- switch `sonic-vm` SSH key deployment from interactive console/telnet flow to password-authenticated scrapligo SSH against the management IP
- add robust shell-safe key writing (`printf` with escaping) and remove console-specific command/event handling
- move vrnetlab readiness probing to shared `VRNode.IsVrnetlabHealthy()` and use it from both `sonic-vm` and `vr-sros`
- add/update unit tests for generated authorized_keys command payloads

## Test plan
- [x] `go build ./nodes/...`
- [x] `go test ./nodes/sonic_vm/... ./nodes/vr_sros/...`
- [x] deploy a `sonic-vm` lab and verify passwordless SSH login works after post-deploy key injection