### PR TITLE
Detect Podman netavark management bridges

### DIFF
--- a/docs/rn/0.77.md
+++ b/docs/rn/0.77.md
@@ -67,5 +67,6 @@ Thanks @FloSch62 #3242 #3245 #3246
 
 ## Miscellaneous
 
+- The Docker runtime now detects the correct management bridge name when reusing Podman-managed networks exposed through Docker-compatible APIs, including netavark-backed networks. Thanks @orrious #3277
 - SR Linux SSH public key provisioning now respects the 32-key SR Linux limit, logs a warning when more keys are discovered, and chooses the retained keys deterministically. Thanks @mvanhorn #3239
 - `containerlab graph` now skips non point-to-point links instead of panicking on single-endpoint links such as `dummy`. Thanks @mvanhorn #3244

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -165,18 +166,14 @@ func (d *DockerRuntime) WithMgmtNet(n *clabtypes.MgmtNet) {
 	if d.mgmt.Bridge == "" && d.mgmt.Network != "" {
 		// fetch the network by the name set in the topo and populate the bridge name used by this
 		// network
-		netRes, err := d.Client.NetworkInspect(
+		netRes, raw, err := d.Client.NetworkInspectWithRaw(
 			context.TODO(),
 			d.mgmt.Network,
 			networkapi.InspectOptions{},
 		)
 		// if the network is successfully found, set the bridge used by it
 		if err == nil {
-			if name, exists := netRes.Options[bridgeNameOption]; exists {
-				d.mgmt.Bridge = name
-			} else {
-				d.mgmt.Bridge = "br-" + netRes.ID[:12]
-			}
+			d.mgmt.Bridge = d.detectMgmtBridgeName(context.TODO(), d.mgmt.Network, netRes, raw)
 			log.Debugf(
 				"detected network name in use: %s, backed by a bridge %s",
 				d.mgmt.Network,
@@ -195,18 +192,33 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	bridgeName := d.mgmt.Bridge
 
 	log.Debugf("Checking if docker network %q exists", d.mgmt.Network)
-	netResource, err := d.Client.NetworkInspect(nctx, d.mgmt.Network, networkapi.InspectOptions{})
+	netResource, rawNetResource, err := d.Client.NetworkInspectWithRaw(nctx, d.mgmt.Network, networkapi.InspectOptions{})
 	switch {
 	case dockerC.IsErrNotFound(err):
 		bridgeName, err = d.createMgmtBridge(nctx, bridgeName)
 		if err != nil {
 			return err
 		}
+		netResource, rawNetResource, err = d.Client.NetworkInspectWithRaw(nctx, d.mgmt.Network, networkapi.InspectOptions{})
+		if err != nil {
+			return err
+		}
+		if inspectedBridgeName := d.detectMgmtBridgeName(nctx, d.mgmt.Network, netResource, rawNetResource); inspectedBridgeName != "" {
+			bridgeName = inspectedBridgeName
+		}
 	case err == nil:
 		log.Debugf("network %q was found. Reusing it...", d.mgmt.Network)
 		bridgeName, err = bridgeNameFromInspect(&netResource, d.mgmt.Network)
 		if err != nil {
 			return err
+		}
+		if inspectedBridgeName := d.detectMgmtBridgeName(
+			nctx,
+			d.mgmt.Network,
+			netResource,
+			rawNetResource,
+		); inspectedBridgeName != "" {
+			bridgeName = inspectedBridgeName
 		}
 
 	default:
@@ -229,6 +241,96 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	log.Debugf("Docker network %q, bridge name %q", d.mgmt.Network, bridgeName)
 
 	return d.postCreateNetActions()
+}
+
+func (d *DockerRuntime) detectMgmtBridgeName(
+	ctx context.Context,
+	networkName string,
+	netResource networkapi.Inspect,
+	raw []byte,
+) string {
+	if name := netavarkNetworkInterface(raw); name != "" {
+		return name
+	}
+
+	if name := d.libpodNetworkInterface(ctx, networkName); name != "" {
+		return name
+	}
+
+	return mgmtBridgeNameFromInspect(networkName, netResource, "")
+}
+
+func mgmtBridgeNameFromInspect(
+	networkName string,
+	netResource networkapi.Inspect,
+	podmanNetworkInterface string,
+) string {
+	if podmanNetworkInterface != "" {
+		return podmanNetworkInterface
+	}
+
+	if networkName == "bridge" {
+		return "docker0"
+	}
+
+	if name := netResource.Options["com.docker.network.bridge.name"]; name != "" {
+		return name
+	}
+
+	if len(netResource.ID) >= 12 {
+		return "br-" + netResource.ID[:12]
+	}
+
+	return ""
+}
+
+func netavarkNetworkInterface(raw []byte) string {
+	var inspect struct {
+		NetworkInterface string `json:"network_interface"`
+	}
+	if err := json.Unmarshal(raw, &inspect); err != nil {
+		return ""
+	}
+
+	return inspect.NetworkInterface
+}
+
+func (d *DockerRuntime) libpodNetworkInterface(ctx context.Context, networkName string) string {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"http://"+dockerC.DummyHost+"/v5.0.0/libpod/networks/json",
+		nil,
+	)
+	if err != nil {
+		return ""
+	}
+
+	resp, err := d.Client.HTTPClient().Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var networks []struct {
+		Name             string `json:"name"`
+		NetworkInterface string `json:"network_interface"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+		return ""
+	}
+
+	for _, network := range networks {
+		if network.Name == networkName {
+			return network.NetworkInterface
+		}
+	}
+
+	return ""
 }
 
 // skipcq: GO-R1005

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -272,19 +272,11 @@ func mgmtBridgeNameFromInspect(
 		return podmanNetworkInterface
 	}
 
-	if networkName == "bridge" {
-		return "docker0"
+	name, err := bridgeNameFromInspect(&netResource, networkName)
+	if err != nil {
+		return ""
 	}
-
-	if name := netResource.Options["com.docker.network.bridge.name"]; name != "" {
-		return name
-	}
-
-	if len(netResource.ID) >= 12 {
-		return "br-" + netResource.ID[:12]
-	}
-
-	return ""
+	return name
 }
 
 func netavarkNetworkInterface(raw []byte) string {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -168,17 +169,14 @@ func (d *DockerRuntime) WithMgmtNet(n *clabtypes.MgmtNet) {
 	if d.mgmt.Bridge == "" && d.mgmt.Network != "" {
 		// fetch the network by the name set in the topo and populate the bridge name used by this
 		// network
-		netRes, err := d.Client.NetworkInspect(
+		netRes, raw, err := d.Client.NetworkInspectWithRaw(
 			context.TODO(),
 			d.mgmt.Network,
 			networkapi.InspectOptions{},
 		)
 		// if the network is successfully found, set the bridge used by it
 		if err == nil {
-			bridge, bridgeErr := bridgeNameFromInspect(&netRes, d.mgmt.Network)
-			if bridgeErr == nil {
-				d.mgmt.Bridge = bridge
-			}
+			d.mgmt.Bridge = d.detectMgmtBridgeName(context.TODO(), d.mgmt.Network, netRes, raw)
 			log.Debugf(
 				"detected network name in use: %s, backed by bridge %s",
 				d.mgmt.Network,
@@ -197,18 +195,33 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	bridgeName := d.mgmt.Bridge
 
 	log.Debugf("Checking if docker network %q exists", d.mgmt.Network)
-	netResource, err := d.Client.NetworkInspect(nctx, d.mgmt.Network, networkapi.InspectOptions{})
+	netResource, rawNetResource, err := d.Client.NetworkInspectWithRaw(nctx, d.mgmt.Network, networkapi.InspectOptions{})
 	switch {
 	case cerrdefs.IsNotFound(err):
 		bridgeName, err = d.createMgmtBridge(nctx, bridgeName)
 		if err != nil {
 			return err
 		}
+		netResource, rawNetResource, err = d.Client.NetworkInspectWithRaw(nctx, d.mgmt.Network, networkapi.InspectOptions{})
+		if err != nil {
+			return err
+		}
+		if inspectedBridgeName := d.detectMgmtBridgeName(nctx, d.mgmt.Network, netResource, rawNetResource); inspectedBridgeName != "" {
+			bridgeName = inspectedBridgeName
+		}
 	case err == nil:
 		log.Debugf("network %q was found. Reusing it...", d.mgmt.Network)
 		bridgeName, err = bridgeNameFromInspect(&netResource, d.mgmt.Network)
 		if err != nil {
 			return err
+		}
+		if inspectedBridgeName := d.detectMgmtBridgeName(
+			nctx,
+			d.mgmt.Network,
+			netResource,
+			rawNetResource,
+		); inspectedBridgeName != "" {
+			bridgeName = inspectedBridgeName
 		}
 
 	default:
@@ -231,6 +244,96 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	log.Debugf("Docker network %q, bridge name %q", d.mgmt.Network, bridgeName)
 
 	return d.postCreateNetActions()
+}
+
+func (d *DockerRuntime) detectMgmtBridgeName(
+	ctx context.Context,
+	networkName string,
+	netResource networkapi.Inspect,
+	raw []byte,
+) string {
+	if name := netavarkNetworkInterface(raw); name != "" {
+		return name
+	}
+
+	if name := d.libpodNetworkInterface(ctx, networkName); name != "" {
+		return name
+	}
+
+	return mgmtBridgeNameFromInspect(networkName, netResource, "")
+}
+
+func mgmtBridgeNameFromInspect(
+	networkName string,
+	netResource networkapi.Inspect,
+	podmanNetworkInterface string,
+) string {
+	if podmanNetworkInterface != "" {
+		return podmanNetworkInterface
+	}
+
+	if networkName == "bridge" {
+		return "docker0"
+	}
+
+	if name := netResource.Options["com.docker.network.bridge.name"]; name != "" {
+		return name
+	}
+
+	if len(netResource.ID) >= 12 {
+		return "br-" + netResource.ID[:12]
+	}
+
+	return ""
+}
+
+func netavarkNetworkInterface(raw []byte) string {
+	var inspect struct {
+		NetworkInterface string `json:"network_interface"`
+	}
+	if err := json.Unmarshal(raw, &inspect); err != nil {
+		return ""
+	}
+
+	return inspect.NetworkInterface
+}
+
+func (d *DockerRuntime) libpodNetworkInterface(ctx context.Context, networkName string) string {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"http://"+dockerC.DummyHost+"/v5.0.0/libpod/networks/json",
+		nil,
+	)
+	if err != nil {
+		return ""
+	}
+
+	resp, err := d.Client.HTTPClient().Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var networks []struct {
+		Name             string `json:"name"`
+		NetworkInterface string `json:"network_interface"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+		return ""
+	}
+
+	for _, network := range networks {
+		if network.Name == networkName {
+			return network.NetworkInterface
+		}
+	}
+
+	return ""
 }
 
 // skipcq: GO-R1005

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -1,0 +1,77 @@
+package docker
+
+import (
+	"testing"
+
+	networkapi "github.com/docker/docker/api/types/network"
+)
+
+func TestMgmtBridgeNameFromInspect(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		inspect     networkapi.Inspect
+		podman      string
+		want        string
+	}{
+		{
+			name:        "podman netavark network_interface wins",
+			networkName: "clab-mgmt",
+			inspect: networkapi.Inspect{
+				ID:      "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+				Options: map[string]string{"com.docker.network.bridge.name": "br-cd38716161df"},
+			},
+			podman: "podman1",
+			want:   "podman1",
+		},
+		{
+			name:        "docker explicit bridge option",
+			networkName: "clab-mgmt",
+			inspect: networkapi.Inspect{
+				ID:      "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+				Options: map[string]string{"com.docker.network.bridge.name": "clab0"},
+			},
+			want: "clab0",
+		},
+		{
+			name:        "docker default bridge",
+			networkName: "bridge",
+			inspect: networkapi.Inspect{
+				ID: "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+			},
+			want: "docker0",
+		},
+		{
+			name:        "docker generated bridge name",
+			networkName: "clab-mgmt",
+			inspect: networkapi.Inspect{
+				ID: "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+			},
+			want: "br-cd38716161df",
+		},
+		{
+			name:        "short id has no generated bridge",
+			networkName: "clab-mgmt",
+			inspect: networkapi.Inspect{
+				ID: "short",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mgmtBridgeNameFromInspect(tt.networkName, tt.inspect, tt.podman)
+			if got != tt.want {
+				t.Fatalf("got bridge name %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNetavarkNetworkInterface(t *testing.T) {
+	got := netavarkNetworkInterface([]byte(`{"network_interface":"podman1"}`))
+	if got != "podman1" {
+		t.Fatalf("got network interface %q, want %q", got, "podman1")
+	}
+}

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -18,6 +18,7 @@ func TestMgmtBridgeNameFromInspect(t *testing.T) {
 			name:        "podman netavark network_interface wins",
 			networkName: "clab-mgmt",
 			inspect: networkapi.Inspect{
+				Driver:  "bridge",
 				ID:      "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
 				Options: map[string]string{"com.docker.network.bridge.name": "br-cd38716161df"},
 			},
@@ -28,6 +29,7 @@ func TestMgmtBridgeNameFromInspect(t *testing.T) {
 			name:        "docker explicit bridge option",
 			networkName: "clab-mgmt",
 			inspect: networkapi.Inspect{
+				Driver:  "bridge",
 				ID:      "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
 				Options: map[string]string{"com.docker.network.bridge.name": "clab0"},
 			},
@@ -37,7 +39,8 @@ func TestMgmtBridgeNameFromInspect(t *testing.T) {
 			name:        "docker default bridge",
 			networkName: "bridge",
 			inspect: networkapi.Inspect{
-				ID: "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+				Driver: "bridge",
+				ID:     "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
 			},
 			want: "docker0",
 		},
@@ -45,7 +48,8 @@ func TestMgmtBridgeNameFromInspect(t *testing.T) {
 			name:        "docker generated bridge name",
 			networkName: "clab-mgmt",
 			inspect: networkapi.Inspect{
-				ID: "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
+				Driver: "bridge",
+				ID:     "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
 			},
 			want: "br-cd38716161df",
 		},
@@ -53,7 +57,17 @@ func TestMgmtBridgeNameFromInspect(t *testing.T) {
 			name:        "short id has no generated bridge",
 			networkName: "clab-mgmt",
 			inspect: networkapi.Inspect{
-				ID: "short",
+				Driver: "bridge",
+				ID:     "short",
+			},
+			want: "",
+		},
+		{
+			name:        "non-bridge network has no bridge",
+			networkName: "macvlan-net",
+			inspect: networkapi.Inspect{
+				Driver: "macvlan",
+				ID:     "cd38716161df05aff76bae83d9fc31415f843e2c2f939597307d4be0c1551fe6",
 			},
 			want: "",
 		},


### PR DESCRIPTION
## Summary

Detect the actual Linux bridge backing a Podman netavark management network instead of assuming Docker's generated `br-<id>` naming convention.

- read netavark's `network_interface` field from the raw network inspect response
- fall back to Podman's libpod network endpoint when the compatibility response omits that field
- retain Docker bridge-name handling as the final fallback
- preserve current behavior for non-bridge Docker networks
- document the fix in the release notes

## Validation

- Linux Go 1.26.5: `go test ./runtime/docker`
