### PR TITLE
Unified and improved error check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,11 +7,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/fang"
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
@@ -304,4 +306,19 @@ func processGitTopoFile(topo string) (string, error) {
 	}
 
 	return repo.GetFilename(), err
+}
+
+// ErrorHandler logs each error of an aggregated error on its own line before
+// handing a short summary to fangs default handler.
+func ErrorHandler(w io.Writer, styles fang.Styles, err error) {
+	errs := flattenErrors([]error{err})
+	if len(errs) > 1 {
+		for _, e := range errs {
+			log.Error(e)
+		}
+
+		err = fmt.Errorf("%d errors occurred", len(errs))
+	}
+
+	fang.DefaultErrorHandler(w, styles, err)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
+	clabconstants "github.com/srl-labs/containerlab/constants"
 	clabcore "github.com/srl-labs/containerlab/core"
 )
 
 func validateCmd(o *Options) (*cobra.Command, error) {
+	format := clabconstants.FormatTable
+
 	c := &cobra.Command{
 		Use:   "validate",
 		Short: "validate a topology file",
@@ -16,32 +21,110 @@ func validateCmd(o *Options) (*cobra.Command, error) {
 			"\nreference: https://containerlab.dev/cmd/validate/",
 		Aliases:      []string{"val"},
 		SilenceUsage: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return validateFn(o)
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return validateFn(cobraCmd.Context(), o, format)
 		},
 	}
+
+	c.Flags().StringVarP(&format, "format", "f", format, "output format. One of [table, json]")
 
 	return c, nil
 }
 
 // validateFn parses the topology (NewContainerLab runs all schema/node checks)
 // and resolves links, reporting any error without touching the runtime state.
-func validateFn(o *Options) error {
+func validateFn(ctx context.Context, o *Options, format string) error {
+	if format != clabconstants.FormatTable && format != clabconstants.FormatJSON {
+		return fmt.Errorf("output format %q is not supported, use one of [table, json]", format)
+	}
+
+	var errs []error
+
+	name := ""
+	nodes := 0
+	links := 0
+
 	c, err := clabcore.NewContainerLab(o.ToClabOptions()...)
 	if err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
-	if c.Config.Name == "" || len(c.Nodes) == 0 {
+	switch {
+	case c == nil:
+	case err == nil && (c.Config.Name == "" || len(c.Nodes) == 0):
 		return fmt.Errorf("topology file %q defines no name or nodes. likely an empty file", c.TopoPaths.TopologyFilenameBase())
+	default:
+		name = c.Config.Name
+
+		if err := c.ResolveLinks(); err != nil {
+			errs = append(errs, err)
+		}
+
+		if err := c.ValidateTopology(ctx); err != nil {
+			errs = append(errs, err)
+		}
+
+		nodes = len(c.Nodes)
+		links = len(c.Links)
 	}
 
-	if err := c.ResolveLinks(); err != nil {
-		return err
+	issues := flattenErrors(errs)
+
+	if format == clabconstants.FormatJSON {
+		messages := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			messages = append(messages, issue.Error())
+		}
+
+		out, err := json.MarshalIndent(struct {
+			Name   string   `json:"name"`
+			Valid  bool     `json:"valid"`
+			Nodes  int      `json:"nodes"`
+			Links  int      `json:"links"`
+			Errors []string `json:"errors"`
+		}{
+			Name:   name,
+			Valid:  len(issues) == 0,
+			Nodes:  nodes,
+			Links:  links,
+			Errors: messages,
+		}, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(out))
 	}
 
-	log.Info("Topology is valid", "name", c.Config.Name,
-		"nodes", len(c.Nodes), "links", len(c.Links))
+	if len(issues) > 0 {
+		if format == clabconstants.FormatTable {
+			for _, issue := range issues {
+				log.Error(issue)
+			}
+		}
+
+		return fmt.Errorf("topology is invalid: %d error(s) found", len(issues))
+	}
+
+	if format == clabconstants.FormatTable {
+		log.Info("Topology is valid", "name", name, "nodes", nodes, "links", links)
+	}
 
 	return nil
+}
+
+func flattenErrors(errs []error) []error {
+	var flat []error
+
+	for _, err := range errs {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			flat = append(flat, flattenErrors(joined.Unwrap())...)
+
+			continue
+		}
+
+		flat = append(flat, err)
+	}
+
+	return flat
 }

--- a/core/apply.go
+++ b/core/apply.go
@@ -136,7 +136,7 @@ func (c *CLab) apply(
 		return nil, err
 	}
 
-	if err := c.checkApplyTopologyDefinition(ctx); err != nil {
+	if err := c.ValidateTopology(ctx); err != nil {
 		return nil, err
 	}
 
@@ -223,24 +223,6 @@ func (c *CLab) apply(
 	}
 
 	return applyResultFromPlan(plan), nil
-}
-
-func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {
-	if err := c.verifyLinks(ctx); err != nil {
-		return err
-	}
-
-	if err := c.verifyRootNetNSLinks(); err != nil {
-		return err
-	}
-
-	for _, nodeName := range sortedNodeNames(c.Nodes) {
-		if err := c.Nodes[nodeName].CheckDeploymentConditions(ctx); err != nil {
-			return err
-		}
-	}
-
-	return c.verifyDuplicateAddresses()
 }
 
 func (c *CLab) prepareApply(

--- a/core/clab.go
+++ b/core/clab.go
@@ -66,6 +66,10 @@ type CLab struct {
 	// to avoid repeated repository opens. Empty strings indicate not yet cached.
 	gitBranch string
 	gitHash   string
+	// validationErrors collects non-fatal topology errors (decode errors,
+	// invalid nodes) during loading; NewContainerLab returns them joined so the
+	// caller gets the fully loaded topology together with everything wrong with it.
+	validationErrors []error
 }
 
 // NewContainerLab function defines a new container lab.
@@ -95,9 +99,10 @@ func NewContainerLab(opts ...ClabOption) (*CLab, error) {
 		}
 	}
 
-	var err error
 	if c.TopoPaths.TopologyFileIsSet() {
-		err = c.parseTopology()
+		if err := c.parseTopology(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Extract the host systems DNS servers and populate the
@@ -107,7 +112,7 @@ func NewContainerLab(opts ...ClabOption) (*CLab, error) {
 		return nil, err
 	}
 
-	return c, err
+	return c, errors.Join(c.validationErrors...)
 }
 
 // RuntimeInitializer returns a runtime initializer function for a provided runtime name.
@@ -685,4 +690,9 @@ func (c *CLab) CheckConnectivity(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// addValidationError records a non-fatal topology error found while loading.
+func (c *CLab) addValidationError(err error) {
+	c.validationErrors = append(c.validationErrors, err)
 }

--- a/core/config.go
+++ b/core/config.go
@@ -146,7 +146,7 @@ func (c *CLab) parseTopology() error {
 	for idx, nodeName := range nodeNames {
 		err = c.NewNode(nodeName, nodeRuntimes[nodeName], c.Config.Topology.Nodes[nodeName], idx)
 		if err != nil {
-			return err
+			c.addValidationError(err)
 		}
 	}
 
@@ -163,6 +163,23 @@ func (c *CLab) NewNode(
 	nodeCfg, err := c.createNodeCfg(nodeName, nodeDef, idx)
 	if err != nil {
 		return err
+	}
+
+	if nodeCfg.Kind == "" {
+		errs := []error{fmt.Errorf(
+			"node %q has no kind defined, set the kind on the node or in the topology defaults/groups",
+			nodeCfg.ShortName)}
+
+		// without a kind the node cannot be constructed and its other attributes
+		// cannot be checked, so report the missing image here as well
+		if nodeCfg.Image == "" {
+			errs = append(errs, fmt.Errorf(
+				"node %q has no image defined, note that all kinds except bridge, host, "+
+					"ovs-bridge, ext-container and k8s-kind require one",
+				nodeCfg.ShortName))
+		}
+
+		return errors.Join(errs...)
 	}
 
 	// construct node
@@ -439,23 +456,7 @@ func (c *CLab) processNodeLicense(nodeCfg *clabtypes.NodeConfig) error {
 // checkTopologyDefinition runs topology checks and returns any errors found.
 // This function runs after topology file is parsed and all nodes/links are initialized.
 func (c *CLab) checkTopologyDefinition(ctx context.Context) error {
-	if err := c.verifyLinks(ctx); err != nil {
-		return err
-	}
-
-	if err := c.verifyRootNetNSLinks(); err != nil {
-		return err
-	}
-
-	// Check deployment conditions for all nodes (sequentially)
-	for _, node := range c.Nodes {
-		err := node.CheckDeploymentConditions(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := c.verifyDuplicateAddresses(); err != nil {
+	if err := c.ValidateTopology(ctx); err != nil {
 		return err
 	}
 
@@ -585,6 +586,8 @@ func (*CLab) loadKernelModules() error {
 
 // verifyDuplicateAddresses checks that every static IP address in the topology is unique.
 func (c *CLab) verifyDuplicateAddresses() error {
+	var errs []error
+
 	dupIps := map[string]struct{}{}
 	for _, node := range c.Nodes {
 		ips := []string{node.Config().MgmtIPv4Address, node.Config().MgmtIPv6Address}
@@ -600,15 +603,15 @@ func (c *CLab) verifyDuplicateAddresses() error {
 
 				dupIps[ip] = struct{}{}
 			} else {
-				return fmt.Errorf(
+				errs = append(errs, fmt.Errorf(
 					"management IP address %s appeared more than once in the topology file",
 					ip,
-				)
+				))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // verifyContainersUniqueness ensures that nodes defined in the topology do not have names of the

--- a/core/file.go
+++ b/core/file.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -102,9 +103,12 @@ func (c *CLab) LoadTopologyFromFile(topo string, varsFiles []string) error {
 
 	err = yaml.UnmarshalStrict(yamlFile, c.Config)
 	if err != nil {
-		return fmt.Errorf(
-			"%w\nConsult with release notes to see if any fields were changed/removed", err,
-		)
+		var typeErr *yaml.TypeError
+		if !errors.As(err, &typeErr) {
+			return err
+		}
+
+		c.addValidationError(descriptiveYamlError(typeErr))
 	}
 
 	c.Config.Topology.ImportEnvs()

--- a/core/options_clab.go
+++ b/core/options_clab.go
@@ -191,7 +191,7 @@ func WithTopoPath(path string, varsFiles []string) ClabOption {
 		}
 
 		if err := c.LoadTopologyFromFile(file, varsFiles); err != nil {
-			return fmt.Errorf("failed to read topology file: %v", err)
+			return fmt.Errorf("failed to read topology file: %w", err)
 		}
 
 		return c.initMgmtNetwork()

--- a/core/validate.go
+++ b/core/validate.go
@@ -1,0 +1,191 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"syscall"
+
+	"github.com/charmbracelet/log"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	yamlDupKeyRe   = regexp.MustCompile(`^line (\d+): key "(.*)" already set in map$`)
+	yamlBadFieldRe = regexp.MustCompile(`^line (\d+): field (\S+) not found in type \S+$`)
+)
+
+// descriptiveYamlError rewrites the yaml-speak of strict unmarshal errors
+// ("key already set in map", "field not found in type") into topology file
+// terms, one error per finding.
+func descriptiveYamlError(typeErr *yaml.TypeError) error {
+	errs := make([]error, 0, len(typeErr.Errors))
+
+	for _, msg := range typeErr.Errors {
+		if m := yamlDupKeyRe.FindStringSubmatch(msg); m != nil {
+			errs = append(errs, fmt.Errorf("line %s: %q is defined more than once", m[1], m[2]))
+
+			continue
+		}
+
+		if m := yamlBadFieldRe.FindStringSubmatch(msg); m != nil {
+			errs = append(errs, fmt.Errorf(
+				"line %s: unknown field %q, consult the release notes to see if it was renamed or removed",
+				m[1], m[2]))
+
+			continue
+		}
+
+		errs = append(errs, errors.New(msg))
+	}
+
+	return errors.Join(errs...)
+}
+
+// ValidateTopology runs the topology checks shared by the validate, deploy and
+// apply commands, collecting all found errors instead of failing on the first one.
+func (c *CLab) ValidateTopology(ctx context.Context) error {
+	var errs []error
+
+	if err := c.verifyLinks(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := c.verifyRootNetNSLinks(); err != nil {
+		errs = append(errs, err)
+	}
+
+	for _, nodeName := range sortedNodeNames(c.Nodes) {
+		if err := c.Nodes[nodeName].CheckDeploymentConditions(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := c.verifyDuplicateAddresses(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := c.checkHostPortsAvailable(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+// checkHostPortsAvailable checks that the host ports requested by the nodes port
+// bindings are not already in use on the host and are not requested by more than
+// one node in the topology. Ports published by the lab's own running containers
+// are exempt from the probe so that a running lab revalidates cleanly.
+func (c *CLab) checkHostPortsAvailable(ctx context.Context) error {
+	var errs []error
+
+	claimed := map[string]string{}
+
+	// fetched lazily on the first bound port, topologies without port bindings
+	// skip the runtime roundtrip entirely
+	var ownPorts map[string]bool
+
+	for name, n := range c.Nodes {
+		for port, bindings := range n.Config().PortBindings {
+			for _, binding := range bindings {
+				if binding.HostPort == "" {
+					// the runtime will pick a free port
+					continue
+				}
+
+				if ownPorts == nil {
+					ownPorts = c.ownPublishedPorts(ctx)
+				}
+
+				addr := net.JoinHostPort(binding.HostIP, binding.HostPort)
+				key := addr + "/" + port.Proto()
+
+				if other, exists := claimed[key]; exists {
+					errs = append(errs, fmt.Errorf(
+						"host port %s/%s is used by both node %q and node %q",
+						addr, port.Proto(), other, name))
+
+					continue
+				}
+
+				claimed[key] = name
+
+				// ponytail: exemption matches port/proto only, ignoring the host IP
+				if ownPorts[binding.HostPort+"/"+port.Proto()] {
+					continue
+				}
+
+				if err := checkPortAvailable(port.Proto(), addr); err != nil {
+					errs = append(errs, fmt.Errorf(
+						"node %q: host port %s/%s %w", name, addr, port.Proto(), err))
+				}
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// ownPublishedPorts returns the "port/proto" set currently published by the
+// lab's own running containers.
+func (c *CLab) ownPublishedPorts(ctx context.Context) map[string]bool {
+	ports := map[string]bool{}
+
+	if c.Config.Name == "" {
+		return ports
+	}
+
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	containers, err := c.ListContainers(nctx, WithListLabName(c.Config.Name))
+	if err != nil {
+		log.Debugf("could not list the lab's own containers for the port check: %v", err)
+
+		return ports
+	}
+
+	for i := range containers {
+		for _, p := range containers[i].Ports {
+			if p.HostPort != 0 {
+				ports[fmt.Sprintf("%d/%s", p.HostPort, p.Protocol)] = true
+			}
+		}
+	}
+
+	return ports
+}
+
+// checkPortAvailable probes a host port by briefly binding it. Only conclusive
+// failures (port taken, host IP not present on this host) are returned
+func checkPortAvailable(proto, addr string) error {
+	var err error
+
+	switch proto {
+	case "tcp":
+		var l net.Listener
+		if l, err = net.Listen(proto, addr); err == nil {
+			l.Close()
+		}
+	case "udp":
+		var pc net.PacketConn
+		if pc, err = net.ListenPacket(proto, addr); err == nil {
+			pc.Close()
+		}
+	default:
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, syscall.EADDRINUSE):
+		return errors.New("is already in use on the host")
+	case errors.Is(err, syscall.EADDRNOTAVAIL):
+		return errors.New("refers to an IP address that is not configured on the host")
+	case err != nil:
+		log.Debugf("could not probe availability of host port %s/%s: %v", addr, proto, err)
+	}
+
+	return nil
+}

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestDescriptiveYamlError(t *testing.T) {
+	typeErr := &yaml.TypeError{Errors: []string{
+		`line 8: key "n1" already set in map`,
+		`line 7: field bogus-field not found in type types.NodeDefinitionWithDeprecatedFields`,
+		`line 3: cannot unmarshal !!str ` + "`abc`" + ` into int`,
+	}}
+
+	got := descriptiveYamlError(typeErr).Error()
+
+	for _, want := range []string{
+		`line 8: "n1" is defined more than once`,
+		`line 7: unknown field "bogus-field"`,
+		"line 3: cannot unmarshal", // untranslated messages pass through
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in error, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestCheckPortAvailable(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	addr := l.Addr().String()
+
+	if err := checkPortAvailable("tcp", addr); err == nil {
+		t.Errorf("expected error for busy port %s, got nil", addr)
+	}
+
+	l.Close()
+
+	if err := checkPortAvailable("tcp", addr); err != nil {
+		t.Errorf("expected no error for free port %s, got %v", addr, err)
+	}
+
+	// unsupported protocols are not probed
+	if err := checkPortAvailable("sctp", addr); err != nil {
+		t.Errorf("expected no error for sctp, got %v", err)
+	}
+}

--- a/links/generic_link_node_test.go
+++ b/links/generic_link_node_test.go
@@ -23,6 +23,26 @@ func (e *deleteTestEndpoint) Remove(context.Context) error {
 	return nil
 }
 
+func TestCheckEndpointUniqueness(t *testing.T) {
+	node := newFakeNode("n1")
+
+	ep1 := &EndpointVeth{EndpointGeneric: EndpointGeneric{Node: node, IfaceName: "eth1"}}
+	ep2 := &EndpointVeth{EndpointGeneric: EndpointGeneric{Node: node, IfaceName: "eth1"}}
+
+	_ = node.AddEndpoint(ep1)
+	_ = node.AddEndpoint(ep2)
+
+	if err := CheckEndpointUniqueness(ep1); err == nil {
+		t.Fatal("expected duplicate endpoint error, got nil")
+	}
+
+	ep2.IfaceName = "eth2"
+
+	if err := CheckEndpointUniqueness(ep1); err != nil {
+		t.Fatalf("expected no error for unique endpoints, got %v", err)
+	}
+}
+
 func TestGenericLinkNodeDeleteHandlesEndpointsWithoutLink(t *testing.T) {
 	node := &GenericLinkNode{
 		shortname: "test-node",

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	root.SetContext(ctx)
 
-	err = fang.Execute(ctx, root, fang.WithoutVersion())
+	err = fang.Execute(ctx, root, fang.WithoutVersion(), fang.WithErrorHandler(clabcmd.ErrorHandler))
 
 	// ensure cancel is *always* called (os.Exit bypasses)
 	cancel()

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -120,32 +120,33 @@ func (d *DefaultNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {
 // CheckDeploymentConditions wraps individual functions that check if a node
 // satisfies deployment requirements.
 func (d *DefaultNode) CheckDeploymentConditions(ctx context.Context) error {
-	err := d.OverwriteNode.VerifyHostRequirements()
-	if err != nil {
-		return err
+	var errs []error
+
+	if err := d.VerifyNodeImage(ctx); err != nil {
+		errs = append(errs, err)
 	}
 
-	err = d.OverwriteNode.VerifyStartupConfig(d.Cfg.LabDir)
-	if err != nil {
-		return err
+	if err := d.OverwriteNode.VerifyHostRequirements(); err != nil {
+		errs = append(errs, err)
 	}
 
-	err = d.OverwriteNode.CheckInterfaceName()
-	if err != nil {
-		return err
+	if err := d.OverwriteNode.VerifyStartupConfig(d.Cfg.LabDir); err != nil {
+		errs = append(errs, err)
 	}
 
-	err = d.OverwriteNode.VerifyLicenseFileExists(ctx)
-	if err != nil {
-		return err
+	if err := d.OverwriteNode.CheckInterfaceName(); err != nil {
+		errs = append(errs, err)
 	}
 
-	err = d.OverwriteNode.VerifyContainerName()
-	if err != nil {
-		return err
+	if err := d.OverwriteNode.VerifyLicenseFileExists(ctx); err != nil {
+		errs = append(errs, err)
 	}
 
-	return nil
+	if err := d.OverwriteNode.VerifyContainerName(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
 }
 
 func (d *DefaultNode) PullImage(ctx context.Context) error {
@@ -505,27 +506,13 @@ func (d *DefaultNode) DeleteNetnsSymlink() error {
 	return clabutils.DeleteNetnsSymlink(d.OverwriteNode.GetContainerName())
 }
 
-func (d *DefaultNode) CheckInterfaceOverlap() error {
-	var seenEps []clablinks.Endpoint
-
-	for _, ep := range d.Endpoints {
-		ifName := ep.GetIfaceName()
-		for _, seenEp := range seenEps {
-			if ifName == seenEp.GetIfaceName() {
-				return fmt.Errorf("%q and %q have overlapping interface names", ep, seenEp)
-			}
-		}
-		seenEps = append(seenEps, ep)
-	}
-
-	return nil
-}
-
 // CheckInterfaceName checks if a name of the interface referenced in the topology file is in the
 // expected range of name values.
 // A no-op for the default node, specific nodes should implement this method.
-func (d *DefaultNode) CheckInterfaceName() error {
-	return d.CheckInterfaceOverlap()
+// Duplicate interface names are caught by the endpoint uniqueness check during
+// link verification.
+func (*DefaultNode) CheckInterfaceName() error {
+	return nil
 }
 
 // CalculateInterfaceIndex parses the supplied interface name with the InterfaceRegexp.
@@ -1242,4 +1229,18 @@ func (d *DefaultNode) Start(ctx context.Context) error {
 	execCollection.Log()
 
 	return nil
+}
+
+// VerifyNodeImage checks that every image required by the node is defined.
+func (d *DefaultNode) VerifyNodeImage(ctx context.Context) error {
+	var errs []error
+
+	for imageKey, imageName := range d.OverwriteNode.GetImages(ctx) {
+		if imageName == "" {
+			errs = append(errs, fmt.Errorf(
+				"missing required %q attribute for node %q", imageKey, d.Cfg.ShortName))
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -542,30 +542,6 @@ func TestInterfacesAliases(t *testing.T) { // skipcq: GO-R1005
 				"eth1", "eth2", "eth4",
 			},
 		},
-		"overlap": {
-			endpoints: []*clablinks.EndpointVeth{
-				{
-					EndpointGeneric: clablinks.EndpointGeneric{
-						IfaceName: "ge-0/0/1",
-					},
-				},
-				{
-					EndpointGeneric: clablinks.EndpointGeneric{
-						IfaceName: "eth1",
-					},
-				},
-			},
-			node: &DefaultNode{
-				Cfg: &clabtypes.NodeConfig{
-					ShortName: "juniper-overlap",
-				},
-				InterfaceRegexp: regexp.MustCompile(`(?:et|xe|ge)-0/0/(?P<port>\d+)$`),
-				InterfaceOffset: 0,
-			},
-			endpointErrContains: "",
-			checkErrContains:    "overlapping interface names",
-			resultEps:           []string{},
-		},
 		"out-of-bounds-index": {
 			endpoints: []*clablinks.EndpointVeth{
 				{

--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -411,31 +412,30 @@ func (n *iol) AddEndpoint(e clablinks.Endpoint) error {
 }
 
 func (n *iol) CheckInterfaceName() error {
-	err := n.CheckInterfaceOverlap()
-	if err != nil {
-		return err
-	}
+	var errs []error
 
 	for _, e := range n.Endpoints {
 		IFaceName := e.GetIfaceName()
 		if MgmtIntfRegexp.MatchString(IFaceName) {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"IOL Node: %q. Management interface Ethernet0/0, e0/0 or eth0 is not allowed",
 				n.Cfg.ShortName,
-			)
+			))
+
+			continue
 		}
 
 		if !DefaultIntfRegexp.MatchString(IFaceName) {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"IOL Node %q has an interface named %q which doesn't match the required pattern. %s",
 				n.Cfg.ShortName,
 				IFaceName,
 				IntfHelpMsg,
-			)
+			))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (n *iol) UpdateMgmtIntf(ctx context.Context) error {

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -1035,29 +1036,28 @@ func (n *srl) CheckInterfaceName() error {
 	ifRe := regexp.MustCompile(`(:?e|ethernet)\d+-\d+(-\d+)?|` + mgmt0InterfaceName)
 	nm := strings.ToLower(n.Cfg.NetworkMode)
 
-	err := n.CheckInterfaceOverlap()
-	if err != nil {
-		return err
-	}
+	var errs []error
 
 	for _, e := range n.Endpoints {
 		if !ifRe.MatchString(e.GetIfaceName()) {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"nokia sr linux interface name %q doesn't match the required pattern: %s",
 				e.GetIfaceName(),
 				n.InterfaceHelp,
-			)
+			))
+
+			continue
 		}
 
 		if e.GetIfaceName() == mgmt0InterfaceName && nm != "none" {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"mgmt0 interface name is not allowed for %s node when network mode is not set to none",
 				n.Cfg.ShortName,
-			)
+			))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // createRepoFiles creates apt/ym repository files

--- a/nodes/sros/sros.go
+++ b/nodes/sros/sros.go
@@ -1550,29 +1550,28 @@ func (n *sros) GetMappedInterfaceName(ifName string) (string, error) {
 func (n *sros) CheckInterfaceName() error {
 	nm := n.Cfg.NetworkMode
 
-	err := n.CheckInterfaceOverlap()
-	if err != nil {
-		return err
-	}
+	var errs []error
 
 	for _, e := range n.Endpoints {
 		if !MappedInterfaceRegexp.MatchString(e.GetIfaceName()) {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"nokia SR OS interface name %q doesn't match the required pattern: %s",
 				e.GetIfaceName(),
 				n.InterfaceHelp,
-			)
+			))
+
+			continue
 		}
 
 		if e.GetIfaceName() == "eth0" && nm != "none" {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"eth0 interface name is not allowed for %s node when network mode is not set to none",
 				n.Cfg.ShortName,
-			)
+			))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (n *sros) SaveConfig(ctx context.Context) (*clabnodes.SaveConfigResult, error) {

--- a/nodes/vr_node.go
+++ b/nodes/vr_node.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,24 +107,21 @@ func (vr *VRNode) AddEndpoint(e clablinks.Endpoint) error {
 // CheckInterfaceName checks interface names for generic VM-based nodes.
 // Displays InterfaceHelp if the check fails for the expected VM interface regexp.
 func (vr *VRNode) CheckInterfaceName() error {
-	err := vr.CheckInterfaceOverlap()
-	if err != nil {
-		return err
-	}
+	var errs []error
 
 	for _, ep := range vr.Endpoints {
 		ifName := ep.GetIfaceName()
 		if !VMInterfaceRegexp.MatchString(ifName) {
-			return fmt.Errorf(
+			errs = append(errs, fmt.Errorf(
 				"%q interface name %q does not match the required interface patterns: %q",
 				vr.Cfg.ShortName,
 				ifName,
 				vr.InterfaceHelp,
-			)
+			))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (n *VRNode) SaveConfig(_ context.Context) (*SaveConfigResult, error) {


### PR DESCRIPTION
Strengthen the validate command to not just return the 1st error. Instead we can now collect all errors and display them to the user/report them with validate cmd.

Instead to just add this to the validate command, this is all unified to deploy/apply etc. should get the same error checking flow.