### PR TITLE
nodes/srsim: Add ED25519 key support for SR-SIM 26.7 and higher

### DIFF
--- a/nodes/sros/configs/ixr/ixr_config_classic.go.tpl
+++ b/nodes/sros/configs/ixr/ixr_config_classic.go.tpl
@@ -135,6 +135,15 @@ echo "System Security Configuration"
                         exit
 {{ end }}
                     exit
+{{ if .SSHPubKeysED25519 }}
+                    ed25519
+{{ range $index, $key := .SSHPubKeysED25519 }}
+                        ed25519-key {{ subtract 32 $index }} create
+                            key-value {{ $key }}
+                        exit
+{{ end }}
+                    exit
+{{ end }}
                 exit
                 console
                     member "administrative"

--- a/nodes/sros/configs/sar/sar_config_classic.go.tpl
+++ b/nodes/sros/configs/sar/sar_config_classic.go.tpl
@@ -118,6 +118,15 @@ echo "System Security Configuration"
                         exit
 {{ end }}
                     exit
+{{ if .SSHPubKeysED25519 }}
+                    ed25519
+{{ range $index, $key := .SSHPubKeysED25519 }}
+                        ed25519-key {{ subtract 32 $index }} create
+                            key-value {{ $key }}
+                        exit
+{{ end }}
+                    exit
+{{ end }}
                 exit
                 console
                     member "administrative"

--- a/nodes/sros/configs/sros_config_classic.go.tpl
+++ b/nodes/sros/configs/sros_config_classic.go.tpl
@@ -131,6 +131,15 @@ echo "System Security Configuration"
                         exit
 {{ end }}
                     exit
+{{ if .SSHPubKeysED25519 }}
+                    ed25519
+{{ range $index, $key := .SSHPubKeysED25519 }}
+                        ed25519-key {{ subtract 32 $index }} create
+                            key-value {{ $key }}
+                        exit
+{{ end }}
+                    exit
+{{ end }}
                 exit
                 console
                     member "administrative"

--- a/nodes/sros/configs/sros_config_sros25.go.tpl
+++ b/nodes/sros/configs/sros_config_sros25.go.tpl
@@ -16,5 +16,9 @@
 {{ range $index, $key := .SSHPubKeysECDSA }}
 /configure system security user-params local-user user "admin" public-keys ecdsa ecdsa-key {{ subtract 32 $index }} key-value {{ $key }}
 {{ end }}
+
+{{ range $index, $key := .SSHPubKeysED25519 }}
+/configure system security user-params local-user user "admin" public-keys ed25519 ed25519-key {{ subtract 32 $index }} key-value {{ $key }}
+{{ end }}
 {{/* Component configuration for cards, xioms, xiom-mdas and mdas */}}
 {{ .ComponentConfig }}

--- a/nodes/sros/sros_test.go
+++ b/nodes/sros/sros_test.go
@@ -226,6 +226,7 @@ func Test_sros_buildStartupConfig(t *testing.T) {
 			LongName:      "lab-n1",
 			StartupConfig: cfgPath,
 		}
+		n.swVersion = &SrosVersion{"0", "0", "0"}
 
 		cfg, err := n.buildStartupConfig(false) // full config, not partial
 		require.NoError(t, err)
@@ -255,6 +256,7 @@ func Test_sros_buildStartupConfig(t *testing.T) {
 			LabDir:      t.TempDir(),
 		}
 		n.WithRuntime(mockRt)
+		n.swVersion = &SrosVersion{"0", "0", "0"}
 
 		cfg, err := n.buildStartupConfig(true) // no full config; use default + partial
 		require.NoError(t, err)

--- a/nodes/sros/ssh.go
+++ b/nodes/sros/ssh.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scrapli/scrapligo/transport"
 	"github.com/scrapli/scrapligo/util"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/mod/semver"
 )
 
 // limitSSHKeys truncates SSH keys to SROS maximum of 32 per type.
@@ -41,10 +42,19 @@ func (n *sros) prepareSSHPubKeys(tplData *srosTemplateData) {
 		ssh.KeyAlgoECDSA256: &tplData.SSHPubKeysECDSA,
 	}
 
+	currVersion := tplData.SwVersion.MajorMinorSemverString()
+	if semver.Compare(currVersion, "v26.7") >= 0 {
+		supportedSSHKeyAlgos[ssh.KeyAlgoED25519] = &tplData.SSHPubKeysED25519
+	}
+
 	n.mapSSHPubKeys(supportedSSHKeyAlgos)
 
 	limitSSHKeys(&tplData.SSHPubKeysRSA, "RSA")
 	limitSSHKeys(&tplData.SSHPubKeysECDSA, "ECDSA")
+	if semver.Compare(currVersion, "v26.7") >= 0 {
+		limitSSHKeys(&tplData.SSHPubKeysED25519, "ED25519")
+	}
+
 }
 
 // mapSSHPubKeys goes over s.sshPubKeys and puts the supported keys to the corresponding

--- a/nodes/sros/ssh_test.go
+++ b/nodes/sros/ssh_test.go
@@ -3,18 +3,23 @@ package sros
 import (
 	"testing"
 
+	"github.com/srl-labs/containerlab/nodes"
+	"github.com/srl-labs/containerlab/types"
 	"golang.org/x/crypto/ssh"
 )
 
 func Test_sros_mapSSHPubKeys(t *testing.T) {
 	tests := []struct {
-		name          string
-		keysAsStr     [][]byte
-		expectedRSA   int
-		expectedECDSA int
+		name            string
+		keysAsStr       [][]byte
+		version         *SrosVersion
+		expectedRSA     int
+		expectedECDSA   int
+		expectedED25519 int
 	}{
 		{
-			name: "Test with 3 rsa and 4 ecdsa keys",
+			name:    "Test with 3 rsa, 4 ecdsa and 2 ED25519 keys",
+			version: &SrosVersion{"26", "7", "1"},
 			keysAsStr: [][]byte{
 				[]byte(
 					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDhR6+tNYAAP0i40O5INIrSGMuhQH2R6nsH0ZfPlMScmvORGgGPyFFHg76MiVIudEnwDKaytkZZmOJM1aWvF94WZJQDhzR6Uz9W8k14cRDPhOrLXjTbu2LKWRJtJpvcVB/gjhMoOuzGID/lBzpzC4bKLVYBze7Ek3XrTjf6xlB3I4G3GVCJHO6gDfpQqSPucXiXtO2gMhk1sKDVDD1N/31VSxVwHDB1BHUREM/rbmGHSSJaEjAByxYIL80kLQRTejnL3NMXGbuVisO6OL4H2h9gdTNppjQjSUCKcn/IFOx7LuYO64xGm3ThfBKRWVQNul2Ab/pL4/BqD4ziZ3Wad94Ob7kClKeY9rO9I1wfSckDaF1CvabeyM63ekNF8xOViDOfBJGK+eOWsN5nKVcD2lSzQZAolDGSYQPcSeZ82/oqcHrG/kUcVZxuU5Lkc8QpDYlW0EorrUIvgM0Ta7GrmcxAU1WxUD9W6GzNbrCm71eP4Gu9ZD+U6p0+r4XC0bGUThE=",
@@ -37,18 +42,28 @@ func Test_sros_mapSSHPubKeys(t *testing.T) {
 				[]byte(
 					"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAC+ZByJkRXxaZQQ3NDJRDQudtrV1PguOUJ/43UFMmHr8KfA5+oYG/lQzFgXwXxe4OWefJPjuSEqcNuw3xvb5MTVJwFEyXPRyyjljSUhdocWemAMb9oh8t9B4daPwoe0sVG7m9VH0h4uESFuf/SjHhngZgtuh22j9OpEbMiJjOgGL3JC/w==",
 				),
+				[]byte(
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBkGFC/EiEb8+WrHSopj1LKhjjicD9bUsENim666p3jX",
+				),
+				[]byte(
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAEqo0zpGPF/teMviFV5w8G492w8tAMHXnUCaAewT0t",
+				),
 			},
-			expectedRSA:   3,
-			expectedECDSA: 4,
+			expectedRSA:     3,
+			expectedECDSA:   4,
+			expectedED25519: 2,
 		},
 		{
-			name:          "Test without keys",
-			keysAsStr:     [][]byte{},
-			expectedRSA:   0,
-			expectedECDSA: 0,
+			name:            "Test without keys",
+			version:         &SrosVersion{"26", "7", "1"},
+			keysAsStr:       [][]byte{},
+			expectedRSA:     0,
+			expectedECDSA:   0,
+			expectedED25519: 0,
 		},
 		{
-			name: "Test with 35 RSA and 40 ecdsa keys",
+			name:    "Test with 35 RSA, 40 ecdsa and 45 ED25519 keys",
+			version: &SrosVersion{"26", "7", "1"},
 			keysAsStr: func() [][]byte {
 				rsaKey := []byte(
 					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDXvF3x+IWYfy957yhPqN+kfO/vCXitJ4jAZJVp28P5yw43TKHFqmoecITEtS4i8Rrt+w+L6I7t4XKRptEeISLdOzxkMgVfutShqBrxMkWSmwRd2vFABT5In1gsU666cahAF2n7kNC2X2OBw8oANcsk+nsPGZzOfFyCPB1Vc8z/66UJAbe3bwSjnwzUAShXkPpMmaGhm7+LY9foH4aW0ho4vlGXnZ7M1WDlnBC+9ae8MUP5eAgNw+q0MPlKmzDXDoxQTKEtY1Mu66oacUmIsqxRFajrVCplc2O9MGhcNw8Z+TKkrP7cJxgX0kMh92m2LVV3TLMcI513aBhvDzwHdTH/Tqn/qpa2Jpqovg9RpJBCIjX8tN6j8TKsdfDnqadW8HL89Lrlv36lk6DOD872z3zxajH9FaJgVjQjxEVYafZDqgHHNnNLp05IBwuExV2q93ML7WdhWemSgIVV2GF7cgEcnHWm+Q7JKCJTMEUBimshJEaMm6ROcgfDO4KFpMYpJAc=",
@@ -58,18 +73,62 @@ func Test_sros_mapSSHPubKeys(t *testing.T) {
 					"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAC+ZByJkRXxaZQQ3NDJRDQudtrV1PguOUJ/43UFMmHr8KfA5+oYG/lQzFgXwXxe4OWefJPjuSEqcNuw3xvb5MTVJwFEyXPRyyjljSUhdocWemAMb9oh8t9B4daPwoe0sVG7m9VH0h4uESFuf/SjHhngZgtuh22j9OpEbMiJjOgGL3JC/w==",
 				)
 
-				keys := make([][]byte, 75)
+				ed25519Key := []byte(
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAEqo0zpGPF/teMviFV5w8G492w8tAMHXnUCaAewT0t",
+				)
+
+				keys := make([][]byte, 120)
 				for i := 0; i < 35; i++ {
 					keys[i] = rsaKey
 				}
 				for i := 35; i < 75; i++ {
 					keys[i] = ecdsaKey
 				}
+				for i := 75; i < 120; i++ {
+					keys[i] = ed25519Key
+				}
 
 				return keys
 			}(),
-			expectedRSA:   32, // SROS supports a maximum of 32 keys per key type
-			expectedECDSA: 32,
+			expectedRSA:     32, // SROS supports a maximum of 32 keys per key type
+			expectedECDSA:   32,
+			expectedED25519: 32,
+		},
+		{
+			name:    "Test with 3 rsa, 4 ecdsa and 2 ED25519 keys on version not supporting ED25519 keys",
+			version: &SrosVersion{"25", "10", "1"},
+			keysAsStr: [][]byte{
+				[]byte(
+					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDhR6+tNYAAP0i40O5INIrSGMuhQH2R6nsH0ZfPlMScmvORGgGPyFFHg76MiVIudEnwDKaytkZZmOJM1aWvF94WZJQDhzR6Uz9W8k14cRDPhOrLXjTbu2LKWRJtJpvcVB/gjhMoOuzGID/lBzpzC4bKLVYBze7Ek3XrTjf6xlB3I4G3GVCJHO6gDfpQqSPucXiXtO2gMhk1sKDVDD1N/31VSxVwHDB1BHUREM/rbmGHSSJaEjAByxYIL80kLQRTejnL3NMXGbuVisO6OL4H2h9gdTNppjQjSUCKcn/IFOx7LuYO64xGm3ThfBKRWVQNul2Ab/pL4/BqD4ziZ3Wad94Ob7kClKeY9rO9I1wfSckDaF1CvabeyM63ekNF8xOViDOfBJGK+eOWsN5nKVcD2lSzQZAolDGSYQPcSeZ82/oqcHrG/kUcVZxuU5Lkc8QpDYlW0EorrUIvgM0Ta7GrmcxAU1WxUD9W6GzNbrCm71eP4Gu9ZD+U6p0+r4XC0bGUThE=",
+				),
+				[]byte(
+					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1XraioeGL9OVkGVu9yMLVkVWMYrp2yP377HoKqA63VuDuJMDHVKT/BDINh/NUiorS1jOwu3cE66ZvU8w2hC9gkIdCUZ6ZTsUP2Zb1bk1V/kNbjd77Ra9iSssK/o2SBzeOZ6k0xbz1Yp9cXbTNh2s5g5/E764rd2hdyRWYagC1re7hrTBuxEXEJC4+1iUsp2gC1ZxNG2ol1UOk1e7sHV/eiw9VyIDyNiU0d8Dul4a5/Fp4/vBiEI6BvVegeQTgJd29Guf2Tl7oOwFiQpdDevnN/CcsCuEF5zcdywIujaLwwEIjI7rf6210DXQdxNlruI1Oq8koIn/WAhH/geeRDA7mSIRxYF2Uqb+VErNF2iTq7P6/609bcXow8S5TfB8PIQH/E9gItTg2XlgAwAB/HYlUUUwrjhNYUtYvQq3a+EjdJFKTJdHQp08xVb1f4aD+61NSROwtwHm+NHttdSIo9nqqSpdm0KxlS9t6iVVJALqy8oiUEBWJDVilRB7RLyHt0sk=",
+				),
+				[]byte(
+					"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDXvF3x+IWYfy957yhPqN+kfO/vCXitJ4jAZJVp28P5yw43TKHFqmoecITEtS4i8Rrt+w+L6I7t4XKRptEeISLdOzxkMgVfutShqBrxMkWSmwRd2vFABT5In1gsU666cahAF2n7kNC2X2OBw8oANcsk+nsPGZzOfFyCPB1Vc8z/66UJAbe3bwSjnwzUAShXkPpMmaGhm7+LY9foH4aW0ho4vlGXnZ7M1WDlnBC+9ae8MUP5eAgNw+q0MPlKmzDXDoxQTKEtY1Mu66oacUmIsqxRFajrVCplc2O9MGhcNw8Z+TKkrP7cJxgX0kMh92m2LVV3TLMcI513aBhvDzwHdTH/Tqn/qpa2Jpqovg9RpJBCIjX8tN6j8TKsdfDnqadW8HL89Lrlv36lk6DOD872z3zxajH9FaJgVjQjxEVYafZDqgHHNnNLp05IBwuExV2q93ML7WdhWemSgIVV2GF7cgEcnHWm+Q7JKCJTMEUBimshJEaMm6ROcgfDO4KFpMYpJAc=",
+				),
+				[]byte(
+					"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBiXo8DavZ3rzNfynQCr5WJia1S5VT2Jx91OEjqeipcwzpqqeSciaIIwGt78Oq7PCNNrBoYDns+rjtzKq4ViFhk=",
+				),
+				[]byte(
+					"ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBDi9AlTU5OMFKIjLSCQMCwH+IQtv82sfU2BDsSLdFeM7xiZtNSUzoaH+WQA61rwNi4sc3iddQLv54LyxC9Z7auL+ItsoDulQ9TklBq7mlmQfS5yS0LsdSAaK7iGKfiLong==",
+				),
+				[]byte(
+					"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBABZMizDux+9W92bOxwgPVTTau4xLzcUVF+vfkySVaop7cq8YtJ4QbxTbOkawpG8ZC9gCGzhiVqF7aFhoMIF0jpF5AGcBUxm1ahp7uURmI7YXjlnvzHMgrp0ot8sdY8ibjZSGYzK0BuGOsZFq1cFQRJjIWoNTJjqRFqA/gLIWaab2V9nrg==",
+				),
+				[]byte(
+					"ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAC+ZByJkRXxaZQQ3NDJRDQudtrV1PguOUJ/43UFMmHr8KfA5+oYG/lQzFgXwXxe4OWefJPjuSEqcNuw3xvb5MTVJwFEyXPRyyjljSUhdocWemAMb9oh8t9B4daPwoe0sVG7m9VH0h4uESFuf/SjHhngZgtuh22j9OpEbMiJjOgGL3JC/w==",
+				),
+				[]byte(
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBkGFC/EiEb8+WrHSopj1LKhjjicD9bUsENim666p3jX",
+				),
+				[]byte(
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAEqo0zpGPF/teMviFV5w8G492w8tAMHXnUCaAewT0t",
+				),
+			},
+			expectedRSA:     3,
+			expectedECDSA:   4,
+			expectedED25519: 0,
 		},
 	}
 
@@ -86,9 +145,14 @@ func Test_sros_mapSSHPubKeys(t *testing.T) {
 
 			s := &sros{
 				sshPubKeys: keys,
+				DefaultNode: nodes.DefaultNode{
+					Cfg: &types.NodeConfig{
+						ShortName: "test",
+					},
+				},
 			}
 
-			tmplData := &srosTemplateData{}
+			tmplData := &srosTemplateData{SwVersion: tt.version}
 
 			s.prepareSSHPubKeys(tmplData)
 
@@ -105,6 +169,14 @@ func Test_sros_mapSSHPubKeys(t *testing.T) {
 					"expected %d ECDSA keys, got %d",
 					tt.expectedECDSA,
 					len(tmplData.SSHPubKeysECDSA),
+				)
+			}
+
+			if len(tmplData.SSHPubKeysED25519) != tt.expectedED25519 {
+				t.Errorf(
+					"expected %d ED25519 keys, got %d",
+					tt.expectedECDSA,
+					len(tmplData.SSHPubKeysED25519),
 				)
 			}
 		})

--- a/nodes/sros/template.go
+++ b/nodes/sros/template.go
@@ -17,9 +17,10 @@ type srosTemplateData struct {
 	TLSAnchor string
 
 	// Banner and SSH
-	Banner          string
-	SSHPubKeysRSA   []string
-	SSHPubKeysECDSA []string
+	Banner            string
+	SSHPubKeysRSA     []string
+	SSHPubKeysECDSA   []string
+	SSHPubKeysED25519 []string
 
 	// Network configuration
 	IFaces     map[string]tplIFace


### PR DESCRIPTION
ED25519 SSH keys are now supported in SR-OS 26.7.R1 (and newer). This PR adds support for automatically adding these type of SSH keys.