### PR TITLE
Add plvision_sonic node kind for PLVision Enterprise SONiC

### DIFF
--- a/core/register.go
+++ b/core/register.go
@@ -64,6 +64,7 @@ import (
 	clabnodesvr_xrv9k "github.com/srl-labs/containerlab/nodes/vr_xrv9k"
 	clabnodesvyosnetworks_vyos "github.com/srl-labs/containerlab/nodes/vyosnetworks_vyos"
 	clabnodesxrd "github.com/srl-labs/containerlab/nodes/xrd"
+	clabnodesplvision_sonic "github.com/srl-labs/containerlab/nodes/plvision_sonic"
 )
 
 // RegisterNodes registers all the nodes/kinds supported by containerlab.
@@ -127,4 +128,5 @@ func (c *CLab) RegisterNodes() { //nolint:funlen
 	clabnodesarrcus_arcos.Register(c.Reg)
 	clabnodesveesix_osvbng.Register(c.Reg)
 	clabnodesspirent_stc.Register(c.Reg)
+	clabnodesplvision_sonic.Register(c.Reg)
 }

--- a/docs/manual/kinds/index.md
+++ b/docs/manual/kinds/index.md
@@ -84,6 +84,7 @@ Within each predefined kind, we store the necessary information that is used to 
 | **FD.io VPP**              | [`fdio_vpp`](fdio_vpp.md)                           | supported | container |
 | **RARE/freeRtr**           | [`rare`](rare-freertr.md)                           | supported | container |
 | **VyOS Networks VyOS**     | [`vyosnetworks_vyos`](vyosnetworks_vyos.md)         | supported |    VM     |
+| **PLVision SONiC**         | [`plvision_sonic`](plvision_sonic.md)               | supported |    VM     |
 | **Generic VM**             | [`generic_vm`](generic_vm.md)                       | supported |    VM     |
 | **Linux container**        | [`linux`](linux.md)                                 | supported | container |
 | **Ostinato**               | [`linux`](ostinato.md)                              | supported | container |

--- a/docs/manual/kinds/plvision_sonic.md
+++ b/docs/manual/kinds/plvision_sonic.md
@@ -9,6 +9,16 @@ This document covers the VM flavor of [Enterprise SONiC Linux Distribution](http
 
 The image is built with the [`vrnetlab/plvision_sonic`](https://github.com/srl-labs/vrnetlab) vrnetlab project and packaged as a Qemu VM inside a Docker container.
 
+## Overview
+
+`-{{ kind_code_name }}-` is an optimized SONiC distribution designed for:
+
+- Access switches
+- Out-of-band management switches
+- Campus deployments
+- Edge deployments
+- Resource-constrained platforms
+
 ## Getting -{{ kind_display_name }}- images
 
 1. To download the image, log in to [Solutions: PLVision ServiceDesk](https://support.plvision.eu/support/solutions) and find the required version.

--- a/docs/manual/kinds/plvision_sonic.md
+++ b/docs/manual/kinds/plvision_sonic.md
@@ -1,0 +1,73 @@
+---
+search:
+  boost: 4
+kind_code_name: plvision_sonic
+kind_display_name: "Enterprise SONiC Linux Distribution by PLVision"
+---
+# -{{ kind_display_name }}-
+This document covers the VM flavor of [Enterprise SONiC Linux Distribution](https://plvision.eu/sonic-lite) from PLVision, identified with the `-{{ kind_code_name }}-` kind in the [topology file](../topo-def-file.md).
+
+The image is built with the [`vrnetlab/plvision_sonic`](https://github.com/srl-labs/vrnetlab) vrnetlab project and packaged as a Qemu VM inside a Docker container.
+
+## Getting -{{ kind_display_name }}- images
+
+1. To download the image, log in to [Solutions: PLVision ServiceDesk](https://support.plvision.eu/support/solutions) and find the required version.
+2. Extract the archive and place the `.img` file in the `-{{ kind_code_name }}-` directory of the vrnetlab repo.
+3. Rename the file to `plvision_sonic-vs-<version>.qcow2` and run `make`.
+
+After the build completes, the image will be available as `vrnetlab/plvision_sonic:<version>` (for example `vrnetlab/plvision_sonic:lite_1_13_202405`).
+
+## System requirements
+
+- CPU: 2 cores
+- RAM: 4GB
+- DISK: ~6.5GB
+
+## Managing plvision_sonic nodes
+
+A `-{{ kind_code_name }}-` node launched with containerlab takes approximately 1 minute to boot and can be managed via the following interfaces:
+
+/// note
+The default login credentials for the PLVision Enterprise SONiC VM are `admin:admin`
+///
+
+/// note | exec runs in the launcher container, not the SONiC VM
+`-{{ kind_code_name }}-` is a VM-based (vrnetlab) kind, so the [`exec` node property](../nodes.md#exec) and the [`exec` command](../../cmd/exec.md) run inside the launcher container that wraps the VM, not inside the SONiC guest. SONiC CLI commands such as `show version` are not available via `exec` and fail with `executable file not found in $PATH`. Use the SSH method below to run commands against SONiC.
+///
+
+/// tab | SSH
+To open a Linux shell, simply type in
+
+```bash
+ssh <node-name>
+```
+
+From within the Linux shell users can perform system configuration using Linux utilities, or connect to the SONiC CLI using the `vtysh` command.
+
+///
+/// tab | Telnet
+To connect to the `-{{ kind_code_name }}-` CLI via telnet
+
+```bash
+telnet <container-name/id> 5000
+```
+
+///
+
+## Interfaces mapping
+
+The `-{{ kind_code_name }}-` container uses the following mapping for its Linux interfaces:
+
+* `eth0` - management interface connected to the containerlab management network
+* `eth1` - first data (front-panel port) interface that is mapped to Ethernet0 port
+* `eth2` - second data interface that is mapped to Ethernet4 port. Any new port will result in a "previous interface + 4" (Ethernet4) mapping.
+
+When containerlab launches a `-{{ kind_code_name }}-` node, it will assign IPv4/6 address to the `eth0` interface. Data interface `eth1` mapped to `Ethernet0` port and needs to be configured with IP addressing manually.
+
+## Features and Options
+
+### Startup configuration
+
+VM-based PLVision Enterprise SONiC supports the [`startup-config`](../nodes.md#startup-config) feature. The startup configuration file is a JSON file that is available in the VM's filesystem at `/etc/sonic/config_db.json`.
+
+Extracting the config from a running node is possible with the `containerlab save` command. The config will be available in the lab directory.

--- a/lab-examples/plvision_sonic01/plvision_sonic01.clab.yml
+++ b/lab-examples/plvision_sonic01/plvision_sonic01.clab.yml
@@ -1,7 +1,0 @@
-name: plvision_sonic01
-
-topology:
-  nodes:
-    sonic:
-      kind: plvision_sonic
-      image: vrnetlab/plvision_sonic:lite_1_13_202405

--- a/lab-examples/plvision_sonic01/plvision_sonic01.clab.yml
+++ b/lab-examples/plvision_sonic01/plvision_sonic01.clab.yml
@@ -1,0 +1,7 @@
+name: plvision_sonic01
+
+topology:
+  nodes:
+    sonic:
+      kind: plvision_sonic
+      image: vrnetlab/plvision_sonic:lite_1_13_202405

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ nav:
       - Dell:
           - FTOS10v: manual/kinds/vr-ftosv.md
           - Enterprise SONiC: manual/kinds/dell_sonic.md
+      - PLVision:
+          - Enterprise SONiC: manual/kinds/plvision_sonic.md
       - MikroTik RouterOS: manual/kinds/vr-ros.md
       - Huawei VRP: manual/kinds/huawei_vrp.md
       - IPInfusion OcNOS: manual/kinds/ipinfusion-ocnos.md

--- a/nodes/plvision_sonic/plvision_sonic.go
+++ b/nodes/plvision_sonic/plvision_sonic.go
@@ -1,0 +1,131 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package plvision_sonic
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/charmbracelet/log"
+
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clabexec "github.com/srl-labs/containerlab/exec"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	clabutils "github.com/srl-labs/containerlab/utils"
+)
+
+var (
+	kindNames          = []string{"plvision_sonic"}
+	defaultCredentials = clabnodes.NewCredentials("admin", "admin")
+
+	generateable     = true
+	generateIfFormat = "eth%d"
+)
+
+const (
+	configDirName   = "config"
+	startupCfgFName = "config_db.json"
+	saveCmd         = `sh -c "/backup.sh -u $USERNAME -p $PASSWORD backup"`
+
+	scrapliPlatformName = "sonic"
+)
+
+// Register registers the node in the NodeRegistry.
+func Register(r *clabnodes.NodeRegistry) {
+	generateNodeAttributes := clabnodes.NewGenerateNodeAttributes(generateable, generateIfFormat)
+	platformAttrs := &clabnodes.PlatformAttrs{
+		ScrapliPlatformName: scrapliPlatformName,
+	}
+
+	nrea := clabnodes.NewNodeRegistryEntryAttributes(
+		defaultCredentials,
+		generateNodeAttributes,
+		platformAttrs,
+	)
+
+	r.Register(kindNames, func() clabnodes.Node {
+		return new(plvision_sonic)
+	}, nrea)
+}
+
+type plvision_sonic struct {
+	clabnodes.DefaultNode
+}
+
+func (n *plvision_sonic) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) error {
+	n.DefaultNode = *clabnodes.NewDefaultNode(n)
+	n.HostRequirements.VirtRequired = true
+
+	n.Cfg = cfg
+	for _, o := range opts {
+		o(n)
+	}
+
+	defEnv := map[string]string{
+		"USERNAME":           n.Cfg.Credentials.Username,
+		"PASSWORD":           n.Cfg.Credentials.Password,
+		"CONNECTION_MODE":    clabnodes.VrDefConnMode,
+		"DOCKER_NET_V4_ADDR": n.Mgmt.IPv4Subnet,
+		"DOCKER_NET_V6_ADDR": n.Mgmt.IPv6Subnet,
+	}
+	n.Cfg.Env = clabutils.MergeStringMaps(defEnv, n.Cfg.Env)
+
+	n.Cfg.Binds = append(
+		n.Cfg.Binds,
+		fmt.Sprint(path.Join(n.Cfg.LabDir, configDirName), ":/config"),
+	)
+
+	n.Cfg.Cmd = fmt.Sprintf(
+		"--username %s --password %s --hostname %s --connection-mode %s --trace",
+		n.Cfg.Env["USERNAME"],
+		n.Cfg.Env["PASSWORD"],
+		n.Cfg.ShortName,
+		n.Cfg.Env["CONNECTION_MODE"],
+	)
+
+	return nil
+}
+
+func (n *plvision_sonic) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) error {
+	clabutils.CreateDirectory(n.Cfg.LabDir, clabconstants.PermissionsOpen)
+	_, err := n.LoadOrGenerateCertificate(params.Cert, params.TopologyName)
+	if err != nil {
+		return err
+	}
+
+	return clabnodes.LoadStartupConfigFileVr(n, configDirName, startupCfgFName)
+}
+
+func (n *plvision_sonic) SaveConfig(ctx context.Context) (*clabnodes.SaveConfigResult, error) {
+	cmd, err := clabexec.NewExecCmdFromString(saveCmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to create execute cmd: %w", n.Cfg.ShortName, err)
+	}
+
+	execResult, err := n.RunExec(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to execute cmd: %w", n.Cfg.ShortName, err)
+	}
+
+	if execResult.GetStdErrString() != "" {
+		return nil, fmt.Errorf("%s errors: %s", n.Cfg.ShortName, execResult.GetStdErrString())
+	}
+
+	confPath := n.Cfg.LabDir + "/" + configDirName
+	log.Infof(
+		"saved /etc/sonic/config_db.json backup from %s node to %s\n",
+		n.Cfg.ShortName,
+		confPath,
+	)
+
+	return nil, nil
+}
+
+// CheckInterfaceName checks if a name of the interface referenced in the topology file is correct.
+func (n *plvision_sonic) CheckInterfaceName() error {
+	return clabnodes.GenericVMInterfaceCheck(n.Cfg.ShortName, n.Endpoints)
+}

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -71,7 +71,7 @@
                         "juniper_crpd",
                         "juniper_csrx",
                         "sonic-vs",
-                        "sonic-vm",       
+                        "sonic-vm",
                         "nokia_sros",
                         "nokia_srsim",
                         "juniper_vmx",
@@ -2034,7 +2034,7 @@
                         },
                         "sonic-vm": {
                             "$ref": "#/definitions/node-config"
-                        },  
+                        },
                         "dell_ftosv": {
                             "$ref": "#/definitions/node-config"
                         },

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -71,7 +71,7 @@
                         "juniper_crpd",
                         "juniper_csrx",
                         "sonic-vs",
-                        "sonic-vm",
+                        "sonic-vm",       
                         "nokia_sros",
                         "nokia_srsim",
                         "juniper_vmx",
@@ -126,7 +126,8 @@
                         "openwrt",
                         "spirent_stc",
                         "veesix_osvbng",
-                        "ostinato"
+                        "ostinato",
+                        "plvision_sonic"
                     ]
                 },
                 "license": {
@@ -2033,11 +2034,14 @@
                         },
                         "sonic-vm": {
                             "$ref": "#/definitions/node-config"
-                        },
+                        },  
                         "dell_ftosv": {
                             "$ref": "#/definitions/node-config"
                         },
                         "dell_sonic": {
+                            "$ref": "#/definitions/node-config"
+                        },
+                        "plvision_sonic": {
                             "$ref": "#/definitions/node-config"
                         },
                         "juniper_vmx": {


### PR DESCRIPTION
## Summary
- Add `plvision_sonic` vrnetlab-based VM kind for Enterprise SONiC Linux Distribution by PLVision
- Register the kind in core, schema, docs, and mkdocs navigation

Related vrnelab PR: https://github.com/srl-labs/vrnetlab/pull/508