### PR TITLE
runtime/podman: retry mgmt network removal on destroy

### DIFF
--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -140,11 +140,41 @@ func (r *PodmanRuntime) DeleteNet(ctx context.Context) error {
 		return err
 	}
 	log.Debugf("trying to delete mgmt network %v", r.mgmt.Network)
-	_, err = network.Remove(ctx, r.mgmt.Network, &network.RemoveOptions{})
+
+	// Removal can fail with "network is being used" right after destroy has
+	// deleted all lab containers, because podman can briefly still consider
+	// them associated with the network. A short retry rides out that window.
+	// Force is deliberately not set: it would also delete any containers
+	// still attached to the network, such as those of another lab sharing
+	// the default mgmt network.
+	const (
+		netInUseRetries      = 3
+		netInUseRetryBackoff = time.Second
+	)
+
+	for attempt := range netInUseRetries {
+		_, err = network.Remove(ctx, r.mgmt.Network, &network.RemoveOptions{})
+		if err == nil || !isNetworkInUseErr(err) || attempt == netInUseRetries-1 {
+			break
+		}
+		log.Debugf("transient in-use error removing network %q (attempt %d/%d): %v",
+			r.mgmt.Network, attempt+1, netInUseRetries, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(netInUseRetryBackoff):
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("error while trying to remove a mgmt network %w", err)
 	}
 	return nil
+}
+
+// isNetworkInUseErr reports whether err is podman's "network is being used"
+// error, raised while any container is still associated with the network.
+func isNetworkInUseErr(err error) bool {
+	return strings.Contains(err.Error(), "network is being used")
 }
 
 func (r *PodmanRuntime) PullImage(


### PR DESCRIPTION
`PodmanRuntime.DeleteNet` now retries mgmt network removal up to 3 times, 1
second apart, when podman rejects it with "network is being used". This mirrors
the transient IPv6 gateway retry in the docker runtime's `StartContainer`.

`containerlab destroy -r podman` can fail to remove the lab's mgmt network:

```
ERRO[0010] error while trying to remove a mgmt network "clab" has associated containers with it. Use -f to forcibly delete containers and pods: network is being used
```

This happens even though every lab container is already gone: `deleteNodes`
waits for all `DeleteContainer` calls to return before `DeleteNet` runs, but
podman can briefly still consider those containers associated with the network.
The issue report shows a manual `podman network rm` succeeding right after the
failed destroy, so the window is short and a bounded retry covers it. Without
it, a second `destroy` finds no containers and returns before network cleanup,
leaving the network behind.

I did not set `Force`, which podman's error text suggests: multiple labs share
the default mgmt network unless configured otherwise, and `podman network rm -f`
deletes every container attached to it, so destroying one lab would kill the
others' containers. The docker runtime's `DeleteNet` skips removal while the
network has active endpoints for the same reason.

Retries only fire on that specific error, adding at most 2 seconds to a destroy
that previously failed outright. `bridge` exclusion and `--keep-mgmt-net` are
unchanged.

Fixes #2294

Validation: gofmt, go build, go vet and golangci-lint clean on `runtime/podman`
with the podman build tags, plus `make build-with-podman`. `runtime/podman` has
no unit tests and no mock for the podman bindings, so none is included. I have
no podman host, so I could not run a live deploy/destroy cycle - a confirmation
from someone hitting the issue would be welcome.
