### PR TITLE
fix: improve UX of post-install group instructions

### DIFF
--- a/utils/postinstall.sh
+++ b/utils/postinstall.sh
@@ -14,7 +14,7 @@ if [ ! -f /etc/containerlab/suid_setup_done ]; then
     groupadd -r clab_admins
     usermod -aG clab_admins "$SUDO_USER"
     touch /etc/containerlab/suid_setup_done
-    echo "Please run the command 'sudo usermod -aG clab_admins <insert your username here> && newgrp clab_admins' to ensure that you are part of the Container admin group. You can check this by running 'groups'."
+    echo "Please run the command 'sudo usermod -aG clab_admins \$USER && newgrp clab_admins' to ensure that you are part of the Container admin group. You can check this by running 'groups'."
 fi
 
 # exit at this point if no /etc/apt/sources.list.d/netdevops.list or /etc/yum.repos.d/yum.fury.io_netdevops_.repo is found


### PR DESCRIPTION
Replaced the hardcoded <insert your username here> placeholder with an escaped \$USER variable. This allows the output command to be directly copy-pasted into the terminal without manual editing.

**What does this PR do?**
This PR improves the quality-of-life for the post-install instruction by replacing the hardcoded `<insert your username here>` placeholder with the `$USER` environment variable.

**Why is this needed?**
Currently, users are prompted with:
`sudo usermod -aG clab_admins <insert your username here> && newgrp clab_admins`
This requires the user to manually backspace and type their username before executing.

By changing the output to:
`sudo usermod -aG clab_admins $USER && newgrp clab_admins`
The user can simply copy and paste the string into their terminal. Their local shell will seamlessly evaluate `$USER` to their active account. 

*Note: The variable is escaped as `\$USER` in the echo statement so it prints the literal string rather than evaluating to `root` during the sudo installation process.*