### PR TITLE
fix: make bind resolution deterministic

### DIFF
--- a/types/topology.go
+++ b/types/topology.go
@@ -771,17 +771,11 @@ func (t *Topology) GetNodeBinds(nodeName string) ([]string, error) {
 		return nil, nil
 	}
 
-	// Sort by destination path so map iteration cannot introduce config drift.
-	destinations := make([]string, 0, len(binds))
-	for dst := range binds {
-		destinations = append(destinations, dst)
-	}
-	slices.Sort(destinations)
-
 	result := make([]string, 0, len(binds))
-	for _, dst := range destinations {
-		result = append(result, binds[dst].String())
+	for _, b := range binds {
+		result = append(result, b.String())
 	}
+	slices.Sort(result)
 
 	return result, nil
 }

--- a/types/topology.go
+++ b/types/topology.go
@@ -772,9 +772,11 @@ func (t *Topology) GetNodeBinds(nodeName string) ([]string, error) {
 	}
 
 	result := make([]string, 0, len(binds))
+
 	for _, b := range binds {
 		result = append(result, b.String())
 	}
+
 	slices.Sort(result)
 
 	return result, nil

--- a/types/topology.go
+++ b/types/topology.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/docker/go-connections/nat"
@@ -770,11 +771,16 @@ func (t *Topology) GetNodeBinds(nodeName string) ([]string, error) {
 		return nil, nil
 	}
 
-	// build the result array with all the entries from binds map
-	result := make([]string, 0, len(binds))
+	// Sort by destination path so map iteration cannot introduce config drift.
+	destinations := make([]string, 0, len(binds))
+	for dst := range binds {
+		destinations = append(destinations, dst)
+	}
+	slices.Sort(destinations)
 
-	for _, b := range binds {
-		result = append(result, b.String())
+	result := make([]string, 0, len(binds))
+	for _, dst := range destinations {
+		result = append(result, binds[dst].String())
 	}
 
 	return result, nil

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -896,6 +896,39 @@ func TestGetNodeBinds(t *testing.T) {
 	}
 }
 
+func TestGetNodeBindsDeterministicOrder(t *testing.T) {
+	topology := &Topology{
+		Defaults: &NodeDefinition{},
+		Nodes: map[string]*NodeDefinition{
+			"node1": {
+				Binds: []string{
+					"z-source:/etc/z.conf",
+					"a-source:/etc/a.conf",
+					"m-source:/etc/m.conf",
+				},
+			},
+		},
+	}
+	want := []string{
+		"a-source:/etc/a.conf",
+		"m-source:/etc/m.conf",
+		"z-source:/etc/z.conf",
+	}
+
+	for range 100 {
+		got, err := topology.GetNodeBinds("node1")
+		if err != nil {
+			t.Fatalf("GetNodeBinds() unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf(
+				"GetNodeBinds() returned binds in a non-deterministic order (-want +got):\n%s",
+				diff,
+			)
+		}
+	}
+}
+
 func TestGetNodeEnv(t *testing.T) {
 	for name, item := range topologyTestSet {
 		t.Logf("%q test item", name)


### PR DESCRIPTION
## What changed

- sort resolved bind mounts by destination path before returning them from `GetNodeBinds`
- add a regression test that repeatedly verifies deterministic multi-bind ordering

## Why

`GetNodeBinds` deduplicates bind mounts in a map and previously returned them in randomized map iteration order. Apply reconciliation compares the resulting slices positionally, so unchanged nodes with multiple binds could be reported as `config drift: Binds` and unnecessarily recreated.

This keeps unchanged multi-bind nodes stable for both `containerlab deploy` and its `apply` alias while preserving detection of real bind changes.

Fixes #3299.

## Validation

- `make test` (race detection and coverage)
- `make build`
- bind regression tests repeated across 100 test runs
- deployed two real Alpine nodes with two bind mounts each
- 100 unchanged dry-runs and 20 unchanged real applies all reported no changes without replacing either container
- a controlled environment change recreated only the intended node; the untouched multi-bind node retained its container ID
- 50 post-change dry-runs all reported no changes
