### PR TITLE
feat: add nix flake and CI to keep it fresh

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,7 +7,15 @@ on:
   push:
     branches: [main, nix-flake]
     # releases always bump go.mod/go.sum or touch the release notes in docs/rn
-    paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml, docs/rn/**]
+    paths:
+      [
+        go.mod,
+        go.sum,
+        flake.nix,
+        flake.lock,
+        .github/workflows/nix.yml,
+        docs/rn/**,
+      ]
   pull_request:
     paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
   schedule:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,10 +5,13 @@ name: nix
 
 on:
   push:
-    branches: [main]
-    paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
+    branches: [main, nix-flake]
+    # releases always bump go.mod/go.sum or touch the release notes in docs/rn
+    paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml, docs/rn/**]
   pull_request:
     paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
+  schedule:
+    - cron: "0 3 * * 0" # weekly on Sundays 03:00 UTC, catches releases that changed nothing above
   workflow_dispatch:
 
 permissions:
@@ -21,16 +24,30 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # git describe needs tags
+          fetch-depth: 0 # full history, tag handling below needs it
       - uses: cachix/install-nix-action@v31
+
+      # Forks do not inherit tags created after the fork point, and the
+      # checkout action does not fetch tags from upstream either. Fetch the
+      # upstream tags explicitly so the "latest stable release" detection
+      # below is reliable both here and on forks.
+      - name: Fetch upstream tags
+        run: git fetch --tags --force https://github.com/srl-labs/containerlab.git '+refs/tags/v*:refs/tags/v*'
 
       # version + vendorHash are the only things in flake.nix that go stale.
       - name: Refresh flake.nix
         id: refresh
         run: |
-          version=$(git describe --tags --abbrev=0 | tr -d v)
+          version=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1 | tr -d v)
+          if [ -z "$version" ]; then
+            echo "::error::no v* release tags found after upstream tag fetch"
+            exit 1
+          fi
+          echo "latest stable release: $version"
           sed -i "s|version = \".*\";|version = \"$version\";|" flake.nix
-          got=$(nix build .#containerlab --no-link 2>&1 | awk '/got:/{print $2}')
+          # a mismatching vendorHash is expected whenever go.mod/go.sum changed;
+          # `|| true` keeps the step alive so the reported got: hash can be used
+          got=$(nix build .#containerlab --no-link 2>&1 | awk '/got:/{print $2}' || true)
           if [ -n "$got" ]; then
             sed -i "s|vendorHash = \".*\";|vendorHash = \"$got\";|" flake.nix
           fi
@@ -41,9 +58,20 @@ jobs:
         if: steps.refresh.outputs.changed == 'true' && github.event_name == 'pull_request'
         run: git diff flake.nix && exit 1
 
+      # On the upstream repo the refresh lands via a bot PR;
+      # on forks (used as nix flake inputs) commit straight to the branch.
       - uses: peter-evans/create-pull-request@v7
-        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
+        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository == 'srl-labs/containerlab'
         with:
           branch: update-flake
           title: "chore: update flake.nix"
           commit-message: "chore: update flake.nix"
+
+      - name: Commit refreshed flake.nix (forks only)
+        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository != 'srl-labs/containerlab'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit -m "chore: update flake.nix"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,20 +4,11 @@
 name: nix
 
 on:
-  push:
-    branches: [main, nix-flake]
-    # releases always bump go.mod/go.sum or touch the release notes in docs/rn
-    paths:
-      [
-        go.mod,
-        go.sum,
-        flake.nix,
-        flake.lock,
-        .github/workflows/nix.yml,
-        docs/rn/**,
-      ]
   pull_request:
     paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
+  workflow_run:
+    workflows: ["CICD"]
+    types: [completed]
   schedule:
     - cron: "0 3 * * 0" # weekly on Sundays 03:00 UTC, catches releases that changed nothing above
   workflow_dispatch:
@@ -26,13 +17,26 @@ permissions:
   contents: read
 
 jobs:
-  nix-refresh:
+  nix-validation:
+    # Validate PRs in parallel, and validate main/release commits only after
+    # the main CICD workflow succeeds. Scheduled and manual runs are allowed
+    # independently because they are maintenance builds, not release builds.
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request'
+      )
     outputs:
       changed: ${{ steps.refresh.outputs.changed }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 1
       - uses: cachix/install-nix-action@v31
 
@@ -90,8 +94,24 @@ jobs:
             flake.lock
 
   update:
-    needs: nix-refresh
-    if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
+    needs: nix-validation
+    # Only mutate repository state after a successful Nix validation that
+    # changed metadata. Main/release workflow runs are gated by successful
+    # CICD; scheduled/manual runs are explicit maintenance operations.
+    if: >-
+      needs.nix-validation.result == 'success' &&
+      needs.nix-validation.outputs.changed == 'true' &&
+      (
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.ref_type == 'branch'
+        ) ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -99,6 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
@@ -112,17 +133,20 @@ jobs:
       # On the upstream repo the refresh lands via a bot PR;
       # on forks (used as nix flake inputs) commit straight to the branch.
       - uses: peter-evans/create-pull-request@v7
-        if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository == 'srl-labs/containerlab'
+        if: github.repository == 'srl-labs/containerlab'
         with:
           branch: update-flake
+          base: main
           title: "chore: update Nix flake"
           commit-message: "chore: update Nix flake"
 
       - name: Commit refreshed flake metadata (forks only)
-        if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository != 'srl-labs/containerlab'
+        if: github.repository != 'srl-labs/containerlab'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add flake.nix flake.lock
           git commit -m "chore: update Nix flake"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "HEAD:${TARGET_BRANCH}"
+        env:
+          TARGET_BRANCH: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,49 @@
+# Copyright 2020 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+name: nix
+
+on:
+  push:
+    branches: [main]
+    paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
+  pull_request:
+    paths: [go.mod, go.sum, flake.nix, flake.lock, .github/workflows/nix.yml]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # git describe needs tags
+      - uses: cachix/install-nix-action@v31
+
+      # version + vendorHash are the only things in flake.nix that go stale.
+      - name: Refresh flake.nix
+        id: refresh
+        run: |
+          version=$(git describe --tags --abbrev=0 | tr -d v)
+          sed -i "s|version = \".*\";|version = \"$version\";|" flake.nix
+          got=$(nix build .#containerlab --no-link 2>&1 | awk '/got:/{print $2}')
+          if [ -n "$got" ]; then
+            sed -i "s|vendorHash = \".*\";|vendorHash = \"$got\";|" flake.nix
+          fi
+          nix build .#containerlab --no-link
+          git diff --quiet flake.nix || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fail PRs with a stale flake.nix
+        if: steps.refresh.outputs.changed == 'true' && github.event_name == 'pull_request'
+        run: git diff flake.nix && exit 1
+
+      - uses: peter-evans/create-pull-request@v7
+        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
+        with:
+          branch: update-flake
+          title: "chore: update flake.nix"
+          commit-message: "chore: update flake.nix"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,15 +25,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # full history, tag handling below needs it
+          fetch-depth: 1
       - uses: cachix/install-nix-action@v31
 
-      # Forks do not inherit tags created after the fork point, and the
-      # checkout action does not fetch tags from upstream either. Fetch the
-      # upstream tags explicitly so the "latest stable release" detection
-      # below is reliable both here and on forks.
-      - name: Fetch upstream tags
-        run: git fetch --tags --force https://github.com/srl-labs/containerlab.git '+refs/tags/v*:refs/tags/v*'
+      # Query upstream directly instead of importing tags into the checkout.
+      # This prevents fork-only tags from affecting the selected version.
+      - name: Detect latest upstream stable release
+        id: release
+        run: |
+          stable_tags=$(
+            git ls-remote --refs --tags https://github.com/srl-labs/containerlab.git 'refs/tags/v[0-9]*' |
+              awk -F/ '$3 !~ /-/ { print $3 }' |
+              sort -V -r
+          )
+          version=${stable_tags%%$'\n'*}
+          version=${version#v}
+          if [ -z "$version" ]; then
+            echo "::error::no v* release tags found on upstream"
+            exit 1
+          fi
+          echo "latest stable release: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Update Nixpkgs lock
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -42,13 +54,10 @@ jobs:
       # version + vendorHash + the Nixpkgs lock are maintained here.
       - name: Refresh flake metadata
         id: refresh
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
-          version=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1 | tr -d v)
-          if [ -z "$version" ]; then
-            echo "::error::no v* release tags found after upstream tag fetch"
-            exit 1
-          fi
-          echo "latest stable release: $version"
+          version="$VERSION"
           sed -i "s|version = \".*\";|version = \"$version\";|" flake.nix
           # a mismatching vendorHash is expected whenever go.mod/go.sum changed;
           # `|| true` keeps the step alive so the reported got: hash can be used

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -90,7 +90,7 @@ jobs:
             flake.lock
 
   update:
-    needs: refresh
+    needs: nix-refresh
     if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 jobs:
-  refresh:
+  nix-refresh:
     outputs:
       changed: ${{ steps.refresh.outputs.changed }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -35,8 +35,12 @@ jobs:
       - name: Fetch upstream tags
         run: git fetch --tags --force https://github.com/srl-labs/containerlab.git '+refs/tags/v*:refs/tags/v*'
 
-      # version + vendorHash are the only things in flake.nix that go stale.
-      - name: Refresh flake.nix
+      - name: Update Nixpkgs lock
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: nix flake lock --update-input nixpkgs
+
+      # version + vendorHash + the Nixpkgs lock are maintained here.
+      - name: Refresh flake metadata
         id: refresh
         run: |
           version=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1 | tr -d v)
@@ -53,18 +57,20 @@ jobs:
             sed -i "s|vendorHash = \".*\";|vendorHash = \"$got\";|" flake.nix
           fi
           nix build .#containerlab --no-link
-          git diff --quiet flake.nix || echo "changed=true" >> "$GITHUB_OUTPUT"
+          git diff --quiet -- flake.nix flake.lock || echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Fail PRs with a stale flake.nix
+      - name: Fail PRs with stale flake metadata
         if: steps.refresh.outputs.changed == 'true' && github.event_name == 'pull_request'
-        run: git diff flake.nix && exit 1
+        run: git diff -- flake.nix flake.lock && exit 1
 
-      - name: Upload refreshed flake.nix
+      - name: Upload refreshed flake metadata
         if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: refreshed-flake
-          path: flake.nix
+          name: refreshed-flake-metadata
+          path: |
+            flake.nix
+            flake.lock
 
   update:
     needs: refresh
@@ -79,10 +85,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
-          name: refreshed-flake
-          path: refreshed-flake
-      - name: Apply refreshed flake.nix
-        run: cp refreshed-flake/flake.nix flake.nix
+          name: refreshed-flake-metadata
+          path: refreshed-flake-metadata
+      - name: Apply refreshed flake metadata
+        run: |
+          cp refreshed-flake-metadata/flake.nix flake.nix
+          cp refreshed-flake-metadata/flake.lock flake.lock
 
       # On the upstream repo the refresh lands via a bot PR;
       # on forks (used as nix flake inputs) commit straight to the branch.
@@ -90,14 +98,14 @@ jobs:
         if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository == 'srl-labs/containerlab'
         with:
           branch: update-flake
-          title: "chore: update flake.nix"
-          commit-message: "chore: update flake.nix"
+          title: "chore: update Nix flake"
+          commit-message: "chore: update Nix flake"
 
-      - name: Commit refreshed flake.nix (forks only)
+      - name: Commit refreshed flake metadata (forks only)
         if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository != 'srl-labs/containerlab'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add flake.nix
-          git commit -m "chore: update flake.nix"
+          git add flake.nix flake.lock
+          git commit -m "chore: update Nix flake"
           git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,11 +15,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  build:
+  refresh:
+    outputs:
+      changed: ${{ steps.refresh.outputs.changed }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -58,17 +59,42 @@ jobs:
         if: steps.refresh.outputs.changed == 'true' && github.event_name == 'pull_request'
         run: git diff flake.nix && exit 1
 
+      - name: Upload refreshed flake.nix
+        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: refreshed-flake
+          path: flake.nix
+
+  update:
+    needs: refresh
+    if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v8
+        with:
+          name: refreshed-flake
+          path: refreshed-flake
+      - name: Apply refreshed flake.nix
+        run: cp refreshed-flake/flake.nix flake.nix
+
       # On the upstream repo the refresh lands via a bot PR;
       # on forks (used as nix flake inputs) commit straight to the branch.
       - uses: peter-evans/create-pull-request@v7
-        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository == 'srl-labs/containerlab'
+        if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository == 'srl-labs/containerlab'
         with:
           branch: update-flake
           title: "chore: update flake.nix"
           commit-message: "chore: update flake.nix"
 
       - name: Commit refreshed flake.nix (forks only)
-        if: steps.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository != 'srl-labs/containerlab'
+        if: needs.refresh.outputs.changed == 'true' && github.event_name != 'pull_request' && github.repository != 'srl-labs/containerlab'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,11 @@ venv/
 # rf test report files
 tests/*.xml
 tests/*.html
+
+# nix
+result
+result-*
+
+# local agent/editor state
+.claude/
+.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,3 @@ tests/*.html
 # nix
 result
 result-*
-
-# local agent/editor state
-.claude/
-.cursor/

--- a/docs/install.md
+++ b/docs/install.md
@@ -188,6 +188,44 @@ yum install https://github.com/srl-labs/containerlab/releases/download/v0.7.0/co
 The package installer will put the `containerlab` binary in the `/usr/bin` directory as well as create the `/usr/bin/clab -> /usr/bin/containerlab` symlink. The symlink allows the users to save on typing when they use containerlab: `clab <command>`.
 Containerlab is also set up for sudo-less operation, and the current user (even if the package manager was called through `sudo`) is automatically granted access to privileged Containerlab commands. For further information, see [Sudo-less operation](#sudo-less-operation).
 
+## Nix
+
+The flake provides packages for `x86_64-linux` and `aarch64-linux`:
+
+```bash
+nix profile install github:srl-labs/containerlab
+containerlab version
+```
+
+The package installed in a Nix profile is not SUID, because files in the Nix store cannot safely provide root-owned SUID executables. Run privileged commands with `sudo`:
+
+```bash
+sudo containerlab deploy -t topology.clab.yml
+```
+
+For NixOS, import the module to enable sudo-less operation through NixOS security wrappers:
+
+```nix
+{
+  inputs.containerlab.url = "github:srl-labs/containerlab";
+
+  outputs = { self, nixpkgs, containerlab, ... }: {
+    nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        containerlab.nixosModules.default
+        {
+          programs.containerlab.enable = true;
+          users.users.alice.extraGroups = [ "clab_admins" ];
+        }
+      ];
+    };
+  };
+}
+```
+
+The module installs both `containerlab` and `clab`, creates the `clab_admins` group, and provides root-owned SUID wrappers for privileged commands. Users must be members of `clab_admins` to use those commands.
+
 ## Windows
 
 Containerlab runs on Windows powered by Windows Subsystem Linux (aka WSL), where you can run Containerlab directly or in a Devcontainer. Open up [**Containerlab on Windows**](windows.md) documentation for more details.

--- a/docs/install.md
+++ b/docs/install.md
@@ -190,11 +190,48 @@ Containerlab is also set up for sudo-less operation, and the current user (even 
 
 ## Nix
 
-The flake provides packages for `x86_64-linux` and `aarch64-linux`:
+The flake provides packages for `x86_64-linux` and `aarch64-linux`.
+
+### Build and run
+
+From a local containerlab checkout, build the package and run the resulting binary:
+
+```bash
+nix build .#containerlab
+./result/bin/containerlab version
+```
+
+The default package is also available without the attribute name:
+
+```bash
+nix build
+```
+
+To run containerlab without creating a profile installation, use `nix run`:
+
+```bash
+# From a local checkout
+nix run .#containerlab -- version
+
+# Directly from GitHub
+nix run github:srl-labs/containerlab -- version
+```
+
+/// details | Additional Nix instructions
+
+### Install in a Nix profile
+
+Install the latest version from the repository's default branch:
 
 ```bash
 nix profile install github:srl-labs/containerlab
 containerlab version
+```
+
+To install a specific release, reference its tag:
+
+```bash
+nix profile install github:srl-labs/containerlab/v0.78.2
 ```
 
 The package installed in a Nix profile is not SUID, because files in the Nix store cannot safely provide root-owned SUID executables. Run privileged commands with `sudo`:
@@ -203,13 +240,28 @@ The package installed in a Nix profile is not SUID, because files in the Nix sto
 sudo containerlab deploy -t topology.clab.yml
 ```
 
+The profile package provides `containerlab`, but not the `clab` compatibility symlink. The NixOS module below provides both names.
+
+### Development shell
+
+The flake's development shell provides Go, `gopls`, and `golangci-lint`:
+
+```bash
+nix develop github:srl-labs/containerlab
+```
+
+Docker or Podman is not included in the shell. Containerlab's integration tests still require the corresponding runtime and root privileges.
+
 For NixOS, import the module to enable sudo-less operation through NixOS security wrappers:
 
 ```nix
 {
-  inputs.containerlab.url = "github:srl-labs/containerlab";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    containerlab.url = "github:srl-labs/containerlab";
+  };
 
-  outputs = { self, nixpkgs, containerlab, ... }: {
+  outputs = { nixpkgs, containerlab, ... }: {
     nixosConfigurations.example = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
@@ -225,6 +277,7 @@ For NixOS, import the module to enable sudo-less operation through NixOS securit
 ```
 
 The module installs both `containerlab` and `clab`, creates the `clab_admins` group, and provides root-owned SUID wrappers for privileged commands. Users must be members of `clab_admins` to use those commands.
+///
 
 ## Windows
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,47 @@
         default = containerlab;
       });
 
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.containerlab;
+        in
+        {
+          options.programs.containerlab = {
+            enable = lib.mkEnableOption "containerlab";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.containerlab;
+              description = "The containerlab package to install.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ cfg.package ];
+
+            security.wrappers.containerlab = {
+              source = "${cfg.package}/bin/containerlab";
+              owner = "root";
+              group = "root";
+              setuid = true;
+            };
+
+            security.wrappers.clab = {
+              source = "${cfg.package}/bin/containerlab";
+              owner = "root";
+              group = "root";
+              setuid = true;
+            };
+
+            users.groups.clab_admins = { };
+          };
+        };
+
       devShells = forAll (pkgs: {
         default = pkgs.mkShell {
           packages = [

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
           pname = "containerlab";
           inherit version;
           src = ./.;
-          vendorHash = "sha256-kRBYjxirApj91hNBz3a+NyRm8SqRTVeQQCz+JFsKY0U=";
+          vendorHash = "sha256-zpZAiX9ipHKrZ/aup2a8w9pfKCviPKib3pv64saELts=";
           env = {
             CGO_ENABLED = 0;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "containerlab - container-based networking labs";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # ponytail: linux-only, matching .goreleaser.yml's goos list
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAll = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in
+    {
+      packages = forAll (pkgs: rec {
+        containerlab = pkgs.buildGoModule {
+          pname = "containerlab";
+          version = "0.78.0";
+          src = ./.;
+          vendorHash = "sha256-kRBYjxirApj91hNBz3a+NyRm8SqRTVeQQCz+JFsKY0U=";
+
+          tags = [
+            "podman"
+            "exclude_graphdriver_btrfs"
+            "btrfs_noversion"
+            "exclude_graphdriver_devicemapper"
+            "exclude_graphdriver_overlay"
+            "containers_image_openpgp"
+          ];
+          ldflags = [
+            "-s"
+            "-w"
+            "-X github.com/srl-labs/containerlab/cmd.Version=${containerlab.version}"
+          ];
+
+          # ponytail: tests need docker/root, skip them here
+          doCheck = false;
+
+          meta = {
+            description = "Container-based networking labs";
+            homepage = "https://containerlab.dev";
+            license = pkgs.lib.licenses.bsd3;
+            mainProgram = "containerlab";
+          };
+        };
+        default = containerlab;
+      });
+
+      devShells = forAll (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.go
+            pkgs.gopls
+            pkgs.golangci-lint
+          ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,18 +6,19 @@
   outputs =
     { self, nixpkgs }:
     let
-      # ponytail: linux-only, matching .goreleaser.yml's goos list
+      # linux-only, matching .goreleaser.yml's goos list
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
       forAll = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+      version = "0.78.2";
     in
     {
       packages = forAll (pkgs: rec {
         containerlab = pkgs.buildGoModule {
           pname = "containerlab";
-          version = "0.78.0";
+          inherit version;
           src = ./.;
           vendorHash = "sha256-kRBYjxirApj91hNBz3a+NyRm8SqRTVeQQCz+JFsKY0U=";
 
@@ -32,17 +33,25 @@
           ldflags = [
             "-s"
             "-w"
-            "-X github.com/srl-labs/containerlab/cmd.Version=${containerlab.version}"
+            "-X github.com/srl-labs/containerlab/cmd.Version=${version}"
+            "-X github.com/srl-labs/containerlab/cmd.commit=${self.shortRev or "unknown"}"
           ];
 
-          # ponytail: tests need docker/root, skip them here
+          # stamp the build date (ISO 8601, UTC) of the flake revision,
+          # which keeps the build reproducible for a given input
+          preBuild = ''
+            ldflags+=" -X github.com/srl-labs/containerlab/cmd.date=$(date -u -d @${self.lastModifiedDate} +%Y-%m-%dT%H:%M:%SZ)"
+          '';
+
+          # tests need docker/root, skip them here
           doCheck = false;
 
           meta = {
             description = "Container-based networking labs";
             homepage = "https://containerlab.dev";
-            license = pkgs.lib.licenses.bsd3;
+            license = nixpkgs.lib.licenses.bsd3;
             mainProgram = "containerlab";
+            platforms = nixpkgs.lib.platforms.linux;
           };
         };
         default = containerlab;

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,11 @@
           ];
 
           # stamp the build date (ISO 8601, UTC) of the flake revision,
-          # which keeps the build reproducible for a given input
+          # which keeps the build reproducible for a given input.
+          # note: self.lastModified (epoch) is used instead of
+          # self.lastModifiedDate, whose format varies across nix versions.
           preBuild = ''
-            ldflags+=" -X github.com/srl-labs/containerlab/cmd.date=$(date -u -d @${self.lastModifiedDate} +%Y-%m-%dT%H:%M:%SZ)"
+            ldflags+=" -X github.com/srl-labs/containerlab/cmd.date=$(date -u -d @${toString self.lastModified} +%Y-%m-%dT%H:%M:%SZ)"
           '';
 
           # tests need docker/root, skip them here

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
           inherit version;
           src = ./.;
           vendorHash = "sha256-kRBYjxirApj91hNBz3a+NyRm8SqRTVeQQCz+JFsKY0U=";
+          env = {
+            CGO_ENABLED = 0;
+          };
 
           tags = [
             "podman"


### PR DESCRIPTION
Hi,

This PR tries to implement flake from Nix (#3296). It add the flake.nix so anyone pointing directly to this repo can build it from scratch and keep track automatically using Nix Flakes. Also it is meant for testing (Nix-way).

I have also added a small workflow that updates the vendor hash on new updates so maintenance should be negligible if at all (as intended). Please refer to this PR if any breaking changes happen.