### PR TITLE
core/topology_reconcile: Fix deployment and reconciliation of bridges

### DIFF
--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -470,6 +470,7 @@ func TestDiscoverLiveApplyEndpointsRejectsStoppedExternalNode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	externalNode := clabmocksmocknodes.NewMockNode(ctrl)
 	externalNode.EXPECT().GetContainerStatus(ctx).Return(clabruntime.Stopped)
+	externalNode.EXPECT().Config().Return(&clabtypes.NodeConfig{Kind: "ext-container"})
 
 	c := &CLab{
 		Nodes: map[string]clabnodes.Node{"external": externalNode},

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -377,21 +377,23 @@ func (c *CLab) discoverLiveApplyEndpoints(
 			}
 			n = parkingNode
 		} else if !isApplySpecialNode(nodeName) {
-			status := c.Nodes[nodeName].GetContainerStatus(ctx)
-			if !clabruntime.ContainerHasJoinableNetns(status) {
-				if plan.isExternallyManaged(nodeName) {
+			if c.Nodes[nodeName].Config().Kind != "bridge" {
+				status := c.Nodes[nodeName].GetContainerStatus(ctx)
+				if !clabruntime.ContainerHasJoinableNetns(status) {
+					if plan.isExternallyManaged(nodeName) {
+						return fmt.Errorf(
+							"externally managed node %q is %s; "+
+								"start it outside containerlab before running apply",
+							nodeName,
+							status,
+						)
+					}
 					return fmt.Errorf(
-						"externally managed node %q is %s; "+
-							"start it outside containerlab before running apply",
+						"node %q is %s; apply requires existing nodes to have a joinable network namespace",
 						nodeName,
 						status,
 					)
 				}
-				return fmt.Errorf(
-					"node %q is %s; apply requires existing nodes to have a joinable network namespace",
-					nodeName,
-					status,
-				)
 			}
 		}
 

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -35,13 +35,6 @@ func (e *EndpointBridge) Verify(ctx context.Context, p *VerifyLinkParams) error 
 			errs = append(errs, err)
 		}
 	}
-	// if it is supposed to be a bridge in a Namespace, the if exists check is to be skipped.
-	if e.Node.GetLinkEndpointType() != LinkEndpointTypeBridgeNS {
-		err = CheckEndpointDoesNotExistYet(ctx, e)
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}

--- a/tests/01-smoke/29-apply.clab.yml
+++ b/tests/01-smoke/29-apply.clab.yml
@@ -50,6 +50,8 @@ topology:
         set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
         set / interface ethernet-1/1 subinterface 0 ipv4 address 172.31.0.2/24
         set / network-instance default interface ethernet-1/1.0
+    br-29-apply:
+      kind: bridge
 {{- if .addNode }}
     l3:
       kind: linux
@@ -64,6 +66,7 @@ topology:
     - endpoints: ["l1:eth1", "l2:eth1"]
     - endpoints: ["n1:eth1", "n2:eth1"]
     - endpoints: ["srlc:eth1", "srl1:e1-1"]
+    - endpoints: ["l2:eth4", "br-29-apply:appbr1"]
 {{- if .addLink }}
     - endpoints: ["l1:eth2", "l2:eth2"]
     - endpoints: ["n1:eth2", "n2:eth2"]

--- a/tests/01-smoke/29-apply.robot
+++ b/tests/01-smoke/29-apply.robot
@@ -19,6 +19,8 @@ ${deploy-drift-vars}        29-apply.vars.deploy-drift.yml
 ${runtime-cli-exec-cmd}     docker exec
 ${recovery-timeout}         30s
 ${retry-interval}           2s
+${bridge-name}              br-29-apply
+${bridge-interface}         appbr1
 
 
 *** Test Cases ***
@@ -34,6 +36,8 @@ Apply initial lab
     Interface Should Exist    n2    eth1
     Interface Should Exist    srlc    eth1
     Interface Should Exist    srl1    e1-1
+    Interface Should Exist    l2    eth4
+    Host Interface Should Be Attached To Bridge    ${bridge-interface}    ${bridge-name}
     Configure Interface Address    n1    eth1    172.30.0.1/24
     Configure Interface Address    n2    eth1    172.30.0.2/24
     Configure Interface Address    srlc    eth1    172.31.0.1/24
@@ -50,6 +54,13 @@ Apply initial lab
     ...    Ping From Node Succeeds
     ...    srlc
     ...    172.31.0.2
+
+Apply reconciles existing bridge
+    ${rc}    ${output} =    Apply Topology    ${initial-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    Apply summary
+    Interface Should Exist    l2    eth4
+    Host Interface Should Be Attached To Bridge    ${bridge-interface}    ${bridge-name}
 
 Dry-run reports link additions
     ${rc}    ${output} =    Apply Topology    ${add-link-vars}    --dry-run
@@ -235,9 +246,19 @@ Deploy reconciles node config drift idempotently
 *** Keywords ***
 Setup
     Run Clab Command    destroy --name ${lab-name} --cleanup
+    Run    sudo ip link del ${bridge-name}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip link add name ${bridge-name} type bridge
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip link set ${bridge-name} up
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
 
 Teardown
     Run Clab Command    destroy --name ${lab-name} --cleanup
+    Run    sudo ip link del ${bridge-name}
 
 Run Clab Command
     [Arguments]    ${args}
@@ -305,6 +326,14 @@ Host Interface Should Not Exist
     ...    ip link show ${interface}
     Log    ${output}
     Should Not Be Equal As Integers    ${rc}    0
+
+Host Interface Should Be Attached To Bridge
+    [Arguments]    ${interface}    ${bridge}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ip link show ${interface}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    master ${bridge}
 
 Node Should Be Running
     [Arguments]    ${node}


### PR DESCRIPTION
At the moment, deploying any topology with bridges will fail due to incorrectly handling them as containers.

Test topo:
```
name: test
topology:
  nodes:
    leaf1:
      kind: nokia_srlinux
      image: ghcr.io/nokia/srlinux:26.7.1
    br-br100:
      kind: bridge
  links:
    - endpoints: ["leaf1:e1-1", "br-br100:e2"]
    - endpoints: ["leaf1:e1-2", "br-br100:e3"]
```

Created bridge before deployment.

```
➜ clab deploy
14:57:18 INFO Containerlab started version=0.78.0
14:57:18 INFO Parsing & checking topology file=test.clab.yaml

   ERROR

  Externally managed node "br-br100" is NotFound; start it outside containerlab before running apply.
```
  
This PR fixes at least the initial deployment and basic reconciliation of bridges. There is still some wonkyness involved, e.g. deploy the topology listed above, and then change the links like so, and deploy it again:

```
  link:
                                    # was e2
    - endpoints: ["leaf1:e1-1", "br-br100:e1"]
                                    # was e3
    - endpoints: ["leaf1:e1-2", "br-br100:e2"]
```

and this will result in e2 getting deleted and only e1 getting deployed:

```
15:15:12 INFO Apply summary
╭───────────────────┬───────────────────────────╮
│       Action      │          Details          │
├───────────────────┼───────────────────────────┤
│ added links       │ br-br100:e1 -- leaf1:e1-1 │
│ deleted endpoints │ br-br100:e3               │
╰───────────────────┴───────────────────────────╯
➜ ip -br l | grep -P "e(1|2)"
e1@if106         UP             aa:c1:ab:77:c4:97 <BROADCAST,MULTICAST,UP,LOWER_UP>
```

Running a deploy again will make Clab realize that the link is missing ;)

```
15:16:19 INFO Apply summary
╭─────────────┬───────────────────────────╮
│    Action   │          Details          │
├─────────────┼───────────────────────────┤
│ added links │ br-br100:e2 -- leaf1:e1-2 │
╰─────────────┴───────────────────────────╯
```

It might be a more complex fix - I would like to get this one out of the door to allow people with any bridges in their topologies to get productive again.