### PR TITLE
fix(vr-ros): drop only ether1 management IP, not ether10+

### DIFF
--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -162,27 +162,14 @@ func (n *vrRos) SaveConfig(_ context.Context) (*clabnodes.SaveConfigResult, erro
 // filterManagementInterfaceConfig removes ether1 (management interface) IP address configuration
 // from the exported RouterOS configuration to avoid including containerlab management IP settings.
 func (n *vrRos) filterManagementInterfaceConfig(config string) string {
+	re := regexp.MustCompile(`interface=ether1\b.*\bnetwork=`)
 	lines := strings.Split(config, "\n")
 	var filteredLines []string
-
 	for _, line := range lines {
-		// Skip lines related to ether1 IP address configuration
-		if strings.Contains(line, "/ip address") {
-			// Mark that we're in the IP address section
-			filteredLines = append(filteredLines, line)
+		if re.MatchString(line) {
 			continue
 		}
-
-		// Skip IP address entries for ether1 interface
-		if strings.Contains(line, "interface=ether1") &&
-			(strings.Contains(line, "add address=") || strings.Contains(line, "add ")) {
-			// Skip this line as it's ether1 IP configuration
-			continue
-		}
-
-		// Keep all other lines
 		filteredLines = append(filteredLines, line)
 	}
-
 	return strings.Join(filteredLines, "\n")
 }

--- a/nodes/vr_ros/vr-ros.go
+++ b/nodes/vr_ros/vr-ros.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -162,14 +163,24 @@ func (n *vrRos) SaveConfig(_ context.Context) (*clabnodes.SaveConfigResult, erro
 // filterManagementInterfaceConfig removes ether1 (management interface) IP address configuration
 // from the exported RouterOS configuration to avoid including containerlab management IP settings.
 func (n *vrRos) filterManagementInterfaceConfig(config string) string {
-	re := regexp.MustCompile(`interface=ether1\b.*\bnetwork=`)
 	lines := strings.Split(config, "\n")
-	var filteredLines []string
+	filteredLines := make([]string, 0, len(lines))
+	inIPAddrSection := false
+
 	for _, line := range lines {
-		if re.MatchString(line) {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "/") {
+			inIPAddrSection = trimmedLine == "/ip address"
+		}
+
+		if inIPAddrSection &&
+			strings.HasPrefix(trimmedLine, "add address=") &&
+			slices.Contains(strings.Fields(trimmedLine), "interface=ether1") {
 			continue
 		}
+
 		filteredLines = append(filteredLines, line)
 	}
+
 	return strings.Join(filteredLines, "\n")
 }

--- a/nodes/vr_ros/vr-ros_test.go
+++ b/nodes/vr_ros/vr-ros_test.go
@@ -134,6 +134,7 @@ add address=198.51.100.33/24 comment=data-2 interface=ether2 network=198.51.100.
 add address=203.0.113.36/24 comment=data-11 interface=ether11 network=203.0.113.0
 add address=192.0.2.252/24 comment=loopback interface=lo network=192.0.2.252
 /ip dhcp-client
+add interface=ether1 comment="network=keep-this-dhcp-client"
 add interface=VLAN100_LAN name=BR-WAN use-peer-dns=no use-peer-ntp=no
 /ip dhcp-server lease
 add address=192.0.2.219 client-id=\
@@ -165,6 +166,7 @@ add address=192.0.2.0/24 comment=defconf dns-server=198.51.100.53 gateway=\
 		"interface=ether2 network=198.51.100.0",
 		"interface=lo network=192.0.2.252",
 		"/ip dhcp-client",
+		`interface=ether1 comment="network=keep-this-dhcp-client"`,
 		"interface=VLAN100_LAN name=BR-WAN",
 		"/ip dhcp-server lease",
 		"address=192.0.2.219 client-id=",

--- a/nodes/vr_ros/vr-ros_test.go
+++ b/nodes/vr_ros/vr-ros_test.go
@@ -1,6 +1,7 @@
 package vr_ros
 
 import (
+	"strings"
 	"testing"
 
 	clablinks "github.com/srl-labs/containerlab/links"
@@ -113,5 +114,66 @@ func TestROSInterfaceParsing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestROSFilterManagementInterfaceConfig verifies that filterManagementInterfaceConfig
+// drops only the management interface (ether1) IP address entry and keeps everything
+// else. It guards against substring greediness (ether11 must survive) and against
+// collateral removal of neighbouring sections or ether1 references outside /ip address.
+func TestROSFilterManagementInterfaceConfig(t *testing.T) {
+
+	input := `/interface ethernet
+set [ find default-name=ether1 ] advertise="1G-baseT-full,2.5G-baseT,5G-baseT,10G-baseT"
+set [ find default-name=ether12 ] comment="uplink-1" l2mtu=9000
+set [ find default-name=ether2 ] comment=uplink-2 disabled=yes l2mtu=9000
+set [ find default-name=sfp-sfpplus3 ] comment=uplink-3 l2mtu=9000
+/ip address
+add address=192.0.2.10/24 comment=mgmt interface=ether1 network=192.0.2.0
+add address=198.51.100.33/24 comment=data-2 interface=ether2 network=198.51.100.0
+add address=203.0.113.36/24 comment=data-11 interface=ether11 network=203.0.113.0
+add address=192.0.2.252/24 comment=loopback interface=lo network=192.0.2.252
+/ip dhcp-client
+add interface=VLAN100_LAN name=BR-WAN use-peer-dns=no use-peer-ntp=no
+/ip dhcp-server lease
+add address=192.0.2.219 client-id=\
+    aa:bb:cc:00:00:00:01:00:00:00:2e:00:00:00:88:00:00:00:00:68 mac-address=\
+    00:00:00:00:00:01 server=defconf
+/ip dhcp-server network
+add address=192.0.2.0/24 comment=defconf dns-server=198.51.100.53 gateway=\
+    192.0.2.1
+/ip dns`
+
+	n := new(vrRos)
+	got := n.filterManagementInterfaceConfig(input)
+
+	// The management interface (ether1) IP entry must be filtered out.
+	if strings.Contains(got, "interface=ether1 network=") {
+		t.Errorf("management ether1 entry was not filtered out:\n%s", got)
+	}
+
+	// Other interface named ether11 must NOT be filtered out (no substring greediness).
+	if !strings.Contains(got, "interface=ether11 network=") {
+		t.Errorf("data interface ether11 entry was incorrectly removed:\n%s", got)
+	}
+
+	// Everything else, including other sections and ether1 refs outside /ip address, must be kept.
+	for _, want := range []string{
+		"/interface ethernet",
+		"default-name=ether1",
+		"/ip address",
+		"interface=ether2 network=198.51.100.0",
+		"interface=lo network=192.0.2.252",
+		"/ip dhcp-client",
+		"interface=VLAN100_LAN name=BR-WAN",
+		"/ip dhcp-server lease",
+		"address=192.0.2.219 client-id=",
+		"/ip dhcp-server network",
+		"address=192.0.2.0/24 comment=defconf",
+		"/ip dns",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected entry %q to be kept, but it is missing:\n%s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
### Summary

  ```filterManagementInterfaceConfig``` in nodes/vr_ros/vr-ros.go used a raw substring match on interface=ether1 to drop the management interface's IP from a saved RouterOS config. Because ether1 is a substring of ether10/ether11/…, any data interface numbered ≥10 had its IP address silently stripped from the saved config.

 ### Fix
Match ```interface=ether1\b.*\bnetwork=``` instead of only ```interface=ether1```:

  - ```\b``` after ether1 prevents matching ether10+
  - the ```network=``` anchor scopes it to actual ```/ip address``` entries

###  Testing

  - Added ```TestROSFilterManagementInterfaceConfig``` using arbitrary configs.
  - Asserts the ```ether1``` management entry is dropped, the ```ether11``` data entry is retained (regression guard for the greediness bug), and neighbouring sections (/interface ethernet, /ip dhcp-client, /ip dhcp-server lease/network, /ip dns) plus ether1 references outside /ip address are left untouched.
  - go test ./nodes/vr_ros/ passes.