### PR TITLE
fix: reconcile host bridge links in one pass

### DIFF
--- a/.cursor/rules/git-mutations.mdc
+++ b/.cursor/rules/git-mutations.mdc
@@ -1,0 +1,10 @@
+---
+description: Require explicit user authorization for Git mutations
+alwaysApply: true
+---
+
+# Git mutation policy
+
+- Never automatically commit, amend, push, force-push, or create/update a pull request.
+- Leave ordinary fixes as working-tree changes unless the user explicitly requests the specific Git or GitHub action.
+- A request to implement or fix code alone does not authorize a commit or push.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,6 +53,7 @@ jobs:
           - "27*.robot"
           - "28*.robot"
           - "29*.robot"
+          - "30*.robot"
 
     # allow podman job to fail, since it started to fail on github actions
     continue-on-error: ${{ inputs.runtime == 'podman' }}

--- a/core/apply.go
+++ b/core/apply.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	clablinks "github.com/srl-labs/containerlab/links"
 )
@@ -124,6 +125,10 @@ func (c *CLab) apply(
 		return result, nil
 	}
 
+	if err := c.checkUnsupportedApplyNodes(); err != nil {
+		return nil, err
+	}
+
 	if err := c.setMgmtBridgeFromRuntime(currentNodes); err != nil {
 		return nil, err
 	}
@@ -226,7 +231,19 @@ func (c *CLab) apply(
 }
 
 func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {
-	if err := c.verifyLinks(ctx); err != nil {
+	params := *clablinks.NewVerifyLinkParams()
+	if len(c.Endpoints) > 0 {
+		runtime := c.globalRuntime()
+		if runtime == nil {
+			return fmt.Errorf("container runtime is not initialized")
+		}
+		config := runtime.Config()
+		if config.VerifyLinkParams != nil {
+			params = *config.VerifyLinkParams
+		}
+	}
+	params.AllowExistingEndpoint = true
+	if err := c.verifyLinksWithParams(ctx, &params); err != nil {
 		return err
 	}
 
@@ -241,6 +258,21 @@ func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {
 	}
 
 	return c.verifyDuplicateAddresses()
+}
+
+func (c *CLab) checkUnsupportedApplyNodes() error {
+	for _, nodeName := range sortedNodeNames(c.Nodes) {
+		cfg := c.Nodes[nodeName].Config()
+		if cfg != nil && strings.HasPrefix(cfg.NetworkMode, "container:") {
+			return fmt.Errorf(
+				"apply does not support nodes with %q; use redeploy or "+
+					"deploy --reconfigure",
+				cfg.NetworkMode,
+			)
+		}
+	}
+
+	return nil
 }
 
 func (c *CLab) prepareApply(

--- a/core/apply.go
+++ b/core/apply.go
@@ -243,7 +243,7 @@ func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {
 		}
 	}
 	params.AllowExistingEndpoint = true
-	if err := c.verifyLinksWithParams(ctx, &params); err != nil {
+	if err := c.verifyLinks(ctx, &params); err != nil {
 		return err
 	}
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -383,6 +383,37 @@ func TestApplyPlanLinkNeedsDeploy(t *testing.T) {
 	}
 }
 
+func TestApplyPlanLinkNeedsDeployRejectsMismatchedVethPeer(t *testing.T) {
+	t.Parallel()
+
+	n1 := &applyFakeLinkNode{name: "n1"}
+	n2 := &applyFakeLinkNode{name: "n2"}
+	link := clablinks.NewLinkVEth()
+	ep1 := clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n1, "eth1", link))
+	ep2 := clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n2, "eth1", link))
+	link.Endpoints = []clablinks.Endpoint{ep1, ep2}
+
+	plan := newApplyPlan(nil, nil)
+	plan.liveEndpointSet = map[applyEndpointKey]struct{}{
+		{node: "n1", iface: "eth1"}: {},
+		{node: "n2", iface: "eth1"}: {},
+	}
+	plan.liveEndpointInfo = map[applyEndpointKey]clablinks.OwnedInterface{
+		{node: "n1", iface: "eth1"}: {Name: "eth1", Index: 11, PeerIndex: 21},
+		{node: "n2", iface: "eth1"}: {Name: "eth1", Index: 22, PeerIndex: 11},
+	}
+
+	if !plan.linkNeedsDeploy(link) {
+		t.Fatal("expected link with mismatched live peers to be redeployed")
+	}
+
+	plan.liveEndpointInfo[applyEndpointKey{node: "n1", iface: "eth1"}] =
+		clablinks.OwnedInterface{Name: "eth1", Index: 11, PeerIndex: 22}
+	if plan.linkNeedsDeploy(link) {
+		t.Fatal("expected link with matching live peers to be preserved")
+	}
+}
+
 func TestPlanRecreatedNodeLinksDeploysAllTouchingLinks(t *testing.T) {
 	t.Parallel()
 
@@ -901,6 +932,38 @@ func TestRuntimeNodeGroupsIncludesPreExistingNodes(t *testing.T) {
 	}
 }
 
+func TestRuntimeNodeGroupsClassifiesRootNamespaceResourcesSeparately(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	rt := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+	node := clabmocksmocknodes.NewMockNode(ctrl)
+
+	node.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		IsRootNamespaceBased: true,
+	})
+	rt.EXPECT().ListContainers(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	c := &CLab{
+		Config: &Config{Name: "lab"},
+		Nodes:  map[string]clabnodes.Node{"bridge": node},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: rt,
+		},
+		globalRuntimeName: clabruntimedocker.RuntimeName,
+	}
+
+	groups, err := c.runtimeNodeGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group := groups["bridge"]
+	if group == nil || group.external || !group.rootNamespaceBased {
+		t.Fatalf("unexpected root namespace runtime group: %#v", group)
+	}
+}
+
 func TestNeedsInitialDeploy(t *testing.T) {
 	t.Parallel()
 
@@ -935,6 +998,33 @@ func TestNeedsInitialDeploy(t *testing.T) {
 	})
 	if err != nil || initial {
 		t.Fatalf("external nodes with state: initial = %v, error = %v", initial, err)
+	}
+}
+
+func TestNeedsInitialDeployIgnoresRootNamespaceResources(t *testing.T) {
+	t.Parallel()
+
+	topoFile := filepath.Join(t.TempDir(), "lab.clab.yml")
+	if err := os.WriteFile(topoFile, []byte("name: lab\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	topoPaths, err := clabtypes.NewTopoPaths(topoFile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := topoPaths.SetLabDirByPrefix("lab"); err != nil {
+		t.Fatal(err)
+	}
+	c := &CLab{TopoPaths: topoPaths}
+
+	initial, err := c.needsInitialDeploy(map[string]*runtimeNodeGroup{
+		"bridge": {rootNamespaceBased: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !initial {
+		t.Fatal("expected root-namespace-only state without a state file to deploy initially")
 	}
 }
 

--- a/core/config.go
+++ b/core/config.go
@@ -470,7 +470,7 @@ func (c *CLab) processNodeLicense(nodeCfg *clabtypes.NodeConfig) error {
 // checkTopologyDefinition runs topology checks and returns any errors found.
 // This function runs after topology file is parsed and all nodes/links are initialized.
 func (c *CLab) checkTopologyDefinition(ctx context.Context) error {
-	if err := c.verifyLinks(ctx); err != nil {
+	if err := c.verifyLinks(ctx, c.globalRuntime().Config().VerifyLinkParams); err != nil {
 		return err
 	}
 
@@ -544,15 +544,7 @@ func (c *CLab) verifyRootNetNSLinks() error {
 
 // verifyLinks checks if all the endpoints in the links section of the topology file
 // appear only once.
-func (c *CLab) verifyLinks(ctx context.Context) error {
-	var params *clablinks.VerifyLinkParams
-	if len(c.Endpoints) > 0 {
-		params = c.globalRuntime().Config().VerifyLinkParams
-	}
-	return c.verifyLinksWithParams(ctx, params)
-}
-
-func (c *CLab) verifyLinksWithParams(
+func (c *CLab) verifyLinks(
 	ctx context.Context,
 	params *clablinks.VerifyLinkParams,
 ) error {

--- a/core/config.go
+++ b/core/config.go
@@ -545,12 +545,23 @@ func (c *CLab) verifyRootNetNSLinks() error {
 // verifyLinks checks if all the endpoints in the links section of the topology file
 // appear only once.
 func (c *CLab) verifyLinks(ctx context.Context) error {
+	var params *clablinks.VerifyLinkParams
+	if len(c.Endpoints) > 0 {
+		params = c.globalRuntime().Config().VerifyLinkParams
+	}
+	return c.verifyLinksWithParams(ctx, params)
+}
+
+func (c *CLab) verifyLinksWithParams(
+	ctx context.Context,
+	params *clablinks.VerifyLinkParams,
+) error {
 	var err error
 
 	var verificationErrors []error
 
 	for _, e := range c.Endpoints {
-		err = e.Verify(ctx, c.globalRuntime().Config().VerifyLinkParams)
+		err = e.Verify(ctx, params)
 		if err != nil {
 			verificationErrors = append(verificationErrors, err)
 		}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -452,7 +452,7 @@ func TestVerifyLinks(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = c.verifyLinks(ctx)
+			err = c.verifyLinks(ctx, clablinks.NewVerifyLinkParams())
 			if err != nil && err.Error() != tc.want {
 				t.Fatalf("wanted %q got %q", tc.want, err.Error())
 			}

--- a/core/destroy.go
+++ b/core/destroy.go
@@ -340,7 +340,7 @@ func (c *CLab) deleteApplyNodes(ctx context.Context, plan *applyPlan) error {
 		if runtimeNode == nil {
 			return fmt.Errorf("runtime node %q not found", nodeName)
 		}
-		if runtimeNode.external {
+		if runtimeNode.external || runtimeNode.rootNamespaceBased {
 			continue
 		}
 

--- a/core/runtime_state.go
+++ b/core/runtime_state.go
@@ -11,10 +11,11 @@ import (
 )
 
 type runtimeNodeGroup struct {
-	name        string
-	containers  []clabruntime.GenericContainer
-	distributed bool
-	external    bool
+	name               string
+	containers         []clabruntime.GenericContainer
+	distributed        bool
+	external           bool
+	rootNamespaceBased bool
 }
 
 func (c *CLab) runtimeNodeGroups(
@@ -70,8 +71,14 @@ func (c *CLab) runtimeNodeGroups(
 		if _, exists := result[nodeName]; exists {
 			continue
 		}
-		if !cfg.IsRootNamespaceBased &&
-			(!cfg.SkipUniquenessCheck || node.GetContainerStatus(ctx) == clabruntime.NotFound) {
+		if cfg.IsRootNamespaceBased {
+			result[nodeName] = &runtimeNodeGroup{
+				name:               nodeName,
+				rootNamespaceBased: true,
+			}
+			continue
+		}
+		if !cfg.SkipUniquenessCheck || node.GetContainerStatus(ctx) == clabruntime.NotFound {
 			continue
 		}
 		result[nodeName] = &runtimeNodeGroup{name: nodeName, external: true}
@@ -110,7 +117,7 @@ func (c *CLab) needsInitialDeploy(currentNodes map[string]*runtimeNodeGroup) (bo
 		return true, nil
 	}
 	for _, node := range currentNodes {
-		if !node.external {
+		if !node.external && !node.rootNamespaceBased {
 			return false, nil
 		}
 	}

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -415,9 +415,10 @@ func (c *CLab) discoverLiveApplyEndpoints(
 
 		plan.setEndpointNode(nodeName, n)
 
-		interfaces, err := clablinks.DiscoverOwnedInterfaces(
+		interfaces, err := clablinks.DiscoverOwnedInterfacesFor(
 			ctx,
 			n,
+			nodeName,
 			c.applyKnownEndpointNames(plan, nodeName),
 		)
 		if err != nil {
@@ -455,7 +456,12 @@ func (c *CLab) validateDesiredEndpointOwnership(
 			continue
 		}
 
-		if err := clablinks.ValidateOwnedInterface(ctx, node, key.iface); err != nil {
+		if err := clablinks.ValidateOwnedInterfaceFor(
+			ctx,
+			node,
+			key.node,
+			key.iface,
+		); err != nil {
 			return fmt.Errorf(
 				"desired endpoint %s cannot be reconciled: %w",
 				key.String(),

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -43,6 +43,7 @@ type applyPlan struct {
 	staleEndpoints     []applyEndpointRef
 	desiredEndpointSet map[applyEndpointKey]struct{}
 	liveEndpointSet    map[applyEndpointKey]struct{}
+	liveEndpointInfo   map[applyEndpointKey]clablinks.OwnedInterface
 	endpointNodes      map[string]clablinks.Node
 	state              *LabState
 	parkedNodeSet      map[string]struct{}
@@ -77,6 +78,7 @@ func newApplyPlan(currentNodes map[string]*runtimeNodeGroup, state *LabState) *a
 		plannedLinkSet:     map[int]struct{}{},
 		desiredEndpointSet: map[applyEndpointKey]struct{}{},
 		liveEndpointSet:    map[applyEndpointKey]struct{}{},
+		liveEndpointInfo:   map[applyEndpointKey]clablinks.OwnedInterface{},
 		endpointNodes:      map[string]clablinks.Node{},
 		state:              state,
 		nodeChangeReasons:  map[string]string{},
@@ -89,6 +91,18 @@ func (p *applyPlan) isExternallyManaged(nodeName string) bool {
 	}
 	node := p.currentNodes[nodeName]
 	return node != nil && node.external
+}
+
+func (p *applyPlan) isRootNamespaceNode(nodeName string) bool {
+	if p == nil {
+		return false
+	}
+	node := p.currentNodes[nodeName]
+	return node != nil && node.rootNamespaceBased
+}
+
+func (p *applyPlan) isNonContainerNode(nodeName string) bool {
+	return p.isExternallyManaged(nodeName) || p.isRootNamespaceNode(nodeName)
 }
 
 func (c *CLab) planApply(
@@ -137,6 +151,10 @@ func (c *CLab) planApply(
 	}
 
 	if err := c.discoverLiveApplyEndpoints(ctx, plan); err != nil {
+		return nil, err
+	}
+
+	if err := c.validateDesiredEndpointOwnership(ctx, plan); err != nil {
 		return nil, err
 	}
 
@@ -203,7 +221,7 @@ func (c *CLab) planStoppedNodes(ctx context.Context, plan *applyPlan) {
 	}
 
 	for nodeName := range plan.currentNodes {
-		if plan.isExternallyManaged(nodeName) {
+		if plan.isNonContainerNode(nodeName) {
 			continue
 		}
 		node, exists := c.Nodes[nodeName]
@@ -376,7 +394,7 @@ func (c *CLab) discoverLiveApplyEndpoints(
 				continue
 			}
 			n = parkingNode
-		} else if !isApplySpecialNode(nodeName) {
+		} else if !isApplySpecialNode(nodeName) && !plan.isRootNamespaceNode(nodeName) {
 			status := c.Nodes[nodeName].GetContainerStatus(ctx)
 			if !clabruntime.ContainerHasJoinableNetns(status) {
 				if plan.isExternallyManaged(nodeName) {
@@ -397,7 +415,7 @@ func (c *CLab) discoverLiveApplyEndpoints(
 
 		plan.setEndpointNode(nodeName, n)
 
-		ifaceNames, err := clablinks.DiscoverOwnedInterfaceNames(
+		interfaces, err := clablinks.DiscoverOwnedInterfaces(
 			ctx,
 			n,
 			c.applyKnownEndpointNames(plan, nodeName),
@@ -410,8 +428,39 @@ func (c *CLab) discoverLiveApplyEndpoints(
 			)
 		}
 
-		for _, ifaceName := range ifaceNames {
-			plan.liveEndpointSet[applyEndpointKey{node: nodeName, iface: ifaceName}] = struct{}{}
+		for _, iface := range interfaces {
+			key := applyEndpointKey{node: nodeName, iface: iface.Name}
+			plan.liveEndpointSet[key] = struct{}{}
+			plan.liveEndpointInfo[key] = iface
+		}
+	}
+
+	return nil
+}
+
+func (c *CLab) validateDesiredEndpointOwnership(
+	ctx context.Context,
+	plan *applyPlan,
+) error {
+	for _, key := range sortedEndpointKeys(plan.desiredEndpointSet) {
+		if _, added := plan.addedNodeSet[key.node]; added {
+			continue
+		}
+
+		node, exists := plan.endpointNode(key.node)
+		if !exists {
+			node, exists = c.applyLinkNode(key.node)
+		}
+		if !exists {
+			continue
+		}
+
+		if err := clablinks.ValidateOwnedInterface(ctx, node, key.iface); err != nil {
+			return fmt.Errorf(
+				"desired endpoint %s cannot be reconciled: %w",
+				key.String(),
+				err,
+			)
 		}
 	}
 
@@ -622,7 +671,7 @@ func (c *CLab) planNodeReconciliation(ctx context.Context, plan *applyPlan) erro
 		if err != nil {
 			return fmt.Errorf("reconcile planning failed for node %q: %w", nodeName, err)
 		}
-		if plan.isExternallyManaged(nodeName) && result.Action != clabtypes.TopologyDiffActionNone {
+		if plan.isNonContainerNode(nodeName) && result.Action != clabtypes.TopologyDiffActionNone {
 			return fmt.Errorf(
 				"node %q is externally managed and cannot be %s for %s",
 				nodeName,
@@ -663,6 +712,9 @@ func (c *CLab) reconcileNodes(ctx context.Context, plan *applyPlan) error {
 			continue
 		}
 		if _, added := plan.addedNodeSet[nodeName]; added {
+			continue
+		}
+		if plan.isRootNamespaceNode(nodeName) {
 			continue
 		}
 		// Recreated nodes are handled exclusively by the apply pipeline
@@ -706,7 +758,36 @@ func (p *applyPlan) linkNeedsDeploy(link clablinks.Link) bool {
 		}
 	}
 
-	return false
+	return !p.linkIntact(link)
+}
+
+func (p *applyPlan) linkIntact(link clablinks.Link) bool {
+	endpoints := clablinks.RuntimeEndpoints(link)
+	if len(endpoints) != 2 || len(p.liveEndpointInfo) == 0 {
+		return true
+	}
+
+	left, leftOK := p.liveEndpointInfo[endpointKeyFromEndpoint(endpoints[0])]
+	right, rightOK := p.liveEndpointInfo[endpointKeyFromEndpoint(endpoints[1])]
+	if !leftOK || !rightOK {
+		return false
+	}
+
+	if endpoints[0].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
+		!endpoints[0].IsNodeless() &&
+		left.MasterName != endpoints[0].GetNode().GetShortName() {
+		return false
+	}
+	if endpoints[1].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
+		!endpoints[1].IsNodeless() &&
+		right.MasterName != endpoints[1].GetNode().GetShortName() {
+		return false
+	}
+
+	return left.PeerIndex != 0 &&
+		right.PeerIndex != 0 &&
+		left.PeerIndex == right.Index &&
+		right.PeerIndex == left.Index
 }
 
 func (p *applyPlan) deployNodeNames() []string {

--- a/links/apply_test.go
+++ b/links/apply_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 func TestRuntimeEndpointsForMacVlanExcludesParent(t *testing.T) {
@@ -69,6 +71,30 @@ func TestEndpointByInterfaceName(t *testing.T) {
 
 	if _, ok := endpointByInterfaceName([]Endpoint{nodeEp, hostEp}, "missing"); ok {
 		t.Fatal("expected missing endpoint not to be found")
+	}
+}
+
+func TestHasOwnershipAltNameForScopesOwnershipToLogicalEndpoint(t *testing.T) {
+	t.Parallel()
+
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "eth1",
+			AltNames: []string{
+				ownershipAltNameFor("bridge-a", "eth1"),
+				ownershipAltNameFor("bridge-b", "eth2"),
+			},
+		},
+	}
+
+	if !HasOwnershipAltNameFor(link, "bridge-a", "eth1") {
+		t.Fatal("expected exact logical endpoint ownership marker")
+	}
+	if HasOwnershipAltNameFor(link, "bridge-a", "eth2") {
+		t.Fatal("did not expect another interface to match the marker")
+	}
+	if HasOwnershipAltNameFor(link, "bridge-b", "eth1") {
+		t.Fatal("did not expect another node to match the marker")
 	}
 }
 

--- a/links/endpoint_bridge.go
+++ b/links/endpoint_bridge.go
@@ -27,16 +27,15 @@ func (e *EndpointBridge) Verify(ctx context.Context, p *VerifyLinkParams) error 
 	if err != nil {
 		errs = append(errs, err)
 	}
-	// if the BridgeExists check is disabled by config and it is not a Bridge in an Namespace, run
-	// the check
-	if p.RunBridgeExistsCheck && e.Node.GetLinkEndpointType() != LinkEndpointTypeBridgeNS {
+	if (p == nil || p.RunBridgeExistsCheck) &&
+		e.Node.GetLinkEndpointType() != LinkEndpointTypeBridgeNS {
 		err = CheckBridgeExists(ctx, e.GetNode())
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-	// if it is supposed to be a bridge in a Namespace, the if exists check is to be skipped.
-	if e.Node.GetLinkEndpointType() != LinkEndpointTypeBridgeNS {
+	if (p == nil || !p.AllowExistingEndpoint) &&
+		e.Node.GetLinkEndpointType() != LinkEndpointTypeBridgeNS {
 		err = CheckEndpointDoesNotExistYet(ctx, e)
 		if err != nil {
 			errs = append(errs, err)

--- a/links/endpoint_host.go
+++ b/links/endpoint_host.go
@@ -19,15 +19,17 @@ func (e *EndpointHost) Deploy(ctx context.Context) error {
 	return e.GetLink().Deploy(ctx, e)
 }
 
-func (e *EndpointHost) Verify(ctx context.Context, _ *VerifyLinkParams) error {
+func (e *EndpointHost) Verify(ctx context.Context, p *VerifyLinkParams) error {
 	var errs []error
 	err := CheckEndpointUniqueness(e)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	err = CheckEndpointDoesNotExistYet(ctx, e)
-	if err != nil {
-		errs = append(errs, err)
+	if p == nil || !p.AllowExistingEndpoint {
+		err = CheckEndpointDoesNotExistYet(ctx, e)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/links/link.go
+++ b/links/link.go
@@ -617,7 +617,11 @@ func SetNameMACAndUpInterface(l netlink.Link, endpt Endpoint) func(ns.NetNS) err
 }
 
 func ownershipAltName(endpt Endpoint) string {
-	sum := sha1.Sum([]byte(endpt.GetNode().GetShortName() + "\x00" + endpt.GetIfaceName()))
+	return ownershipAltNameFor(endpt.GetNode().GetShortName(), endpt.GetIfaceName())
+}
+
+func ownershipAltNameFor(nodeName, ifaceName string) string {
+	sum := sha1.Sum([]byte(nodeName + "\x00" + ifaceName))
 	return ownershipAltNamePrefix + hex.EncodeToString(sum[:8])
 }
 
@@ -634,6 +638,23 @@ func hasOwnershipAltName(link netlink.Link) bool {
 // HasOwnershipAltName reports whether link carries a containerlab ownership marker.
 func HasOwnershipAltName(link netlink.Link) bool {
 	return hasOwnershipAltName(link)
+}
+
+// HasOwnershipAltNameFor reports whether link is owned by the logical endpoint
+// identified by nodeName and ifaceName.
+func HasOwnershipAltNameFor(link netlink.Link, nodeName, ifaceName string) bool {
+	if link == nil || nodeName == "" || ifaceName == "" {
+		return false
+	}
+
+	want := ownershipAltNameFor(nodeName, ifaceName)
+	for _, altName := range link.Attrs().AltNames {
+		if altName == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addOwnershipAltName(link netlink.Link, endpt Endpoint) error {
@@ -682,7 +703,8 @@ type ResolveParams struct {
 }
 
 type VerifyLinkParams struct {
-	RunBridgeExistsCheck bool
+	RunBridgeExistsCheck  bool
+	AllowExistingEndpoint bool
 }
 
 func NewVerifyLinkParams() *VerifyLinkParams {

--- a/links/ownership.go
+++ b/links/ownership.go
@@ -30,6 +30,18 @@ func DiscoverOwnedInterfaces(
 	node Node,
 	knownIfaceNames map[string]struct{},
 ) ([]OwnedInterface, error) {
+	return DiscoverOwnedInterfacesFor(ctx, node, node.GetShortName(), knownIfaceNames)
+}
+
+// DiscoverOwnedInterfacesFor discovers interfaces in node's namespace that
+// carry ownership markers for ownerName. Parking nodes use this when the
+// namespace and logical node differ.
+func DiscoverOwnedInterfacesFor(
+	ctx context.Context,
+	node Node,
+	ownerName string,
+	knownIfaceNames map[string]struct{},
+) ([]OwnedInterface, error) {
 	var interfaces []OwnedInterface
 
 	err := node.ExecFunction(ctx, func(_ ns.NetNS) error {
@@ -48,7 +60,7 @@ func DiscoverOwnedInterfaces(
 					continue
 				}
 			}
-			if !HasOwnershipAltNameFor(link, node.GetShortName(), name) {
+			if !HasOwnershipAltNameFor(link, ownerName, name) {
 				continue
 			}
 
@@ -119,6 +131,18 @@ func DiscoverOwnedInterfaceNames(
 // ValidateOwnedInterface returns an error when an existing interface is not
 // owned by the requested logical endpoint. Missing interfaces are valid.
 func ValidateOwnedInterface(ctx context.Context, node Node, ifaceName string) error {
+	return ValidateOwnedInterfaceFor(ctx, node, node.GetShortName(), ifaceName)
+}
+
+// ValidateOwnedInterfaceFor validates an interface in node's namespace against
+// a possibly different logical owner. Parking nodes use this when the
+// interface remains owned by the original node.
+func ValidateOwnedInterfaceFor(
+	ctx context.Context,
+	node Node,
+	ownerName string,
+	ifaceName string,
+) error {
 	return node.ExecFunction(ctx, func(_ ns.NetNS) error {
 		link, err := netlink.LinkByName(ifaceName)
 		if _, notfound := err.(netlink.LinkNotFoundError); notfound {
@@ -127,7 +151,7 @@ func ValidateOwnedInterface(ctx context.Context, node Node, ifaceName string) er
 		if err != nil {
 			return err
 		}
-		if HasOwnershipAltNameFor(link, node.GetShortName(), ifaceName) {
+		if HasOwnershipAltNameFor(link, ownerName, ifaceName) {
 			return nil
 		}
 		return fmt.Errorf(

--- a/links/ownership.go
+++ b/links/ownership.go
@@ -12,12 +12,25 @@ import (
 
 var ErrInterfaceUnowned = errors.New("interface is not marked as containerlab-owned")
 
-func DiscoverOwnedInterfaceNames(
+// OwnedInterface describes a containerlab-owned interface discovered in a node's
+// network namespace.
+type OwnedInterface struct {
+	Name        string
+	Index       int
+	PeerIndex   int
+	MasterIndex int
+	MasterName  string
+	Type        string
+}
+
+// DiscoverOwnedInterfaces returns containerlab-owned interfaces and the
+// netlink metadata needed to verify veth link pairing.
+func DiscoverOwnedInterfaces(
 	ctx context.Context,
 	node Node,
 	knownIfaceNames map[string]struct{},
-) ([]string, error) {
-	var ifaceNames []string
+) ([]OwnedInterface, error) {
+	var interfaces []OwnedInterface
 
 	err := node.ExecFunction(ctx, func(_ ns.NetNS) error {
 		links, err := netlink.LinkList()
@@ -35,11 +48,40 @@ func DiscoverOwnedInterfaceNames(
 					continue
 				}
 			}
-			if !hasOwnershipAltName(link) {
+			if !HasOwnershipAltNameFor(link, node.GetShortName(), name) {
 				continue
 			}
 
-			ifaceNames = append(ifaceNames, name)
+			info := OwnedInterface{
+				Name:        name,
+				Index:       link.Attrs().Index,
+				MasterIndex: link.Attrs().MasterIndex,
+				Type:        link.Type(),
+			}
+			if info.MasterIndex != 0 {
+				master, masterErr := netlink.LinkByIndex(info.MasterIndex)
+				if masterErr != nil {
+					return fmt.Errorf(
+						"failed to discover master for %q: %w",
+						name,
+						masterErr,
+					)
+				}
+				info.MasterName = master.Attrs().Name
+			}
+			if info.Type == "veth" {
+				veth, ok := link.(*netlink.Veth)
+				if !ok {
+					veth = &netlink.Veth{LinkAttrs: *link.Attrs()}
+				}
+				peerIndex, peerErr := netlink.VethPeerIndex(veth)
+				if peerErr != nil {
+					return fmt.Errorf("failed to discover veth peer for %q: %w", name, peerErr)
+				}
+				info.PeerIndex = peerIndex
+			}
+
+			interfaces = append(interfaces, info)
 		}
 
 		return nil
@@ -48,9 +90,52 @@ func DiscoverOwnedInterfaceNames(
 		return nil, err
 	}
 
+	sort.Slice(interfaces, func(i, j int) bool {
+		return interfaces[i].Name < interfaces[j].Name
+	})
+
+	return interfaces, nil
+}
+
+func DiscoverOwnedInterfaceNames(
+	ctx context.Context,
+	node Node,
+	knownIfaceNames map[string]struct{},
+) ([]string, error) {
+	interfaces, err := DiscoverOwnedInterfaces(ctx, node, knownIfaceNames)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaceNames := make([]string, 0, len(interfaces))
+	for _, iface := range interfaces {
+		ifaceNames = append(ifaceNames, iface.Name)
+	}
 	sort.Strings(ifaceNames)
 
 	return ifaceNames, nil
+}
+
+// ValidateOwnedInterface returns an error when an existing interface is not
+// owned by the requested logical endpoint. Missing interfaces are valid.
+func ValidateOwnedInterface(ctx context.Context, node Node, ifaceName string) error {
+	return node.ExecFunction(ctx, func(_ ns.NetNS) error {
+		link, err := netlink.LinkByName(ifaceName)
+		if _, notfound := err.(netlink.LinkNotFoundError); notfound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if HasOwnershipAltNameFor(link, node.GetShortName(), ifaceName) {
+			return nil
+		}
+		return fmt.Errorf(
+			"interface %q on node %q exists but is not containerlab-owned",
+			ifaceName,
+			node.GetShortName(),
+		)
+	})
 }
 
 func RemoveOwnedInterface(ctx context.Context, node Node, ifaceName string) error {
@@ -66,7 +151,7 @@ func RemoveOwnedInterface(ctx context.Context, node Node, ifaceName string) erro
 		if err != nil {
 			return err
 		}
-		if !hasOwnershipAltName(link) {
+		if !HasOwnershipAltNameFor(link, node.GetShortName(), ifaceName) {
 			return fmt.Errorf(
 				"%w: interface %q on node %q",
 				ErrInterfaceUnowned,

--- a/tests/01-smoke/30-bridge-reconcile.clab.yml
+++ b/tests/01-smoke/30-bridge-reconcile.clab.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../schemas/clab.schema.json
+# Copyright 2026 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: bridge-reconcile
+
+topology:
+  nodes:
+    n1:
+      kind: linux
+      image: alpine:3
+      cmd: tail -f /dev/null
+    br-30-reconcile:
+      kind: bridge
+
+  links:
+    - endpoints:
+        ["n1:eth1", "br-30-reconcile:{{ if .remap }}e1{{ else }}e2{{ end }}"]
+    - endpoints:
+        ["n1:eth2", "br-30-reconcile:{{ if .remap }}e2{{ else }}e3{{ end }}"]

--- a/tests/01-smoke/30-bridge-reconcile.robot
+++ b/tests/01-smoke/30-bridge-reconcile.robot
@@ -1,0 +1,99 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Process
+Resource            ../common.robot
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+
+*** Variables ***
+${lab-name}         bridge-reconcile
+${topo}              30-bridge-reconcile.clab.yml
+${initial-vars}      30-bridge-reconcile.vars.initial.yml
+${remap-vars}        30-bridge-reconcile.vars.remap.yml
+${runtime}           docker
+${bridge-name}       br-30-reconcile
+${runtime-cli-exec}  docker exec
+
+
+*** Test Cases ***
+Initial bridge deployment
+    ${rc}    ${output} =    Run Clab Command
+    ...    deploy -t ${CURDIR}/${topo} --vars ${CURDIR}/${initial-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Interface Should Exist    eth1
+    Interface Should Exist    eth2
+    Host Interface Should Be Attached To Bridge    e2
+    Host Interface Should Be Attached To Bridge    e3
+
+Bridge endpoint remap converges in one deploy
+    ${rc}    ${output} =    Run Clab Command
+    ...    deploy -t ${CURDIR}/${topo} --vars ${CURDIR}/${remap-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    Apply summary
+    Interface Should Exist    eth1
+    Interface Should Exist    eth2
+    Host Interface Should Be Attached To Bridge    e1
+    Host Interface Should Be Attached To Bridge    e2
+    Host Interface Should Not Exist    e3
+
+Remapped bridge is idempotent
+    ${rc}    ${output} =    Run Clab Command
+    ...    deploy -t ${CURDIR}/${topo} --vars ${CURDIR}/${remap-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${output}    added links
+    Should Not Contain    ${output}    deleted endpoints
+    Host Interface Should Be Attached To Bridge    e1
+    Host Interface Should Be Attached To Bridge    e2
+
+
+*** Keywords ***
+Setup
+    IF    '${runtime}' == 'podman'
+        Set Suite Variable    ${runtime-cli-exec}    sudo podman exec
+    END
+    Run Clab Command    destroy --name ${lab-name} --cleanup
+    Run    sudo ip link del ${bridge-name}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip link add name ${bridge-name} type bridge
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sudo ip link set ${bridge-name} up
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+
+Teardown
+    Run Clab Command    destroy --name ${lab-name} --cleanup
+    Run    sudo ip link del ${bridge-name}
+
+Run Clab Command
+    [Arguments]    ${args}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} ${args} 2>&1
+    Log    ${output}
+    RETURN    ${rc}    ${output}
+
+Interface Should Exist
+    [Arguments]    ${interface}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime-cli-exec} clab-${lab-name}-n1 ip link show ${interface}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    ${interface}
+
+Host Interface Should Be Attached To Bridge
+    [Arguments]    ${interface}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ip link show ${interface}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    master ${bridge-name}
+
+Host Interface Should Not Exist
+    [Arguments]    ${interface}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ip link show ${interface}
+    Log    ${output}
+    Should Not Be Equal As Integers    ${rc}    0

--- a/tests/01-smoke/30-bridge-reconcile.vars.initial.yml
+++ b/tests/01-smoke/30-bridge-reconcile.vars.initial.yml
@@ -1,0 +1,1 @@
+remap: false

--- a/tests/01-smoke/30-bridge-reconcile.vars.remap.yml
+++ b/tests/01-smoke/30-bridge-reconcile.vars.remap.yml
@@ -1,0 +1,1 @@
+remap: true

--- a/tests/13-srsim/11-srsim-apply.robot
+++ b/tests/13-srsim/11-srsim-apply.robot
@@ -3,6 +3,7 @@ Library             OperatingSystem
 Resource            ../common.robot
 Resource            ../ssh.robot
 
+Suite Setup         Run Keyword    Cleanup
 Suite Teardown      Run Keyword    Cleanup
 
 
@@ -124,4 +125,4 @@ SR-SIM Cards Up
     Should Match Regexp    ${output}    (?m)^1\\s+\\S+\\s+up\\s+up
 
 Cleanup
-    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${topo} --cleanup
+    Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${topo} --vars ${CURDIR}/${linked-with-node-vars} --cleanup


### PR DESCRIPTION
substitutes #3312 

## Problem

Labs containing topology `kind: bridge` nodes could deploy successfully but fail on a subsequent `deploy`/`apply`. Root-namespace bridges were classified as external containers, so reconciliation queried a nonexistent container and rejected the lab. Even after bypassing that failure, endpoint-only reconciliation considered reused interface names live despite their veth peers having changed; deleting a stale endpoint could then remove a peer needed by another desired link.

## Changes

- Model root-namespace resources separately from externally managed containers and avoid container lifecycle/status checks for them.
- Scope interface ownership to the exact logical `(node, interface)` marker, preventing host-namespace bridge/host/OVS nodes from cross-attributing interfaces.
- Keep fresh-deployment collision checks while allowing existing endpoints during reconciliation, with an explicit unowned-interface guard before mutations.
- Discover veth peer and bridge-master metadata and require desired two-ended links to match their live peer pairing before preserving them.
- Reject unsupported `network-mode: container:...` reconciliation explicitly.
- Pass link-verification parameters explicitly through one verification method, keeping fresh deployment and apply policies clear.
- Separate namespace identity from logical ownership identity so interfaces parked during SR-SIM/node restarts remain discoverable and owned by their original node.
- Add a new gating smoke suite that deploys bridge ports `e2/e3`, remaps them to `e1/e2` in one deploy, and verifies the second deploy is a no-op. Existing bridge topologies were not changed.

## Validation

- Baseline bridge regression fails before the fix during reconciliation.
- New `30-bridge-reconcile.robot`: 3/3 passed.
- Existing bridge suites `03*.robot` and `24*.robot`: passed.
- Existing apply suite `29*.robot`: 10/10 passed.
- SRSIM apply suite `11-srsim-apply.robot`: 5/5 passed after the parked-namespace ownership fix.
- `make test`: passed.
- `make lint`: passed.
- Focused follow-up tests: `go test ./core ./links` passed.