### PR TITLE
allow setting ca params via env vars without requiring the ca settings container to be present

### DIFF
--- a/core/deploy.go
+++ b/core/deploy.go
@@ -381,6 +381,7 @@ func (c *CLab) certificateAuthoritySetup() error {
 	// Set defaults for the CA parameters
 	keySize := 2048
 	validityDuration := time.Until(time.Now().AddDate(1, 0, 0)) // 1 year as default
+	var extCACert, extCAKey string
 
 	// check that Settings.CertificateAuthority exists.
 	if s != nil && s.CertificateAuthority != nil {
@@ -395,23 +396,23 @@ func (c *CLab) certificateAuthoritySetup() error {
 		}
 
 		// if external CA cert and key are set, propagate to topopaths
-		extCACert := s.CertificateAuthority.Cert
-		extCAKey := s.CertificateAuthority.Key
+		extCACert = s.CertificateAuthority.Cert
+		extCAKey = s.CertificateAuthority.Key
+	}
 
-		// override external ca and key from env vars
-		if v := os.Getenv("CLAB_CA_KEY_FILE"); v != "" {
-			extCAKey = v
-		}
+	// override external ca and key from env vars
+	if v := os.Getenv("CLAB_CA_KEY_FILE"); v != "" {
+		extCAKey = v
+	}
 
-		if v := os.Getenv("CLAB_CA_CERT_FILE"); v != "" {
-			extCACert = v
-		}
+	if v := os.Getenv("CLAB_CA_CERT_FILE"); v != "" {
+		extCACert = v
+	}
 
-		if extCACert != "" && extCAKey != "" {
-			err := c.TopoPaths.SetExternalCaFiles(extCACert, extCAKey)
-			if err != nil {
-				return err
-			}
+	if extCACert != "" && extCAKey != "" {
+		err := c.TopoPaths.SetExternalCaFiles(extCACert, extCAKey)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/core/deploy_test.go
+++ b/core/deploy_test.go
@@ -5,11 +5,17 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	clabcert "github.com/srl-labs/containerlab/cert"
 )
 
 func TestWaitForNodeDeployErrorPrecedence(t *testing.T) {
@@ -86,5 +92,57 @@ func TestCheckReconcileDeployOptionsAllowsTopologyManagementNetwork(t *testing.T
 
 	if err := c.checkReconcileDeployOptions(&DeployOptions{}); err != nil {
 		t.Fatalf("topology management settings must not be treated as overrides: %v", err)
+	}
+}
+
+func TestCertificateAuthoritySetupUsesEnvironmentCAWithoutSettings(t *testing.T) {
+	tempDir := t.TempDir()
+	topoFile := filepath.Join(tempDir, "topology.clab.yml")
+	if err := os.WriteFile(topoFile, []byte("name: env-ca\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := NewContainerLab()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.TopoPaths.SetTopologyFilePath(topoFile); err != nil {
+		t.Fatal(err)
+	}
+	c.Config.Name = "env-ca"
+	if err := c.TopoPaths.SetLabDirByPrefix(c.Config.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	externalCA, err := clabcert.NewCA().GenerateCACert(&clabcert.CACSRInput{
+		CommonName: "CA-FROM-ENV",
+		Country:    "US",
+		Expiry:     time.Hour,
+		KeySize:    1024,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	certFile := filepath.Join(tempDir, "ca.pem")
+	keyFile := filepath.Join(tempDir, "ca.key")
+	if err := externalCA.Write(certFile, keyFile, ""); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAB_CA_CERT_FILE", certFile)
+	t.Setenv("CLAB_CA_KEY_FILE", keyFile)
+
+	if err := c.certificateAuthoritySetup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := c.TopoPaths.CaCertAbsFilename(); got != certFile {
+		t.Fatalf("CA certificate path = %q, want %q", got, certFile)
+	}
+	loadedCA, err := c.Cert.LoadCaCert()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(loadedCA.Cert, externalCA.Cert) {
+		t.Fatal("certificateAuthoritySetup did not load the CA certificate from CLAB_CA_CERT_FILE")
 	}
 }


### PR DESCRIPTION
fix #3315 

Move the environment variable override for external CA certificate and key files outside the topology CertificateAuthority settings block so that CA files specified via CLAB_CA_CERT_FILE and CLAB_CA_KEY_FILE are used even when the topology does not define certificate authority settings.

