### PR TITLE
feat: add cgroup parent node setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DATE := $(shell date)
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 
 LDFLAGS := -s -w -X 'github.com/srl-labs/containerlab/cmd.Version=0.0.0' -X 'github.com/srl-labs/containerlab/cmd.commit=$(COMMIT_HASH)' -X 'github.com/srl-labs/containerlab/cmd.date=$(DATE)'
+PODMAN_GO_TAGS := podman exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper exclude_graphdriver_overlay containers_image_openpgp
 
 # uv version downloaded by `install-uv` when uv is not found on the system.
 # Keep in sync with UV_VER in .github/workflows/*.
@@ -86,14 +87,14 @@ build-dlv-debug:
 
 build-with-podman:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=0 go build -o $(BINARY) -ldflags="$(LDFLAGS)" -trimpath -tags "podman exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper exclude_graphdriver_overlay containers_image_openpgp" main.go
+	CGO_ENABLED=0 go build -o $(BINARY) -ldflags="$(LDFLAGS)" -trimpath -tags "$(PODMAN_GO_TAGS)" main.go
 	chmod a+x $(BINARY)
 	sudo chown root:root $(BINARY)
 	sudo chmod 4755 $(BINARY)
 
 build-with-podman-debug:
 	mkdir -p $(BIN_DIR)
-	CGO_ENABLED=1 go build -o $(BINARY) -gcflags=all="-N -l" -race -cover -trimpath -tags "podman exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper exclude_graphdriver_overlay containers_image_openpgp" main.go
+	CGO_ENABLED=1 go build -o $(BINARY) -gcflags=all="-N -l" -race -cover -trimpath -tags "$(PODMAN_GO_TAGS)" main.go
 	sudo chown root:root $(BINARY)
 	sudo chmod 4755 $(BINARY)
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -778,6 +778,7 @@ func TestResolveNodeConfigFromTopologyRuntimeOptions(t *testing.T) {
 	topo.Nodes["n1"] = &clabtypes.NodeDefinition{
 		Kind:         "test",
 		CgroupnsMode: "host",
+		CgroupParent: "/xform/my-lab/leaves",
 		PidMode:      "host",
 		Tmpfs:        map[string]string{"/run": "rw,nosuid"},
 		SecurityOpts: []string{"seccomp=unconfined"},
@@ -789,6 +790,9 @@ func TestResolveNodeConfigFromTopologyRuntimeOptions(t *testing.T) {
 	}
 	if cfg.CgroupnsMode != "host" {
 		t.Fatalf("CgroupnsMode = %q, want host", cfg.CgroupnsMode)
+	}
+	if cfg.CgroupParent != "/xform/my-lab/leaves" {
+		t.Fatalf("CgroupParent = %q, want /xform/my-lab/leaves", cfg.CgroupParent)
 	}
 	if cfg.PidMode != "host" {
 		t.Fatalf("PidMode = %q, want host", cfg.PidMode)

--- a/core/config.go
+++ b/core/config.go
@@ -295,6 +295,7 @@ func (c *CLab) createNodeCfg( //nolint: funlen
 		CapAdd:          c.Config.Topology.GetNodeCapAdd(nodeName),
 		Privileged:      privileged,
 		CgroupnsMode:    c.Config.Topology.GetNodeCgroupnsMode(nodeName),
+		CgroupParent:    c.Config.Topology.GetNodeCgroupParent(nodeName),
 		PidMode:         c.resolvePidMode(c.Config.Topology.GetNodePidMode(nodeName)),
 		Tmpfs:           c.Config.Topology.GetNodeTmpfs(nodeName),
 		SecurityOpts:    c.Config.Topology.GetNodeSecurityOpts(nodeName),

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -633,6 +633,7 @@ func (c *CLab) resolveNodeConfigFromTopology(
 		CapAdd:       topo.GetNodeCapAdd(nodeName),
 		Privileged:   privileged,
 		CgroupnsMode: topo.GetNodeCgroupnsMode(nodeName),
+		CgroupParent: topo.GetNodeCgroupParent(nodeName),
 		PidMode:      topo.GetNodePidMode(nodeName),
 		Tmpfs:        topo.GetNodeTmpfs(nodeName),
 		SecurityOpts: topo.GetNodeSecurityOpts(nodeName),

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -789,6 +789,24 @@ my-node:
   cgroupns-mode: host
 ```
 
+### cgroup-parent
+
+The `cgroup-parent` parameter places a node's container under the specified parent cgroup. It has the same semantics as Docker's [`--cgroup-parent`](https://docs.docker.com/reference/cli/docker/container/run/#cgroup-parent) option and is supported by the Docker and Podman runtimes. An empty or omitted value leaves parent selection to the runtime.
+
+This setting is inherited using the standard node, group, kind, then defaults precedence. It is independent of [`cgroupns-mode`](#cgroupns-mode), which selects the cgroup namespace visible inside the container rather than its placement in the host cgroup hierarchy.
+
+```yaml
+topology:
+  groups:
+    leaves:
+      cgroup-parent: /xform/my-lab/leaves
+  nodes:
+    leaf1:
+      group: leaves
+    leaf2:
+      group: leaves
+```
+
 ### pid-mode
 
 The `pid-mode` parameter controls the PID namespace mode used by the container runtime.

--- a/docs/manual/nodes.md
+++ b/docs/manual/nodes.md
@@ -791,14 +791,15 @@ my-node:
 
 ### cgroup-parent
 
-The `cgroup-parent` parameter places a node's container under the specified parent cgroup. It has the same semantics as Docker's [`--cgroup-parent`](https://docs.docker.com/reference/cli/docker/container/run/#cgroup-parent) option and is supported by the Docker and Podman runtimes. An empty or omitted value leaves parent selection to the runtime.
+The `cgroup-parent` parameter places a node's container under the specified parent cgroup. It has the same semantics as Docker's [`--cgroup-parent`](https://docs.docker.com/reference/cli/docker/container/run/#cgroup-parent) option and is supported by the Docker and Podman runtimes. The value is passed to the runtime unchanged; its syntax and availability depend on the runtime's configured cgroup manager. For example, cgroupfs managers use a cgroup path, while systemd managers expect a slice name such as `my-lab.slice`.
 
-This setting is inherited using the standard node, group, kind, then defaults precedence. It is independent of [`cgroupns-mode`](#cgroupns-mode), which selects the cgroup namespace visible inside the container rather than its placement in the host cgroup hierarchy.
+This setting is inherited using the standard node, group, kind, then defaults precedence. An empty value is treated as unset and therefore does not clear a parent inherited from a group, kind, or defaults entry; the runtime default is used only when no value is configured at any level. It is independent of [`cgroupns-mode`](#cgroupns-mode), which selects the cgroup namespace visible inside the container rather than its placement in the host cgroup hierarchy.
 
 ```yaml
 topology:
   groups:
     leaves:
+      # cgroupfs-style path; systemd managers expect a .slice name instead.
       cgroup-parent: /xform/my-lab/leaves
   nodes:
     leaf1:

--- a/nodes/default_node.go
+++ b/nodes/default_node.go
@@ -315,6 +315,9 @@ func (d *DefaultNode) ComputeDiff(oldCfg, newCfg *clabtypes.NodeConfig) *clabtyp
 	if oldCfg.CgroupnsMode != newCfg.CgroupnsMode {
 		diff.Fields = append(diff.Fields, "CgroupnsMode")
 	}
+	if oldCfg.CgroupParent != newCfg.CgroupParent {
+		diff.Fields = append(diff.Fields, "CgroupParent")
+	}
 	if oldCfg.PidMode != newCfg.PidMode {
 		diff.Fields = append(diff.Fields, "PidMode")
 	}

--- a/nodes/default_node_test.go
+++ b/nodes/default_node_test.go
@@ -74,6 +74,11 @@ func TestDefaultNodeConfigChangesRecreate(t *testing.T) {
 			new:  &clabtypes.NodeConfig{CgroupnsMode: "host"},
 		},
 		{
+			name: "cgroup parent",
+			old:  &clabtypes.NodeConfig{},
+			new:  &clabtypes.NodeConfig{CgroupParent: "/xform/my-lab/leaves"},
+		},
+		{
 			name: "PID mode",
 			old:  &clabtypes.NodeConfig{},
 			new:  &clabtypes.NodeConfig{PidMode: "host"},

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -713,6 +713,7 @@ func (d *DockerRuntime) CreateContainer( //nolint: funlen
 	if err := d.processCgroupnsMode(node, containerHostConfig); err != nil {
 		return "", err
 	}
+	d.processCgroupParent(node, containerHostConfig)
 
 	// regular linux containers may benefit from automatic restart on failure
 	// note, that veth pairs added to this container (outside of eth0) will be lost on restart
@@ -1505,6 +1506,13 @@ func (*DockerRuntime) processCgroupnsMode(
 	containerHostConfig.CgroupnsMode = cgroupnsMode
 
 	return nil
+}
+
+func (*DockerRuntime) processCgroupParent(
+	node *clabtypes.NodeConfig,
+	containerHostConfig *container.HostConfig,
+) {
+	containerHostConfig.CgroupParent = node.CgroupParent
 }
 
 func (d *DockerRuntime) processNetworkMode(

--- a/runtime/docker/runtime_options_test.go
+++ b/runtime/docker/runtime_options_test.go
@@ -36,3 +36,46 @@ func TestProcessCgroupnsMode(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessCgroupParent(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+	}{
+		{name: "omitted"},
+		{name: "configured", parent: "/xform/my-lab/leaves"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostConfig := &container.HostConfig{}
+			new(DockerRuntime).processCgroupParent(
+				&clabtypes.NodeConfig{CgroupParent: tt.parent},
+				hostConfig,
+			)
+			if hostConfig.CgroupParent != tt.parent {
+				t.Fatalf("CgroupParent = %q, want %q", hostConfig.CgroupParent, tt.parent)
+			}
+		})
+	}
+}
+
+func TestCgroupParentCoexistsWithCgroupnsMode(t *testing.T) {
+	node := &clabtypes.NodeConfig{
+		CgroupnsMode: "host",
+		CgroupParent: "/xform/my-lab/leaves",
+	}
+	hostConfig := &container.HostConfig{}
+
+	if err := new(DockerRuntime).processCgroupnsMode(node, hostConfig); err != nil {
+		t.Fatal(err)
+	}
+	new(DockerRuntime).processCgroupParent(node, hostConfig)
+
+	if hostConfig.CgroupnsMode != "host" {
+		t.Fatalf("CgroupnsMode = %q, want host", hostConfig.CgroupnsMode)
+	}
+	if hostConfig.CgroupParent != "/xform/my-lab/leaves" {
+		t.Fatalf("CgroupParent = %q, want /xform/my-lab/leaves", hostConfig.CgroupParent)
+	}
+}

--- a/runtime/podman/util.go
+++ b/runtime/podman/util.go
@@ -128,7 +128,8 @@ func (r *PodmanRuntime) createContainerSpec(
 	}
 
 	specCgroupConfig := specgen.ContainerCgroupConfig{
-		CgroupNS: specgen.Namespace{},
+		CgroupNS:     specgen.Namespace{},
+		CgroupParent: cfg.CgroupParent,
 	}
 	if cfg.CgroupnsMode != "" {
 		specCgroupConfig.CgroupNS, err = specgen.ParseCgroupNamespace(cfg.CgroupnsMode)

--- a/runtime/podman/util_test.go
+++ b/runtime/podman/util_test.go
@@ -20,6 +20,7 @@ func TestCreateContainerSpecAppliesRuntimeNamespaceAndTmpfs(t *testing.T) {
 		Labels:       map[string]string{},
 		NetworkMode:  "host",
 		CgroupnsMode: "host",
+		CgroupParent: "/xform/my-lab/leaves",
 		ShmSize:      "64m",
 		Tmpfs:        map[string]string{"/run": "rw,nosuid,nodev", "/run/lock": "rw"},
 		Devices:      []string{"/dev/null"},
@@ -33,6 +34,9 @@ func TestCreateContainerSpecAppliesRuntimeNamespaceAndTmpfs(t *testing.T) {
 
 	if sg.CgroupNS.NSMode != specgen.Host {
 		t.Fatalf("CgroupNS mode = %q, want %q", sg.CgroupNS.NSMode, specgen.Host)
+	}
+	if sg.CgroupParent != "/xform/my-lab/leaves" {
+		t.Fatalf("CgroupParent = %q, want /xform/my-lab/leaves", sg.CgroupParent)
 	}
 	if sg.ShmSize == nil || *sg.ShmSize != 64*1000*1000 {
 		t.Fatalf("ShmSize = %v, want 64000000", sg.ShmSize)

--- a/schemas/clab.schema.json
+++ b/schemas/clab.schema.json
@@ -502,6 +502,10 @@
                         "private"
                     ]
                 },
+                "cgroup-parent": {
+                    "type": "string",
+                    "markdownDescription": "[parent cgroup](https://containerlab.dev/manual/nodes/#cgroup-parent) for the container"
+                },
                 "pid-mode": {
                     "type": "string",
                     "description": "PID namespace mode for the container",

--- a/tests/01-smoke/24-basic-groups.clab.yaml
+++ b/tests/01-smoke/24-basic-groups.clab.yaml
@@ -20,6 +20,7 @@ topology:
         - cat /etc/os-release
       cpu: 1.5
       memory: 1G
+      cgroup-parent: containerlab-smoke.slice
       healthcheck:
         test:
           - CMD-SHELL

--- a/tests/01-smoke/24-groups.robot
+++ b/tests/01-smoke/24-groups.robot
@@ -71,6 +71,14 @@ Verify Mem and CPU limits are set
     # memory=1G
     Should Contain    ${output}    1000000000
 
+Verify cgroup parent is set
+    [Documentation]    Check that the resolved cgroup parent is reflected in Docker HostConfig
+    Skip If    '${runtime}' != 'docker'
+    ${output} =    Run
+    ...    sudo ${runtime} inspect clab-${lab-name}-l1 -f '{{.HostConfig.CgroupParent}}'
+    Log    ${output}
+    Should Be Equal As Strings    ${output}    containerlab-smoke.slice
+
 Verify DNS-Server Config
     [Documentation]    Check if the DNS config did take effect
     Skip If    '${runtime}' != 'docker'

--- a/tests/01-smoke/24-groups.robot
+++ b/tests/01-smoke/24-groups.robot
@@ -72,12 +72,21 @@ Verify Mem and CPU limits are set
     Should Contain    ${output}    1000000000
 
 Verify cgroup parent is set
-    [Documentation]    Check that the resolved cgroup parent is reflected in Docker HostConfig
+    [Documentation]    Check that the resolved cgroup parent reaches Docker and the effective host cgroup
     Skip If    '${runtime}' != 'docker'
     ${output} =    Run
     ...    sudo ${runtime} inspect clab-${lab-name}-l1 -f '{{.HostConfig.CgroupParent}}'
     Log    ${output}
     Should Be Equal As Strings    ${output}    containerlab-smoke.slice
+    ${rc}    ${pid} =    Run And Return Rc And Output
+    ...    sudo ${runtime} inspect clab-${lab-name}-l1 -f '{{.State.Pid}}'
+    Should Be Equal As Integers    ${rc}    0
+    ${pid} =    Strip String    ${pid}
+    ${rc}    ${cgroup} =    Run And Return Rc And Output
+    ...    sudo cat /proc/${pid}/cgroup
+    Should Be Equal As Integers    ${rc}    0
+    Log    ${cgroup}
+    Should Contain    ${cgroup}    containerlab-smoke.slice
 
 Verify DNS-Server Config
     [Documentation]    Check if the DNS config did take effect

--- a/types/node_definition.go
+++ b/types/node_definition.go
@@ -80,6 +80,8 @@ type NodeDefinition struct {
 	Privileged *bool `yaml:"privileged,omitempty"`
 	// Cgroup namespace mode for the container.
 	CgroupnsMode string `yaml:"cgroupns-mode,omitempty"`
+	// Parent cgroup for the container.
+	CgroupParent string `yaml:"cgroup-parent,omitempty"`
 	// PID namespace mode for the container.
 	PidMode string `yaml:"pid-mode,omitempty"`
 	// Tmpfs mounts to add to the container, keyed by destination path.

--- a/types/topology.go
+++ b/types/topology.go
@@ -444,6 +444,18 @@ func (t *Topology) GetNodeCgroupnsMode(nodeName string) string {
 	)
 }
 
+func (t *Topology) GetNodeCgroupParent(nodeName string) string {
+	return getField(
+		t,
+		nodeName,
+		func(node *NodeDefinition) string { return node.CgroupParent },
+		func(group *NodeDefinition) string { return group.CgroupParent },
+		func(kind *NodeDefinition) string { return kind.CgroupParent },
+		func(defaults *NodeDefinition) string { return defaults.CgroupParent },
+		func(v string) bool { return v != "" },
+	)
+}
+
 func (t *Topology) GetNodePidMode(nodeName string) string {
 	return getField(
 		t,

--- a/types/topology_test.go
+++ b/types/topology_test.go
@@ -1482,6 +1482,50 @@ func TestGetNodeRuntimeOptions(t *testing.T) {
 	}
 }
 
+func TestGetNodeCgroupParent(t *testing.T) {
+	topo := &Topology{
+		Defaults: &NodeDefinition{CgroupParent: "/defaults"},
+		Kinds: map[string]*NodeDefinition{
+			"linux": {CgroupParent: "/kind"},
+		},
+		Groups: map[string]*NodeDefinition{
+			"leaves":      {CgroupParent: "/group"},
+			"empty-group": {},
+		},
+		Nodes: map[string]*NodeDefinition{
+			"direct":        {Kind: "linux", Group: "leaves", CgroupParent: "/node"},
+			"from-group":    {Kind: "linux", Group: "leaves"},
+			"from-kind":     {Kind: "linux", Group: "empty-group"},
+			"from-defaults": {},
+			"omitted":       {},
+		},
+	}
+
+	tests := map[string]string{
+		"direct":        "/node",
+		"from-group":    "/group",
+		"from-kind":     "/kind",
+		"from-defaults": "/defaults",
+	}
+	for nodeName, want := range tests {
+		if got := topo.GetNodeCgroupParent(nodeName); got != want {
+			t.Errorf("%s cgroup-parent = %q, want %q", nodeName, got, want)
+		}
+	}
+
+	// Empty values are treated as omitted and therefore do not mask inherited values.
+	topo.Nodes["from-group"].CgroupParent = ""
+	if got := topo.GetNodeCgroupParent("from-group"); got != "/group" {
+		t.Errorf("empty node cgroup-parent = %q, want inherited /group", got)
+	}
+
+	emptyTopo := NewTopology()
+	emptyTopo.Nodes["omitted"] = &NodeDefinition{}
+	if got := emptyTopo.GetNodeCgroupParent("omitted"); got != "" {
+		t.Errorf("omitted cgroup-parent = %q, want empty runtime default", got)
+	}
+}
+
 func TestGetNodePrivilegedDefault(t *testing.T) {
 	topo := &Topology{
 		Nodes: map[string]*NodeDefinition{

--- a/types/types.go
+++ b/types/types.go
@@ -172,6 +172,8 @@ type NodeConfig struct {
 	Privileged bool `json:"privileged,omitempty"`
 	// Cgroup namespace mode for the container.
 	CgroupnsMode string `json:"cgroupns-mode,omitempty"`
+	// Parent cgroup for the container.
+	CgroupParent string `json:"cgroup-parent,omitempty"`
 	// PID namespace mode for the container.
 	PidMode string `json:"pidmode,omitempty"`
 	// Tmpfs mounts to add to the container, keyed by destination path.


### PR DESCRIPTION
## What changed

Add `cgroup-parent` to node configuration with the standard resolution precedence:

1. node
2. group
3. kind
4. defaults

The resolved value is carried through `NodeDefinition`, topology resolution, and `NodeConfig`, then assigned to Docker's `HostConfig.CgroupParent` and Podman's `SpecGenerator.CgroupParent`.

## Why this is needed

Container-oriented eBPF validation and observability often need to attach programs, collect events, or scope checks to a known cgroup subtree. Runtime-generated container cgroup paths can vary with the runtime, cgroup driver, host configuration, and container ID, which makes those paths awkward to predict from a lab topology.

Exposing the runtimes' existing cgroup-parent setting lets a topology place related nodes beneath a deliberate, stable parent. For example, an eBPF validation tool can target `/xform/my-lab/leaves` to observe or validate the leaf containers as a group, while individual containers remain managed normally by Docker or Podman below that parent. Group, kind, and defaults inheritance also make this practical for larger labs without repeating the placement on every node.

This change only exposes runtime placement. It does not install eBPF programs, prescribe a topology-group-to-cgroup policy, or create a Containerlab-specific cgroup hierarchy.

`cgroup-parent` controls placement in the host cgroup hierarchy. This is independent of `cgroupns-mode`, which selects the cgroup namespace visible inside the container; both options can be configured together.

Docker and Podman are supported. Both pinned clients expose a clean parent-cgroup field, so no dependency changes are needed. Empty or omitted values are passed as empty strings, preserving each runtime's default behavior and leaving all existing topologies unchanged.

Docker option documentation: https://docs.docker.com/reference/cli/docker/container/run/#cgroup-parent

## Example

```yaml
topology:
  groups:
    leaves:
      cgroup-parent: /xform/my-lab/leaves
  nodes:
    leaf1:
      group: leaves
    leaf2:
      group: leaves
```

## Verification

The Docker smoke topology was deployed and inspected:

```text
$ sudo docker inspect clab-2-linux-nodes-l1 --format '{{.HostConfig.CgroupParent}} {{.HostConfig.CgroupnsMode}}'
containerlab-smoke.slice private
```

This confirms parent placement reaches `HostConfig` while cgroup namespace selection remains independent.

Tests run:

- `gofmt` on all changed Go files — passed
- `golangci-lint v2.12` — passed (`0 issues`)
- focused affected unit tests in `types`, `core`, `nodes`, and `runtime/docker` — passed
- full affected package suites: `go test ./types ./core ./nodes ./runtime/docker` — passed
- Podman-tagged `TestCreateContainerSpecAppliesRuntimeNamespaceAndTmpfs` — passed
- `jq empty schemas/clab.schema.json` and `git diff --check` — passed
- Docker smoke deployment using `tests/01-smoke/24-basic-groups.clab.yaml`, HostConfig inspection, and cleanup — passed

No additional value validation is introduced: parent syntax and availability depend on the runtime's configured cgroup driver, matching the underlying Docker and Podman APIs.
