### PR TITLE
Order log entries used in execs between dependent nodes

### DIFF
--- a/core/clab_test.go
+++ b/core/clab_test.go
@@ -341,6 +341,112 @@ func Test_scheduleNodes_PostDeployFailureCancelsWorkers(t *testing.T) {
 	}
 }
 
+func Test_scheduleNodes_WaitForHealthyRunsExecBeforeDepender(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	events := make(chan string, 3)
+	h1Config := &clabtypes.NodeConfig{
+		ShortName: "h1",
+		Exec:      []string{"echo h1"},
+		Stages:    clabtypes.NewStages(),
+	}
+	h2Stages := clabtypes.NewStages()
+	h2Stages.Create.WaitFor = clabtypes.WaitForList{
+		&clabtypes.WaitFor{
+			Node:  "h1",
+			Stage: clabtypes.WaitForHealthy,
+		},
+	}
+	h2Config := &clabtypes.NodeConfig{
+		ShortName: "h2",
+		Exec:      []string{"echo h2"},
+		Stages:    h2Stages,
+	}
+
+	h1 := clabmocksmocknodes.NewMockNode(mockCtrl)
+	h1.EXPECT().Config().Return(h1Config).AnyTimes()
+	h1.EXPECT().GetShortName().Return("h1").AnyTimes()
+	h1.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).Return(nil)
+	h1.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
+	h1.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+	h1.EXPECT().DeployEndpoints(gomock.Any()).Return(nil)
+	h1.EXPECT().PostDeploy(gomock.Any(), gomock.Any()).Return(nil)
+	h1.EXPECT().RunExecFromConfig(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *clabexec.ExecCollection) error {
+			events <- "h1 exec"
+			return nil
+		},
+	)
+	h1.EXPECT().IsHealthy(gomock.Any()).DoAndReturn(
+		func(context.Context) (bool, error) {
+			events <- "h1 healthy"
+			return true, nil
+		},
+	)
+
+	h2 := clabmocksmocknodes.NewMockNode(mockCtrl)
+	h2.EXPECT().Config().Return(h2Config).AnyTimes()
+	h2.EXPECT().GetShortName().Return("h2").AnyTimes()
+	h2.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).Return(nil)
+	h2.EXPECT().Deploy(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *clabnodes.DeployParams) error {
+			events <- "h2 deploy"
+			return nil
+		},
+	)
+	h2.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+	h2.EXPECT().DeployEndpoints(gomock.Any()).Return(nil)
+	h2.EXPECT().PostDeploy(gomock.Any(), gomock.Any()).Return(nil)
+	h2.EXPECT().RunExecFromConfig(gomock.Any(), gomock.Any()).Return(nil)
+
+	dependencyManager := clabcoredependency_manager.NewDependencyManager()
+	dependencyManager.AddNode(h1)
+	dependencyManager.AddNode(h2)
+
+	c := &CLab{
+		Config:            &Config{},
+		Nodes:             map[string]clabnodes.Node{"h1": h1, "h2": h2},
+		dependencyManager: dependencyManager,
+	}
+	if err := c.createWaitForDependency(); err != nil {
+		t.Fatalf("createWaitForDependency failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeFailCh := make(chan error, 2)
+	wg, _ := c.scheduleNodes(ctx, 2, false, nodeFailCh)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workers did not finish")
+	}
+
+	got := make([]string, 0, 3)
+	for range 3 {
+		select {
+		case event := <-events:
+			got = append(got, event)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for scheduler event")
+		}
+	}
+
+	want := []string{"h1 exec", "h1 healthy", "h2 deploy"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected event order (-want +got):\n%s", diff)
+	}
+}
+
 // Test_scheduleNodeWorkerF_HealthyWaitHonorsCancel verifies that the
 // WaitForHealthy polling loop in scheduleNodeWorkerF returns promptly when the
 // deploy context is cancelled, instead of spinning on time.Sleep forever (issue

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -172,10 +172,16 @@ func (e *ExecResult) SetStdErr(data []byte) {
 // execEntries is a map indexed by container IDs storing lists of ExecResult.
 type execEntries map[string][]*ExecResult
 
+type execEntry struct {
+	cId    string
+	result *ExecResult
+}
+
 // ExecCollection represents a datastore for exec commands execution results.
 type ExecCollection struct {
 	execEntries
-	m sync.RWMutex
+	orderedEntries []execEntry
+	m              sync.RWMutex
 }
 
 // NewExecCollection initializes the collection of exec command results.
@@ -190,12 +196,16 @@ func (ec *ExecCollection) Add(cId string, e *ExecResult) {
 	ec.m.Lock()
 	defer ec.m.Unlock()
 	ec.execEntries[cId] = append(ec.execEntries[cId], e)
+	ec.orderedEntries = append(ec.orderedEntries, execEntry{cId: cId, result: e})
 }
 
 func (ec *ExecCollection) AddAll(cId string, e []*ExecResult) {
 	ec.m.Lock()
 	defer ec.m.Unlock()
 	ec.execEntries[cId] = append(ec.execEntries[cId], e...)
+	for _, result := range e {
+		ec.orderedEntries = append(ec.orderedEntries, execEntry{cId: cId, result: result})
+	}
 }
 
 // Dump dumps the contents of ExecCollection as a string in one of the provided formats.
@@ -243,26 +253,24 @@ func (ec *ExecCollection) Dump(format string) (string, error) {
 func (ec *ExecCollection) Log() {
 	ec.m.RLock()
 	defer ec.m.RUnlock()
-	for k, execResults := range ec.execEntries {
-		for _, er := range execResults {
-			switch {
-			case er.GetReturnCode() != 0:
-				log.Error(
-					"Failed to execute command",
-					"command", er.GetCmdString(),
-					"node", k,
-					"rc", er.GetReturnCode(),
-					"stdout", er.GetStdOutString(),
-					"stderr", er.GetStdErrString(),
-				)
-			default:
-				log.Info(
-					"Executed command",
-					"node", k,
-					"command", er.GetCmdString(),
-					"stdout", er.GetStdOutString(),
-				)
-			}
+	for _, entry := range ec.orderedEntries {
+		switch {
+		case entry.result.GetReturnCode() != 0:
+			log.Error(
+				"Failed to execute command",
+				"command", entry.result.GetCmdString(),
+				"node", entry.cId,
+				"rc", entry.result.GetReturnCode(),
+				"stdout", entry.result.GetStdOutString(),
+				"stderr", entry.result.GetStdErrString(),
+			)
+		default:
+			log.Info(
+				"Executed command",
+				"node", entry.cId,
+				"command", entry.result.GetCmdString(),
+				"stdout", entry.result.GetStdOutString(),
+			)
 		}
 	}
 }

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -1,8 +1,12 @@
 package exec
 
 import (
+	"bytes"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/log"
 	clabconstants "github.com/srl-labs/containerlab/constants"
 )
 
@@ -68,5 +72,27 @@ func TestParseExecOutputFormat(t *testing.T) {
 				t.Errorf("ParseExecOutputFormat() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExecCollectionLogPreservesAddOrder(t *testing.T) {
+	collection := NewExecCollection()
+	collection.Add("h1", NewExecResult(NewExecCmdFromSlice([]string{"echo", "h1"})))
+	collection.Add("h2", NewExecResult(NewExecCmdFromSlice([]string{"echo", "h2"})))
+
+	var output bytes.Buffer
+	log.SetOutput(&output)
+	defer log.SetOutput(os.Stderr)
+
+	collection.Log()
+
+	logOutput := output.String()
+	h1Index := strings.Index(logOutput, "node=h1")
+	h2Index := strings.Index(logOutput, "node=h2")
+	if h1Index == -1 || h2Index == -1 {
+		t.Fatalf("expected both command results in log output, got:\n%s", logOutput)
+	}
+	if h1Index > h2Index {
+		t.Fatalf("log output did not preserve add order:\n%s", logOutput)
 	}
 }


### PR DESCRIPTION
fix #3028 