### PR TITLE
allow setting mac address in the SONIC's startup config

### DIFF
--- a/docs/manual/kinds/sonic-vm.md
+++ b/docs/manual/kinds/sonic-vm.md
@@ -125,4 +125,21 @@ When containerlab launches sonic-vs node, it will assign IPv4/6 address to the `
 
 VM-based SONiC supports the [`startup-config`](../nodes.md#startup-config) feature. The startup configuration file is a JSON file that is available in the VM's filesystem by the `/etc/sonic/config_db.json` path.
 
+To keep SONiC's system MAC aligned with the container management interface, use the
+`{{ .MacAddress }}` template in the `DEVICE_METADATA` section of the startup configuration:
+
+```json
+{
+  "DEVICE_METADATA": {
+    "localhost": {
+      "mac": "{{ .MacAddress }}"
+    }
+  }
+}
+```
+
+Containerlab generates the management MAC before rendering the startup configuration and uses the
+same value for the container's `eth0` interface. Literal MAC values remain unchanged; data-plane
+interface MACs are independent.
+
 Extracting the config from a running node is possible with `containerlab save` command. The config will be available in the lab directory.

--- a/nodes/sonic_vm/sonic_vm.go
+++ b/nodes/sonic_vm/sonic_vm.go
@@ -102,6 +102,12 @@ func (n *sonic_vm) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption)
 		n.Cfg.Env["CONNECTION_MODE"],
 	)
 
+	hwa, err := clabutils.GenMac(clabconstants.ClabOUI)
+	if err != nil {
+		return err
+	}
+	n.Cfg.MacAddress = hwa.String()
+
 	return nil
 }
 

--- a/nodes/sonic_vm/sonic_vm_test.go
+++ b/nodes/sonic_vm/sonic_vm_test.go
@@ -1,6 +1,48 @@
 package sonic_vm
 
-import "testing"
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+func TestInitSetsMacAddressForStartupConfig(t *testing.T) {
+	node := new(sonic_vm)
+	cfg := &clabtypes.NodeConfig{
+		LabDir:    t.TempDir(),
+		ShortName: "sonic",
+	}
+
+	if err := node.Init(cfg, clabnodes.WithMgmtNet(&clabtypes.MgmtNet{})); err != nil {
+		t.Fatalf("Init() failed: %v", err)
+	}
+
+	if cfg.MacAddress == "" {
+		t.Fatal("Init() did not set MacAddress")
+	}
+	if _, err := net.ParseMAC(cfg.MacAddress); err != nil {
+		t.Fatalf("Init() set invalid MacAddress %q: %v", cfg.MacAddress, err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "config_db.json")
+	template := `{"DEVICE_METADATA":{"localhost":{"mac":"{{ .MacAddress }}"}}}`
+	if err := node.GenerateConfig(dst, template); err != nil {
+		t.Fatalf("GenerateConfig() failed: %v", err)
+	}
+
+	rendered, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read rendered config: %v", err)
+	}
+	if !strings.Contains(string(rendered), `"mac":"`+cfg.MacAddress+`"`) {
+		t.Fatalf("rendered config does not contain MacAddress %q: %s", cfg.MacAddress, rendered)
+	}
+}
 
 func TestBuildSSHKeyInjectionCommands(t *testing.T) {
 	cmds := buildSSHKeyInjectionCommands([]string{

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -1599,7 +1599,8 @@ func (d *DockerRuntime) processNetworkMode(
 					IPv4Address: node.MgmtIPv4Address,
 					IPv6Address: node.MgmtIPv6Address,
 				},
-				Aliases: node.Aliases,
+				Aliases:    node.Aliases,
+				MacAddress: node.MacAddress,
 			},
 		}
 	}

--- a/runtime/docker/mac_test.go
+++ b/runtime/docker/mac_test.go
@@ -1,0 +1,38 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	networkapi "github.com/docker/docker/api/types/network"
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+func TestProcessNetworkModeSetsManagementMac(t *testing.T) {
+	const macAddress = "aa:c1:ab:5b:9f:0e"
+
+	runtime := &DockerRuntime{
+		mgmt: &clabtypes.MgmtNet{Network: "clab"},
+	}
+	networking := new(networkapi.NetworkingConfig)
+
+	err := runtime.processNetworkMode(
+		context.Background(),
+		networking,
+		new(container.HostConfig),
+		new(container.Config),
+		&clabtypes.NodeConfig{MacAddress: macAddress},
+	)
+	if err != nil {
+		t.Fatalf("processNetworkMode() failed: %v", err)
+	}
+
+	endpoint, ok := networking.EndpointsConfig["clab"]
+	if !ok {
+		t.Fatal("management network endpoint was not configured")
+	}
+	if endpoint.MacAddress != macAddress {
+		t.Fatalf("management endpoint MAC = %q, want %q", endpoint.MacAddress, macAddress)
+	}
+}


### PR DESCRIPTION
fix #3324

it is now possible to set the runtime variables in the sonic's statup config (config_db.json) to ensure that the mac address generated at runtime by clab will be used:


```json
{
  "DEVICE_METADATA": {
    "localhost": {
      "mac": "{{ .MacAddress }}"
    }
  }
}
```