### PR TITLE
Support non-bridge management networks

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-units"
@@ -34,6 +35,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/dustin/go-humanize"
 	"github.com/google/shlex"
+	clabconstants "github.com/srl-labs/containerlab/constants"
 	clabexec "github.com/srl-labs/containerlab/exec"
 	clablinks "github.com/srl-labs/containerlab/links"
 	clabruntime "github.com/srl-labs/containerlab/runtime"
@@ -173,13 +175,12 @@ func (d *DockerRuntime) WithMgmtNet(n *clabtypes.MgmtNet) {
 		)
 		// if the network is successfully found, set the bridge used by it
 		if err == nil {
-			if name, exists := netRes.Options[bridgeNameOption]; exists {
-				d.mgmt.Bridge = name
-			} else {
-				d.mgmt.Bridge = "br-" + netRes.ID[:12]
+			bridge, bridgeErr := bridgeNameFromInspect(&netRes, d.mgmt.Network)
+			if bridgeErr == nil {
+				d.mgmt.Bridge = bridge
 			}
 			log.Debugf(
-				"detected network name in use: %s, backed by a bridge %s",
+				"detected network name in use: %s, backed by bridge %s",
 				d.mgmt.Network,
 				d.mgmt.Bridge,
 			)
@@ -198,7 +199,7 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 	log.Debugf("Checking if docker network %q exists", d.mgmt.Network)
 	netResource, err := d.Client.NetworkInspect(nctx, d.mgmt.Network, networkapi.InspectOptions{})
 	switch {
-	case dockerC.IsErrNotFound(err):
+	case cerrdefs.IsNotFound(err):
 		bridgeName, err = d.createMgmtBridge(nctx, bridgeName)
 		if err != nil {
 			return err
@@ -214,7 +215,7 @@ func (d *DockerRuntime) CreateNet(ctx context.Context) (err error) {
 		return err
 	}
 
-	if d.mgmt.Bridge == "" {
+	if bridgeName == "" || d.mgmt.Bridge == "" {
 		d.mgmt.Bridge = bridgeName
 	}
 
@@ -336,7 +337,7 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 		Internal:   false,
 		Attachable: false,
 		Labels: map[string]string{
-			"containerlab": "",
+			clabconstants.Containerlab: "",
 		},
 		Options: netwOpts,
 	}
@@ -420,6 +421,10 @@ func (d *DockerRuntime) createMgmtBridge( //nolint: funlen
 // bridgeNameFromInspect resolves the underlying linux bridge name from a docker network inspect
 // response.
 func bridgeNameFromInspect(netResource *networkapi.Inspect, mgmtNetwork string) (string, error) {
+	if netResource.Driver != "bridge" {
+		return "", nil
+	}
+
 	if len(netResource.ID) < 12 {
 		return "", fmt.Errorf("could not get bridge ID")
 	}
@@ -440,12 +445,18 @@ func getMgmtBridgeIPs(
 	bridgeName string,
 	netResource *networkapi.Inspect,
 ) (v4, v6 string, err error) {
-	if v4, v6, err = clabutils.FirstLinkIPs(bridgeName); err != nil {
+	if bridgeName != "" {
+		v4, v6, err = clabutils.FirstLinkIPs(bridgeName)
+	}
+
+	if bridgeName != "" && err != nil {
 		log.Warn(
 			"failed gleaning v4 and/or v6 addresses from bridge via netlink," +
 				" falling back to docker network inspect data",
 		)
+	}
 
+	if bridgeName == "" || err != nil {
 		for _, ipamEntry := range netResource.IPAM.Config {
 			addr := ipamEntry.Gateway
 
@@ -465,6 +476,9 @@ func getMgmtBridgeIPs(
 
 	// didnt find any gateways, fallthrough to returning the error
 	if v4 == "" && v6 == "" {
+		if bridgeName == "" {
+			return "", "", nil
+		}
 		return "", "", err
 	}
 
@@ -473,6 +487,11 @@ func getMgmtBridgeIPs(
 
 // postCreateNetActions performs additional actions after the network has been created.
 func (d *DockerRuntime) postCreateNetActions() (err error) {
+	if d.mgmt.Bridge == "" {
+		log.Debug("skipping post-create actions for non-bridged management network")
+		return nil
+	}
+
 	log.Debug("Disable RPF check on the docker host")
 	err = setSysctl("net/ipv4/conf/all/rp_filter", 0)
 	if err != nil {
@@ -534,10 +553,15 @@ func (d *DockerRuntime) DeleteNet(ctx context.Context) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, d.config.Timeout)
 	defer cancel()
 
-	nres, err := d.Client.NetworkInspect(ctx, network, networkapi.InspectOptions{})
+	nres, err := d.Client.NetworkInspect(nctx, network, networkapi.InspectOptions{})
 	if err != nil {
 		return err
 	}
+	if _, ok := nres.Labels[clabconstants.Containerlab]; !ok {
+		log.Debugf("network %q was not created by containerlab, deletion skipped", network)
+		return nil
+	}
+
 	numEndpoints := len(nres.Containers)
 	if numEndpoints > 0 {
 		if d.config.Debug {

--- a/runtime/docker/firewall.go
+++ b/runtime/docker/firewall.go
@@ -9,6 +9,11 @@ import (
 // deleteMgmtNetworkFwdRule deletes `allow` rule installed with installFwdRule
 // when the containerlab management network (bridge) interface doesn't exist anymore.
 func (d *DockerRuntime) deleteMgmtNetworkFwdRule() (err error) {
+	if d.mgmt.Bridge == "" {
+		log.Debug("skipping forwarding rule removal for non-bridged management network")
+		return nil
+	}
+
 	if !*d.mgmt.ExternalAccess {
 		return nil
 	}

--- a/runtime/docker/network_test.go
+++ b/runtime/docker/network_test.go
@@ -16,6 +16,7 @@ import (
 
 	networkapi "github.com/docker/docker/api/types/network"
 	dockerC "github.com/docker/docker/client"
+	clabconstants "github.com/srl-labs/containerlab/constants"
 	clabruntime "github.com/srl-labs/containerlab/runtime"
 	clabtypes "github.com/srl-labs/containerlab/types"
 )
@@ -32,6 +33,7 @@ type fakeDockerNetworkServer struct {
 	created bool
 	info    networkapi.Inspect
 	creates atomic.Int32
+	removes atomic.Int32
 }
 
 func (f *fakeDockerNetworkServer) handler() http.Handler {
@@ -91,6 +93,10 @@ func (f *fakeDockerNetworkServer) handler() http.Handler {
 
 			writeJSON(w, http.StatusOK, info)
 
+		case r.Method == http.MethodDelete && strings.HasPrefix(path, "/networks/"):
+			f.removes.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+
 		default:
 			f.t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -125,15 +131,199 @@ func newFakeDockerRuntime(
 	rt := &DockerRuntime{
 		Client: cli,
 		mgmt: &clabtypes.MgmtNet{
-			Network:    netName,
-			IPv4Subnet: "172.45.99.0/24",
-			MTU:        1500,
+			Network:        netName,
+			IPv4Subnet:     "172.45.99.0/24",
+			MTU:            1500,
+			ExternalAccess: new(bool),
 		},
 		config:  clabruntime.RuntimeConfig{Timeout: defaultTimeout},
 		version: "v27.0.0",
 	}
 
 	return rt, fake, func() { _ = cli.Close(); srv.Close() }
+}
+
+func TestBridgeNameFromInspect(t *testing.T) {
+	t.Parallel()
+
+	const networkID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+	tests := []struct {
+		name    string
+		inspect networkapi.Inspect
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "bridge option",
+			inspect: networkapi.Inspect{
+				ID:     networkID,
+				Driver: "bridge",
+				Options: map[string]string{
+					bridgeNameOption: "custom-bridge",
+				},
+			},
+			want: "custom-bridge",
+		},
+		{
+			name: "default bridge name",
+			inspect: networkapi.Inspect{
+				ID:     networkID,
+				Driver: "bridge",
+			},
+			want: "br-" + networkID[:12],
+		},
+		{
+			name: "non-bridge driver",
+			inspect: networkapi.Inspect{
+				ID:     "short-id",
+				Driver: "macvlan",
+				Options: map[string]string{
+					bridgeNameOption: "not-a-bridge",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "bridge with short ID",
+			inspect: networkapi.Inspect{
+				ID:     "short-id",
+				Driver: "bridge",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := bridgeNameFromInspect(&tc.inspect, "custom")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("bridgeNameFromInspect() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("bridgeNameFromInspect() error = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("bridgeNameFromInspect() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateNetReusesNonBridgeNetwork(t *testing.T) {
+	t.Parallel()
+
+	rt, fake, cleanup := newFakeDockerRuntime(t, "macvlan-net")
+	defer cleanup()
+
+	fake.mu.Lock()
+	fake.created = true
+	fake.info = networkapi.Inspect{
+		ID:     "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		Name:   "macvlan-net",
+		Driver: "macvlan",
+		IPAM: networkapi.IPAM{
+			Config: []networkapi.IPAMConfig{{Gateway: "10.40.40.1"}},
+		},
+	}
+	fake.mu.Unlock()
+
+	if err := rt.CreateNet(context.Background()); err != nil {
+		t.Fatalf("CreateNet() error = %v", err)
+	}
+	if rt.mgmt.Bridge != "" {
+		t.Errorf("CreateNet() set bridge %q for a non-bridge network", rt.mgmt.Bridge)
+	}
+	if rt.mgmt.IPv4Gw != "10.40.40.1" {
+		t.Errorf("CreateNet() IPv4 gateway = %q, want %q", rt.mgmt.IPv4Gw, "10.40.40.1")
+	}
+}
+
+func TestWithMgmtNetDoesNotInferBridgeForNonBridgeNetwork(t *testing.T) {
+	t.Parallel()
+
+	rt, fake, cleanup := newFakeDockerRuntime(t, "macvlan-net")
+	defer cleanup()
+
+	fake.mu.Lock()
+	fake.created = true
+	fake.info = networkapi.Inspect{
+		ID:     "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		Name:   "macvlan-net",
+		Driver: "macvlan",
+	}
+	fake.mu.Unlock()
+
+	rt.mgmt.MTU = 0
+	rt.WithMgmtNet(rt.mgmt)
+
+	if rt.mgmt.Bridge != "" {
+		t.Errorf("WithMgmtNet() inferred bridge %q for a non-bridge network", rt.mgmt.Bridge)
+	}
+}
+
+func TestDeleteNetOnlyRemovesContainerlabNetworks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		labels     map[string]string
+		wantRemove int32
+	}{
+		{
+			name:       "external network",
+			wantRemove: 0,
+		},
+		{
+			name: "containerlab network",
+			labels: map[string]string{
+				clabconstants.Containerlab: "",
+			},
+			wantRemove: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rt, fake, cleanup := newFakeDockerRuntime(t, tc.name)
+			defer cleanup()
+
+			fake.mu.Lock()
+			fake.created = true
+			fake.info = networkapi.Inspect{
+				ID:     "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				Name:   tc.name,
+				Driver: "bridge",
+				Labels: tc.labels,
+			}
+			fake.mu.Unlock()
+
+			if err := rt.DeleteNet(context.Background()); err != nil {
+				t.Fatalf("DeleteNet() error = %v", err)
+			}
+			if got := fake.removes.Load(); got != tc.wantRemove {
+				t.Errorf("NetworkRemove calls = %d, want %d", got, tc.wantRemove)
+			}
+		})
+	}
+}
+
+func TestDeleteMgmtNetworkFwdRuleSkipsNonBridge(t *testing.T) {
+	t.Parallel()
+
+	externalAccess := true
+	rt := &DockerRuntime{
+		mgmt: &clabtypes.MgmtNet{
+			ExternalAccess: &externalAccess,
+		},
+	}
+
+	if err := rt.deleteMgmtNetworkFwdRule(); err != nil {
+		t.Fatalf("deleteMgmtNetworkFwdRule() error = %v", err)
+	}
 }
 
 // TestCreateMgmtBridge_ConcurrentSafe is the regression test for the race


### PR DESCRIPTION
Allow Docker management networks to use non-bridge drivers (e.g. macvlan) by skipping bridge-specific setup/teardown when no Linux bridge is associated with the network. Only delete networks that were created by containerlab, and add tests covering bridge name resolution, non-bridge reuse, and network deletion safety.

fix #1651 