### PR TITLE
vr_ftosv: add interface-alias regexp (ethernet1/1/X) and interface help

### DIFF
--- a/docs/manual/kinds/vr-ftosv.md
+++ b/docs/manual/kinds/vr-ftosv.md
@@ -33,13 +33,24 @@ Dell FTOS10v node launched with containerlab can be managed via the following in
 !!!info
     Default user credentials: `admin:admin`
 
-## Interfaces mapping
+## Interface naming
 
-Dell FTOSv container can have different number of available interfaces which depends on platform used under FTOS10 virtualization .qcow2 disk and container image built using [vrnetlab](../vrnetlab.md) project. Interfaces uses the following mapping rules (in topology file):
+You can use [interface names](../topo-def-file.md#interface-naming) in the topology file like they appear in -{{ kind_display_name }}-.
+
+The interface naming convention is: `ethernet1/1/X` (or `1/1/X`), where `X` is the port number.
+
+With that naming convention in mind:
+
+* `ethernet1/1/1` - first data port available
+* `ethernet1/1/2` - second data port, and so on...
+
+The example ports above would be mapped to the following Linux interfaces inside the container running the -{{ kind_display_name }}- VM:
 
 * `eth0` - management interface connected to the containerlab management network
-* `eth1` - first data interface, mapped to first data port of FTOS10v line card
-* `eth2+` - second and subsequent data interface
+* `eth1` - first data interface, mapped to the first data port of the VM (rendered as `ethernet1/1/1`)
+* `eth2+` - second and subsequent data interfaces, mapped to the second and subsequent data ports of the VM (rendered as `ethernet1/1/2` and so on)
+
+The number of available data interfaces depends on the platform used under the FTOS10 virtualization .qcow2 disk and the container image built using the [vrnetlab](../vrnetlab.md) project.
 
 When containerlab launches Dell FTOSv node, it will assign IPv4/6 address to the `eth0` interface. These addresses can be used to reach management plane of the router.
 

--- a/nodes/vr_ftosv/vr-ftosv.go
+++ b/nodes/vr_ftosv/vr-ftosv.go
@@ -7,6 +7,7 @@ package vr_ftosv
 import (
 	"fmt"
 	"path"
+	"regexp"
 
 	clabnodes "github.com/srl-labs/containerlab/nodes"
 	clabtypes "github.com/srl-labs/containerlab/types"
@@ -16,6 +17,10 @@ import (
 var (
 	kindnames          = []string{"dell_ftosv", "vr-ftosv", "vr-dell_ftosv"}
 	defaultCredentials = clabnodes.NewCredentials("admin", "admin")
+
+	InterfaceRegexp = regexp.MustCompile(`(?:ethernet\s?)?1/1/(?P<port>\d+)`)
+	InterfaceOffset = 1
+	InterfaceHelp   = "ethernet1/1/X or 1/1/X (where X >= 1) or ethX (where X >= 1)"
 )
 
 const (
@@ -80,6 +85,10 @@ func (n *vrFtosv) Init(cfg *clabtypes.NodeConfig, opts ...clabnodes.NodeOption) 
 		n.Cfg.ShortName,
 		n.Cfg.Env["CONNECTION_MODE"],
 	)
+
+	n.InterfaceRegexp = InterfaceRegexp
+	n.InterfaceOffset = InterfaceOffset
+	n.InterfaceHelp = InterfaceHelp
 
 	return nil
 }

--- a/nodes/vr_ftosv/vr-ftosv_test.go
+++ b/nodes/vr_ftosv/vr-ftosv_test.go
@@ -1,0 +1,117 @@
+package vr_ftosv
+
+import (
+	"testing"
+
+	clablinks "github.com/srl-labs/containerlab/links"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
+)
+
+func TestFtosvInterfaceParsing(t *testing.T) {
+	tests := map[string]struct {
+		endpoints []*clablinks.EndpointVeth
+		node      *vrFtosv
+		resultEps []string
+	}{
+		"alias-parse": {
+			endpoints: []*clablinks.EndpointVeth{
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "ethernet1/1/1",
+					},
+				},
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "ethernet 1/1/3",
+					},
+				},
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "1/1/5",
+					},
+				},
+			},
+			node: &vrFtosv{
+				VRNode: clabnodes.VRNode{
+					DefaultNode: clabnodes.DefaultNode{
+						Cfg: &clabtypes.NodeConfig{
+							ShortName: "ftosv",
+						},
+						InterfaceRegexp: InterfaceRegexp,
+						InterfaceOffset: InterfaceOffset,
+					},
+				},
+			},
+			resultEps: []string{
+				"eth1", "eth3", "eth5",
+			},
+		},
+		"original-parse": {
+			endpoints: []*clablinks.EndpointVeth{
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "eth2",
+					},
+				},
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "eth4",
+					},
+				},
+				{
+					EndpointGeneric: clablinks.EndpointGeneric{
+						IfaceName: "eth6",
+					},
+				},
+			},
+			node: &vrFtosv{
+				VRNode: clabnodes.VRNode{
+					DefaultNode: clabnodes.DefaultNode{
+						Cfg: &clabtypes.NodeConfig{
+							ShortName: "ftosv",
+						},
+						InterfaceRegexp: InterfaceRegexp,
+						InterfaceOffset: InterfaceOffset,
+					},
+				},
+			},
+			resultEps: []string{
+				"eth2", "eth4", "eth6",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(tt *testing.T) {
+			foundError := false
+			tc.node.OverwriteNode = tc.node
+			tc.node.InterfaceMappedPrefix = "eth"
+			tc.node.FirstDataIfIndex = 1
+			for _, ep := range tc.endpoints {
+				gotEndpointErr := tc.node.AddEndpoint(ep)
+				if gotEndpointErr != nil {
+					foundError = true
+					t.Errorf("got error for endpoint %+v", gotEndpointErr)
+				}
+			}
+
+			if !foundError {
+				gotCheckErr := tc.node.CheckInterfaceName()
+				if gotCheckErr != nil {
+					foundError = true
+					t.Errorf("got error for check %+v", gotCheckErr)
+				}
+
+				if !foundError {
+					for idx, ep := range tc.node.Endpoints {
+						if ep.GetIfaceName() != tc.resultEps[idx] {
+							t.Errorf("got wrong mapped endpoint %q (%q), want %q",
+								ep.GetIfaceName(), ep.GetIfaceAlias(), tc.resultEps[idx])
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3352 (follow-up to the maintainer's go-ahead there).

### What

Adds `InterfaceRegexp`, `InterfaceOffset`, and `InterfaceHelp` to the `vr_ftosv` node, following the existing vr-kind pattern (`vr_aoscx`, `vr_n9kv`):

```go
InterfaceRegexp = regexp.MustCompile(`(?:ethernet\s?)?1/1/(?P<port>\d+)`)
InterfaceOffset = 1
InterfaceHelp   = "ethernet1/1/X or 1/1/X (where X >= 1) or ethX (where X >= 1)"
```

* Topology links can now use the names as OS10 renders them: `ethernet1/1/X` (running-config form), `ethernet 1/1/X` (CLI-accepted spaced form), or bare `1/1/X` — all mapped onto `ethX`, while raw `ethX` names keep working unchanged.
* Setting `InterfaceHelp` also fixes the second half of the issue: the `CheckInterfaceName` deploy error previously printed an empty pattern hint (`... does not match the required interface patterns: ""`); it now names the accepted forms.
* Unit test added (`vr-ftosv_test.go`), modeled on `vr_aoscx`'s: alias forms `ethernet1/1/1`, `ethernet 1/1/3`, `1/1/5` map to `eth1`/`eth3`/`eth5`; raw `ethN` passes through.
* Kind doc (`docs/manual/kinds/vr-ftosv.md`) updated to the same "Interface naming" structure the sibling vr kinds use.

### Why offset 1 / why this mapping

Validated on real vrnetlab-built OS10 images (10.6.1.1.67 and 10.5.6.14, S5248F personality) while onboarding the kind on our platform: with links declared `eth1↔eth1`, `eth2↔eth2`, both switches see each other via LLDP on `ethernet1/1/1`/`ethernet1/1/2` and form OSPF FULL adjacencies on `ethernet1/1/1` — i.e. `ethN ↔ ethernet1/1/N` is 1:1 in declaration order, so `port − 1 + FirstDataIfIndex` is the correct index calculation. The empty-pattern error reproduced exactly as described in the issue whenever `ethernet1/1/N` endpoint names were used pre-patch.

### Test

```
$ go test -v ./nodes/vr_ftosv/...
=== RUN   TestFtosvInterfaceParsing
=== RUN   TestFtosvInterfaceParsing/alias-parse
=== RUN   TestFtosvInterfaceParsing/original-parse
--- PASS: TestFtosvInterfaceParsing (0.00s)
    --- PASS: TestFtosvInterfaceParsing/alias-parse (0.00s)
    --- PASS: TestFtosvInterfaceParsing/original-parse (0.00s)
PASS
ok      github.com/srl-labs/containerlab/nodes/vr_ftosv 0.020s
```

`go vet` and `golangci-lint run` (v2.12, repo config) report 0 issues on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
