### PR TITLE
fix podman client context when copying config to container

### DIFF
--- a/runtime/podman/podman.go
+++ b/runtime/podman/podman.go
@@ -610,6 +610,11 @@ func (p *PodmanRuntime) CopyToContainer(
 	dstPath string,
 	srcPath string,
 ) error {
+	ctx, err := p.connect(ctx)
+	if err != nil {
+		return err
+	}
+
 	tarBuf, err := utils.FileToTarStream(dstPath, srcPath)
 	if err != nil {
 		return fmt.Errorf("error creating tar stream from source file %s: %w", srcPath, err)


### PR DESCRIPTION
<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/bbbb5c81-b69f-4125-8a9c-70a57c004326" />

I have found this bug, when running containerlab with podman. 

The configuration failed to be copied to the container due to missing context connection (`ctx`) on `CopyToContainer` function in podman runtime which caused another function (`CopyFromArchiveWithOptions`) invoked inside to fail with `Client not set in context`.