### PR TITLE
Feat/preserve links on node destroy

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -69,6 +69,12 @@ func destroyCmd(o *Options) (*cobra.Command, error) {
 		o.Destroy.KeepManagementNetwork,
 		"do not remove the management network",
 	)
+	c.Flags().BoolVar(
+		&o.Destroy.KeepLinks,
+		"keep-links",
+		o.Destroy.KeepLinks,
+		"preserve data-plane links when destroying nodes selected with --node-filter",
+	)
 	c.Flags().StringSliceVarP(
 		&o.Filter.NodeFilter,
 		"node-filter",
@@ -81,6 +87,14 @@ func destroyCmd(o *Options) (*cobra.Command, error) {
 }
 
 func destroyFn(cobraCmd *cobra.Command, o *Options) error {
+	if o.Destroy.KeepLinks && len(o.Filter.NodeFilter) == 0 {
+		return fmt.Errorf("keep-links requires node-filter")
+	}
+
+	if o.Destroy.KeepLinks && o.Destroy.Cleanup {
+		return fmt.Errorf("keep-links cannot be used with cleanup")
+	}
+
 	if o.Destroy.Cleanup && len(o.Filter.NodeFilter) != 0 {
 		return fmt.Errorf("cleanup cannot be used with node-filter")
 	}

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDestroyKeepLinksRequiresNodeFilter(t *testing.T) {
+	o := GetOptions()
+	copyOptions := *o
+	destroyOptions := *o.Destroy
+	filterOptions := *o.Filter
+	copyOptions.Destroy = &destroyOptions
+	copyOptions.Filter = &filterOptions
+	copyOptions.Destroy.KeepLinks = true
+	copyOptions.Filter.NodeFilter = nil
+
+	err := destroyFn(&cobra.Command{}, &copyOptions)
+	if err == nil || !strings.Contains(err.Error(), "keep-links requires node-filter") {
+		t.Fatalf("destroyFn() error = %v, want keep-links/node-filter validation error", err)
+	}
+}
+
+func TestDestroyKeepLinksRejectsCleanup(t *testing.T) {
+	o := GetOptions()
+	copyOptions := *o
+	destroyOptions := *o.Destroy
+	filterOptions := *o.Filter
+	copyOptions.Destroy = &destroyOptions
+	copyOptions.Filter = &filterOptions
+	copyOptions.Destroy.KeepLinks = true
+	copyOptions.Destroy.Cleanup = true
+	copyOptions.Filter.NodeFilter = []string{"node1"}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := destroyFn(cmd, &copyOptions)
+	if err == nil || !strings.Contains(err.Error(), "keep-links cannot be used with cleanup") {
+		t.Fatalf("destroyFn() error = %v, want keep-links/cleanup validation error", err)
+	}
+}

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -188,6 +188,10 @@ func (o *Options) ToClabDestroyOptions() []clabcore.DestroyOption {
 		)
 	}
 
+	if o.Destroy.KeepLinks {
+		destroyOptions = append(destroyOptions, clabcore.WithDestroyKeepLinks())
+	}
+
 	if o.Destroy.Cleanup {
 		destroyOptions = append(
 			destroyOptions,
@@ -354,6 +358,7 @@ type DestroyOptions struct {
 	Cleanup               bool
 	All                   bool
 	KeepManagementNetwork bool
+	KeepLinks             bool
 	AutoApprove           bool
 }
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -415,6 +415,34 @@ func TestApplyPlanLinkNeedsDeployRejectsMismatchedVethPeer(t *testing.T) {
 	}
 }
 
+func TestApplyPlanLinkNeedsDeployMatchesRenamedParkedVethByPeer(t *testing.T) {
+	t.Parallel()
+
+	dut := &applyFakeLinkNode{name: "dut"}
+	frr := &applyFakeLinkNode{name: "frr"}
+	link := clablinks.NewLinkVEth()
+	link.Endpoints = []clablinks.Endpoint{
+		clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(dut, "et1", link)),
+		clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(frr, "eth1", link)),
+	}
+
+	plan := newApplyPlan(nil, nil)
+	plan.parkedNodeSet["dut"] = struct{}{}
+	plan.addedNodeSet["dut"] = struct{}{}
+	plan.liveEndpointSet = map[applyEndpointKey]struct{}{
+		{node: "dut", iface: "e1-1"}: {},
+		{node: "frr", iface: "eth1"}: {},
+	}
+	plan.liveEndpointInfo = map[applyEndpointKey]clablinks.OwnedInterface{
+		{node: "dut", iface: "e1-1"}: {Name: "e1-1", Index: 11, PeerIndex: 22},
+		{node: "frr", iface: "eth1"}: {Name: "eth1", Index: 22, PeerIndex: 11},
+	}
+
+	if plan.linkNeedsDeploy(link) {
+		t.Fatal("expected desired dut:et1 to preserve parked dut:e1-1 paired with frr:eth1")
+	}
+}
+
 func TestPlanRecreatedNodeLinksDeploysAllTouchingLinks(t *testing.T) {
 	t.Parallel()
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -443,6 +443,20 @@ func TestApplyPlanLinkNeedsDeployMatchesRenamedParkedVethByPeer(t *testing.T) {
 	}
 }
 
+func TestTreatAsAddedParkedNodeWithStaleRuntimeEntry(t *testing.T) {
+	t.Parallel()
+
+	if !treatAsAddedParkedNode(true, clabruntime.NotFound, true) {
+		t.Fatal("expected missing container with stale runtime entry and parking namespace to be added+parked")
+	}
+	if treatAsAddedParkedNode(true, clabruntime.Running, true) {
+		t.Fatal("running container must not be reclassified")
+	}
+	if treatAsAddedParkedNode(true, clabruntime.NotFound, false) {
+		t.Fatal("missing container without parking namespace must not be reclassified as parked")
+	}
+}
+
 func TestPlanRecreatedNodeLinksDeploysAllTouchingLinks(t *testing.T) {
 	t.Parallel()
 

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -163,7 +163,7 @@ func (c *CLab) deploy( //nolint: funlen
 	log.Debugf("lab Conf: %+v", c.Config)
 
 	if options.reconfigure {
-		_ = c.destroy(ctx, uint(len(c.Nodes)), true)
+		_ = c.destroy(ctx, uint(len(c.Nodes)), true, false)
 		log.Info("Removing directory", "path", c.TopoPaths.TopologyLabDir())
 
 		if err := os.RemoveAll(c.TopoPaths.TopologyLabDir()); err != nil {

--- a/core/destroy.go
+++ b/core/destroy.go
@@ -130,8 +130,20 @@ func (c *CLab) makeCopyForDestroy(
 		varsFiles = c.TopoPaths.VarsFilenamesAbsPath()
 	}
 
-	if clabutils.FileOrDirExists(topo) {
-		newOpts = append(newOpts, WithTopoPath(topo, varsFiles))
+	destroyTopo := availableDestroyTopology(
+		topo,
+		c.TopoPaths.TopologyFilenameAbsPath(),
+		opts.all,
+	)
+	if destroyTopo != "" {
+		if destroyTopo != topo {
+			log.Debugf(
+				"labeled topology file %q not found, using requested topology %q for destroy",
+				topo,
+				destroyTopo,
+			)
+		}
+		newOpts = append(newOpts, WithTopoPath(destroyTopo, varsFiles))
 	} else {
 		// Derive lab name from lab directory (format: clab-<labname>)
 		labName := filepath.Base(labDir)
@@ -194,6 +206,16 @@ func (c *CLab) makeCopyForDestroy(
 	}
 
 	return cc, nil
+}
+
+func availableDestroyTopology(labeledTopo, requestedTopo string, all bool) string {
+	if clabutils.FileOrDirExists(labeledTopo) {
+		return labeledTopo
+	}
+	if !all && clabutils.FileOrDirExists(requestedTopo) {
+		return requestedTopo
+	}
+	return ""
 }
 
 func (c *CLab) destroyLabDirs(topos map[string]string, all bool) error {

--- a/core/destroy.go
+++ b/core/destroy.go
@@ -95,7 +95,7 @@ func (c *CLab) Destroy(ctx context.Context, options ...DestroyOption) (err error
 			return err
 		}
 
-		err = cc.destroy(ctx, opts.maxWorkers, opts.keepMgmtNet)
+		err = cc.destroy(ctx, opts.maxWorkers, opts.keepMgmtNet, opts.keepLinks)
 		if err != nil {
 			log.Errorf("Error occurred during the %s lab deletion: %v", cc.Config.Name, err)
 			errs = append(errs, err)
@@ -240,7 +240,12 @@ func (c *CLab) destroyLabDirs(topos map[string]string, all bool) error {
 	return nil
 }
 
-func (c *CLab) destroy(ctx context.Context, maxWorkers uint, keepMgmtNet bool) error {
+func (c *CLab) destroy(
+	ctx context.Context,
+	maxWorkers uint,
+	keepMgmtNet,
+	keepLinks bool,
+) error {
 	var containers []clabruntime.GenericContainer
 	var err error
 
@@ -269,14 +274,24 @@ func (c *CLab) destroy(ctx context.Context, maxWorkers uint, keepMgmtNet bool) e
 	// If we have nodes defined, use the normal node-based deletion.
 	// Otherwise, delete containers directly via the runtime (for destroy-by-name-only case).
 	if len(c.Nodes) > 0 {
-		err := clablinks.CleanupFilteredLinks(
-			ctx,
-			c.Config.Topology.Links,
-			c.Config.Name,
-			c.nodeFilter,
-		)
-		if err != nil {
-			return err
+		if keepLinks {
+			for _, nodeName := range sortedNodeNames(c.Nodes) {
+				node := c.Nodes[nodeName]
+				log.Info("Parking links for node replacement", "node", nodeName)
+				if err := node.ParkEndpoints(ctx); err != nil {
+					return fmt.Errorf("failed parking endpoints for node %q: %w", nodeName, err)
+				}
+			}
+		} else {
+			err := clablinks.CleanupFilteredLinks(
+				ctx,
+				c.Config.Topology.Links,
+				c.Config.Name,
+				c.nodeFilter,
+			)
+			if err != nil {
+				return err
+			}
 		}
 		c.deleteNodes(ctx, maxWorkers)
 	} else {

--- a/core/destroy_test.go
+++ b/core/destroy_test.go
@@ -72,3 +72,14 @@ func TestWithLabNameOnly_setsNameWithoutTopologyFile(t *testing.T) {
 		t.Fatal("topology file should not be set for lab-name-only init")
 	}
 }
+
+func TestWithDestroyKeepLinks(t *testing.T) {
+	t.Parallel()
+
+	opts := NewDestroyOptions()
+	WithDestroyKeepLinks()(opts)
+
+	if !opts.keepLinks {
+		t.Fatal("WithDestroyKeepLinks did not enable link preservation")
+	}
+}

--- a/core/destroy_test.go
+++ b/core/destroy_test.go
@@ -6,11 +6,28 @@ package core
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	claberrors "github.com/srl-labs/containerlab/errors"
 )
+
+func TestAvailableDestroyTopologyFallsBackToRequestedTopology(t *testing.T) {
+	t.Parallel()
+
+	requested := filepath.Join(t.TempDir(), "current.clab.yml")
+	if err := os.WriteFile(requested, []byte("name: test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := availableDestroyTopology("/missing/temporary-apply.yml", requested, false); got != requested {
+		t.Fatalf("availableDestroyTopology() = %q, want requested topology %q", got, requested)
+	}
+	if got := availableDestroyTopology("/missing/temporary-apply.yml", requested, true); got != "" {
+		t.Fatalf("availableDestroyTopology(all) = %q, want no cross-lab fallback", got)
+	}
+}
 
 // makeCopyForDestroy must apply WithTopoPath (or WithLabNameOnly) before WithNodeFilter so that
 // filterClabNodes runs against a loaded topology. This mirrors the option order used there.

--- a/core/lifecycle.go
+++ b/core/lifecycle.go
@@ -41,6 +41,9 @@ func (c *CLab) lifecycleNodes(nodeNames []string) ([]clabnodes.Node, error) {
 
 func (c *CLab) parkRecreatedNodes(ctx context.Context, plan *applyPlan) error {
 	for _, nodeName := range sortedStringSet(plan.parkedNodeSet) {
+		if _, recreated := plan.recreatedNodeSet[nodeName]; !recreated {
+			continue
+		}
 		node, exists := c.Nodes[nodeName]
 		if !exists {
 			continue

--- a/core/options_destroy.go
+++ b/core/options_destroy.go
@@ -7,6 +7,7 @@ type DestroyOption func(o *DestroyOptions)
 type DestroyOptions struct {
 	maxWorkers     uint
 	keepMgmtNet    bool
+	keepLinks      bool
 	graceful       bool
 	all            bool
 	terminalPrompt bool
@@ -15,6 +16,13 @@ type DestroyOptions struct {
 	// varsFiles is topology template vars from CLI (--vars), used when destroying all labs
 	// so each topology can be loaded with the same vars (e.g. templated topologies).
 	varsFiles []string
+}
+
+// WithDestroyKeepLinks preserves data-plane links for nodes selected by a node filter.
+func WithDestroyKeepLinks() DestroyOption {
+	return func(o *DestroyOptions) {
+		o.keepLinks = true
+	}
 }
 
 // NewDestroyOptions returns a new destroy options object.

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -299,6 +299,9 @@ func (c *CLab) planDeletedEndpoints(ctx context.Context, plan *applyPlan) {
 		if _, exists := plan.desiredEndpointSet[key]; exists {
 			continue
 		}
+		if _, parked := plan.parkedNodeSet[key.node]; parked {
+			continue
+		}
 		c.addStaleApplyEndpoint(ctx, plan, plannedEndpointSet, key)
 	}
 }
@@ -384,7 +387,9 @@ func (c *CLab) discoverLiveApplyEndpoints(
 	for _, nodeName := range sortedLinkNodeNames(desiredNodes) {
 		n := desiredNodes[nodeName]
 		if _, exists := plan.currentNodes[nodeName]; !exists && !isApplySpecialNode(nodeName) {
-			continue
+			if _, parked := plan.parkedNodeSet[nodeName]; !parked {
+				continue
+			}
 		}
 
 		if _, recreate := plan.recreatedNodeSet[nodeName]; recreate {
@@ -392,6 +397,7 @@ func (c *CLab) discoverLiveApplyEndpoints(
 				continue
 			}
 		}
+		usingParkingNode := false
 		if _, added := plan.addedNodeSet[nodeName]; added {
 			if _, parked := plan.parkedNodeSet[nodeName]; !parked {
 				continue
@@ -401,8 +407,9 @@ func (c *CLab) discoverLiveApplyEndpoints(
 				continue
 			}
 			n = parkingNode
+			usingParkingNode = true
 		}
-		if _, start := plan.startNodeSet[nodeName]; start {
+		if _, start := plan.startNodeSet[nodeName]; start && !usingParkingNode {
 			parkingNode, ok := c.applyParkingLinkNode(nodeName)
 			if !ok {
 				continue
@@ -776,7 +783,12 @@ func (p *applyPlan) linkNeedsDeploy(link clablinks.Link) bool {
 			}
 		}
 		if _, live := p.liveEndpointSet[key]; !live {
-			return true
+			if _, parked := p.parkedNodeSet[key.node]; !parked {
+				return true
+			}
+			if len(p.liveEndpointCandidates(ep)) == 0 {
+				return true
+			}
 		}
 	}
 
@@ -789,27 +801,44 @@ func (p *applyPlan) linkIntact(link clablinks.Link) bool {
 		return true
 	}
 
-	left, leftOK := p.liveEndpointInfo[endpointKeyFromEndpoint(endpoints[0])]
-	right, rightOK := p.liveEndpointInfo[endpointKeyFromEndpoint(endpoints[1])]
-	if !leftOK || !rightOK {
-		return false
+	leftCandidates := p.liveEndpointCandidates(endpoints[0])
+	rightCandidates := p.liveEndpointCandidates(endpoints[1])
+
+	for _, left := range leftCandidates {
+		for _, right := range rightCandidates {
+			if endpoints[0].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
+				!endpoints[0].IsNodeless() && left.MasterName != endpoints[0].GetNode().GetShortName() {
+				continue
+			}
+			if endpoints[1].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
+				!endpoints[1].IsNodeless() && right.MasterName != endpoints[1].GetNode().GetShortName() {
+				continue
+			}
+			if left.PeerIndex != 0 && right.PeerIndex != 0 &&
+				left.PeerIndex == right.Index && right.PeerIndex == left.Index {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *applyPlan) liveEndpointCandidates(ep clablinks.Endpoint) []clablinks.OwnedInterface {
+	key := endpointKeyFromEndpoint(ep)
+	if info, ok := p.liveEndpointInfo[key]; ok {
+		return []clablinks.OwnedInterface{info}
+	}
+	if _, parked := p.parkedNodeSet[key.node]; !parked {
+		return nil
 	}
 
-	if endpoints[0].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
-		!endpoints[0].IsNodeless() &&
-		left.MasterName != endpoints[0].GetNode().GetShortName() {
-		return false
+	var candidates []clablinks.OwnedInterface
+	for liveKey, info := range p.liveEndpointInfo {
+		if liveKey.node == key.node {
+			candidates = append(candidates, info)
+		}
 	}
-	if endpoints[1].GetNode().GetLinkEndpointType() == clablinks.LinkEndpointTypeBridge &&
-		!endpoints[1].IsNodeless() &&
-		right.MasterName != endpoints[1].GetNode().GetShortName() {
-		return false
-	}
-
-	return left.PeerIndex != 0 &&
-		right.PeerIndex != 0 &&
-		left.PeerIndex == right.Index &&
-		right.PeerIndex == left.Index
+	return candidates
 }
 
 func (p *applyPlan) deployNodeNames() []string {

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -213,6 +213,15 @@ func (c *CLab) planParkedNodes(ctx context.Context, plan *applyPlan) {
 			plan.parkedNodeSet[nodeName] = struct{}{}
 		}
 	}
+
+	// A previous filtered destroy --keep-links leaves the node's interfaces in
+	// its deterministic parking namespace. Treat the missing container as an
+	// already-parked added node so apply restores rather than recreates its links.
+	for nodeName := range plan.addedNodeSet {
+		if _, exists := c.applyParkingLinkNode(nodeName); exists {
+			plan.parkedNodeSet[nodeName] = struct{}{}
+		}
+	}
 }
 
 func (c *CLab) planStoppedNodes(ctx context.Context, plan *applyPlan) {
@@ -387,6 +396,11 @@ func (c *CLab) discoverLiveApplyEndpoints(
 			if _, parked := plan.parkedNodeSet[nodeName]; !parked {
 				continue
 			}
+			parkingNode, ok := c.applyParkingLinkNode(nodeName)
+			if !ok {
+				continue
+			}
+			n = parkingNode
 		}
 		if _, start := plan.startNodeSet[nodeName]; start {
 			parkingNode, ok := c.applyParkingLinkNode(nodeName)

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -117,8 +117,28 @@ func (c *CLab) planApply(
 	plan := newApplyPlan(currentNodes, state)
 
 	for _, nodeName := range sortedNodeNames(c.Nodes) {
-		if _, exists := currentNodes[nodeName]; !exists {
-			status := c.Nodes[nodeName].GetContainerStatus(ctx)
+		_, runtimeExists := currentNodes[nodeName]
+		status := clabruntime.NotFound
+		parkingExists := false
+		if runtimeExists {
+			if _, parked := c.applyParkingLinkNode(nodeName); parked {
+				parkingExists = true
+				status = c.Nodes[nodeName].GetContainerStatus(ctx)
+			} else {
+				continue
+			}
+		} else {
+			status = c.Nodes[nodeName].GetContainerStatus(ctx)
+		}
+		if treatAsAddedParkedNode(runtimeExists, status, parkingExists) {
+			// Runtime discovery can briefly retain the just-removed container.
+			// The parking namespace is authoritative for a filtered
+			// destroy --keep-links: plan this as an added+parked node.
+			delete(currentNodes, nodeName)
+			runtimeExists = false
+			plan.parkedNodeSet[nodeName] = struct{}{}
+		}
+		if !runtimeExists {
 			if status != clabruntime.NotFound {
 				return nil, fmt.Errorf(
 					"node %q container %q already exists outside the runtime lab state",
@@ -188,6 +208,14 @@ func (c *CLab) planApply(
 	}
 
 	return plan, nil
+}
+
+func treatAsAddedParkedNode(
+	runtimeExists bool,
+	status clabruntime.ContainerStatus,
+	parkingExists bool,
+) bool {
+	return runtimeExists && status == clabruntime.NotFound && parkingExists
 }
 
 func (p *applyPlan) addDeployApplyLink(linkIdx int, link clablinks.Link) {
@@ -409,7 +437,10 @@ func (c *CLab) discoverLiveApplyEndpoints(
 			n = parkingNode
 			usingParkingNode = true
 		}
-		if _, start := plan.startNodeSet[nodeName]; start && !usingParkingNode {
+		if usingParkingNode {
+			// Added+parked nodes are discovered exclusively through the parking
+			// namespace; their destination container does not exist yet.
+		} else if _, start := plan.startNodeSet[nodeName]; start {
 			parkingNode, ok := c.applyParkingLinkNode(nodeName)
 			if !ok {
 				continue

--- a/docs/cmd/destroy.md
+++ b/docs/cmd/destroy.md
@@ -40,6 +40,16 @@ To make containerlab attempt a graceful shutdown of the running containers, add 
 
 Do not try to remove the management network. Usually the management docker network (in case of docker) and the underlying bridge are being removed. If you have attached additional resources outside of containerlab and you want the bridge to remain intact just add the `--keep-mgmt-net` flag.
 
+#### keep-links
+
+The local `--keep-links` flag preserves the data-plane interfaces of nodes selected with
+`--node-filter`. Containerlab parks the interfaces in persistent network namespaces before it
+removes the containers. A subsequent `deploy` or `apply` restores the interfaces when it creates
+the missing nodes, preserving the existing veth pairs and their peer interfaces.
+
+This flag is intended for replacing selected nodes and requires `--node-filter`. It cannot be
+combined with `--cleanup`.
+
 #### all
 
 Destroy command provided with `--all | -a` flag will perform the deletion of all the labs running on the container host. It will not touch containers launched manually.
@@ -69,6 +79,13 @@ containerlab destroy -t mylab.clab.yml
 
 ```bash
 containerlab destroy -t mylab.clab.yml --cleanup
+```
+
+#### Destroy selected nodes while preserving their links for replacement
+
+```bash
+containerlab destroy -t mylab.clab.yml --node-filter node1,node2 --keep-links --keep-mgmt-net
+containerlab apply -t replacement.clab.yml
 ```
 
 #### Destroy a lab without specifying topology file

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 // Endpoint is the interface that all endpoint types implement.
@@ -228,8 +230,28 @@ func (e *EndpointGeneric) Activate(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		return netlink.LinkSetUp(link)
+		return activateLink(link)
 	})
+}
+
+// activateLink brings a link up and clears IFF_DORMANT. Some network OSes
+// leave that flag behind on veths which are later parked and restored into a
+// different node. netlink.LinkSetUp only changes IFF_UP, so the stale dormant
+// state would otherwise survive the restore.
+func activateLink(link netlink.Link) error {
+	req := nl.NewNetlinkRequest(unix.RTM_NEWLINK, unix.NLM_F_ACK)
+	req.AddData(newActivateLinkMessage(link.Attrs().Index))
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+func newActivateLinkMessage(index int) *nl.IfInfomsg {
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Change = unix.IFF_UP | unix.IFF_DORMANT
+	msg.Flags = unix.IFF_UP
+	msg.Index = int32(index)
+	return msg
 }
 
 func ensureOwnershipAltName(ctx context.Context, e Endpoint) error {

--- a/links/endpoint.go
+++ b/links/endpoint.go
@@ -234,13 +234,13 @@ func (e *EndpointGeneric) Activate(ctx context.Context) error {
 	})
 }
 
-// activateLink brings a link up and clears IFF_DORMANT. Some network OSes
-// leave that flag behind on veths which are later parked and restored into a
-// different node. netlink.LinkSetUp only changes IFF_UP, so the stale dormant
-// state would otherwise survive the restore.
+// activateLink brings a link up in the default link mode. Some network OSes
+// leave restored veths in dormant link mode. netlink.LinkSetUp only changes
+// IFF_UP, so the stale mode would otherwise survive the restore.
 func activateLink(link netlink.Link) error {
 	req := nl.NewNetlinkRequest(unix.RTM_NEWLINK, unix.NLM_F_ACK)
 	req.AddData(newActivateLinkMessage(link.Attrs().Index))
+	req.AddData(newDefaultLinkModeAttr())
 
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
@@ -248,10 +248,16 @@ func activateLink(link netlink.Link) error {
 
 func newActivateLinkMessage(index int) *nl.IfInfomsg {
 	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
-	msg.Change = unix.IFF_UP | unix.IFF_DORMANT
+	msg.Change = unix.IFF_UP
 	msg.Flags = unix.IFF_UP
 	msg.Index = int32(index)
 	return msg
+}
+
+func newDefaultLinkModeAttr() *nl.RtAttr {
+	// IF_LINK_MODE_DEFAULT is zero. x/sys exposes IFLA_LINKMODE but not the
+	// values of the link-mode enum.
+	return nl.NewRtAttr(unix.IFLA_LINKMODE, []byte{0})
 }
 
 func ensureOwnershipAltName(ctx context.Context, e Endpoint) error {

--- a/links/endpoint_test.go
+++ b/links/endpoint_test.go
@@ -1,0 +1,26 @@
+package links
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNewActivateLinkMessageClearsDormantWhileSettingUp(t *testing.T) {
+	const index = 42
+
+	msg := newActivateLinkMessage(index)
+
+	if msg.Index != index {
+		t.Fatalf("Index = %d, want %d", msg.Index, index)
+	}
+	if msg.Change != unix.IFF_UP|unix.IFF_DORMANT {
+		t.Fatalf("Change = %#x, want IFF_UP|IFF_DORMANT", msg.Change)
+	}
+	if msg.Flags&unix.IFF_UP == 0 {
+		t.Fatal("IFF_UP is not set")
+	}
+	if msg.Flags&unix.IFF_DORMANT != 0 {
+		t.Fatal("IFF_DORMANT is set")
+	}
+}

--- a/links/endpoint_test.go
+++ b/links/endpoint_test.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestNewActivateLinkMessageClearsDormantWhileSettingUp(t *testing.T) {
+func TestActivateLinkRequestSetsUpInDefaultMode(t *testing.T) {
 	const index = 42
 
 	msg := newActivateLinkMessage(index)
@@ -14,13 +14,18 @@ func TestNewActivateLinkMessageClearsDormantWhileSettingUp(t *testing.T) {
 	if msg.Index != index {
 		t.Fatalf("Index = %d, want %d", msg.Index, index)
 	}
-	if msg.Change != unix.IFF_UP|unix.IFF_DORMANT {
-		t.Fatalf("Change = %#x, want IFF_UP|IFF_DORMANT", msg.Change)
+	if msg.Change != unix.IFF_UP {
+		t.Fatalf("Change = %#x, want IFF_UP", msg.Change)
 	}
 	if msg.Flags&unix.IFF_UP == 0 {
 		t.Fatal("IFF_UP is not set")
 	}
-	if msg.Flags&unix.IFF_DORMANT != 0 {
-		t.Fatal("IFF_DORMANT is set")
+
+	mode := newDefaultLinkModeAttr()
+	if mode.Type != unix.IFLA_LINKMODE {
+		t.Fatalf("link mode attribute type = %d, want IFLA_LINKMODE", mode.Type)
+	}
+	if len(mode.Data) != 1 || mode.Data[0] != 0 {
+		t.Fatalf("link mode attribute data = %v, want IF_LINK_MODE_DEFAULT", mode.Data)
 	}
 }

--- a/links/link.go
+++ b/links/link.go
@@ -38,6 +38,7 @@ const (
 )
 
 var linkAddAltName = netlink.LinkAddAltName
+var linkDelAltName = netlink.LinkDelAltName
 
 // LinkCommonParams represents the common parameters for all link types.
 type LinkCommonParams struct {
@@ -680,6 +681,25 @@ func addOwnershipAltName(link netlink.Link, endpt Endpoint) error {
 		return fmt.Errorf("failed to add containerlab ownership altname: %w", err)
 	}
 
+	return nil
+}
+
+func replaceOwnershipAltName(link netlink.Link, nodeName, oldIfaceName, newIfaceName string) error {
+	oldName := ownershipAltNameFor(nodeName, oldIfaceName)
+	newName := ownershipAltNameFor(nodeName, newIfaceName)
+	if oldName == newName {
+		return nil
+	}
+
+	if err := linkDelAltName(link, oldName); err != nil && !isAltNameNotSupportedErr(err) {
+		return fmt.Errorf("failed to remove containerlab ownership altname: %w", err)
+	}
+	if err := linkAddAltName(link, newName); err != nil {
+		if isAltNameNotSupportedErr(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to add containerlab ownership altname: %w", err)
+	}
 	return nil
 }
 

--- a/links/parking_node.go
+++ b/links/parking_node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/charmbracelet/log"
 	"github.com/containernetworking/plugins/pkg/ns"
 	clabutils "github.com/srl-labs/containerlab/utils"
 	"github.com/vishvananda/netlink"
@@ -58,6 +59,9 @@ func (p *ParkingNode) CaptureFrom(ctx context.Context, src Node) error {
 }
 
 func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, error) {
+	if err := p.renamePairedEndpoints(ctx, dst); err != nil {
+		return nil, err
+	}
 	if err := p.DiscoverOwnedEndpoints(ctx, dst); err != nil {
 		return nil, err
 	}
@@ -93,6 +97,79 @@ func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, erro
 	}
 
 	return moved, nil
+}
+
+// renamePairedEndpoints maps parked veths to the destination topology by their
+// surviving peer. The parked interface name belongs to the old node kind and
+// is not part of the preserved link's identity.
+func (p *ParkingNode) renamePairedEndpoints(ctx context.Context, dst Node) error {
+	desiredByPeerIndex := map[int]string{}
+	for _, desired := range dst.GetEndpoints() {
+		linkEndpoints := RuntimeEndpoints(desired.GetLink())
+		if len(linkEndpoints) != 2 {
+			continue
+		}
+		var peer Endpoint
+		if linkEndpoints[0] == desired {
+			peer = linkEndpoints[1]
+		} else if linkEndpoints[1] == desired {
+			peer = linkEndpoints[0]
+		} else {
+			continue
+		}
+
+		err := peer.GetNode().ExecFunction(ctx, func(_ ns.NetNS) error {
+			peerLink, err := netlink.LinkByName(peer.GetIfaceName())
+			if _, notFound := err.(netlink.LinkNotFoundError); notFound {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			desiredByPeerIndex[peerLink.Attrs().Index] = desired.GetIfaceName()
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to inspect peer for %q: %w", desired.GetIfaceName(), err)
+		}
+	}
+
+	return p.ExecFunction(ctx, func(_ ns.NetNS) error {
+		parkedLinks, err := netlink.LinkList()
+		if err != nil {
+			return err
+		}
+		for _, parkedLink := range parkedLinks {
+			if parkedLink.Type() != "veth" {
+				continue
+			}
+			veth, ok := parkedLink.(*netlink.Veth)
+			if !ok {
+				veth = &netlink.Veth{LinkAttrs: *parkedLink.Attrs()}
+			}
+			peerIndex, err := netlink.VethPeerIndex(veth)
+			if err != nil {
+				return err
+			}
+			newName, matched := desiredByPeerIndex[peerIndex]
+			oldName := parkedLink.Attrs().Name
+			if !matched || newName == oldName {
+				continue
+			}
+			if !HasOwnershipAltNameFor(parkedLink, dst.GetShortName(), oldName) {
+				continue
+			}
+			if err := netlink.LinkSetName(parkedLink, newName); err != nil {
+				return fmt.Errorf("failed to rename parked interface %q to %q: %w", oldName, newName, err)
+			}
+			if err := replaceOwnershipAltName(parkedLink, dst.GetShortName(), oldName, newName); err != nil {
+				_ = netlink.LinkSetName(parkedLink, oldName)
+				return err
+			}
+			log.Infof("Renamed parked interface node=%s interface=%s new-interface=%s", dst.GetShortName(), oldName, newName)
+		}
+		return nil
+	})
 }
 
 func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original Node) error {

--- a/links/parking_node.go
+++ b/links/parking_node.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/charmbracelet/log"
 	"github.com/containernetworking/plugins/pkg/ns"
 	clabutils "github.com/srl-labs/containerlab/utils"
 	"github.com/vishvananda/netlink"
 )
+
+// containerNamer is implemented by nodes that expose a runtime container name,
+// used to locate the deterministic parking netns for a peer.
+type containerNamer interface {
+	GetContainerName() string
+}
 
 type ParkingNode struct {
 	GenericLinkNode
@@ -99,38 +106,63 @@ func (p *ParkingNode) RestoreTo(ctx context.Context, dst Node) ([]Endpoint, erro
 	return moved, nil
 }
 
+type pendingPeerRename struct {
+	desiredName string
+	peerName    string
+}
+
+type indexedIface struct {
+	name  string
+	index int
+}
+
 // renamePairedEndpoints maps parked veths to the destination topology by their
 // surviving peer. The parked interface name belongs to the old node kind and
 // is not part of the preserved link's identity.
+//
+// When both ends of a link are parked, the peer's new name is not in the live
+// container ns. Resolve that peer from its parking ns (or from leftover old
+// names already restored into the live ns) and match by trailing port index.
 func (p *ParkingNode) renamePairedEndpoints(ctx context.Context, dst Node) error {
 	desiredByPeerIndex := map[int]string{}
+	pendingByPeer := map[string][]pendingPeerRename{}
+	peerNodes := map[string]Node{}
+
 	for _, desired := range dst.GetEndpoints() {
-		linkEndpoints := RuntimeEndpoints(desired.GetLink())
-		if len(linkEndpoints) != 2 {
-			continue
-		}
-		var peer Endpoint
-		if linkEndpoints[0] == desired {
-			peer = linkEndpoints[1]
-		} else if linkEndpoints[1] == desired {
-			peer = linkEndpoints[0]
-		} else {
+		peer, ok := otherRuntimeEndpoint(desired)
+		if !ok {
 			continue
 		}
 
-		err := peer.GetNode().ExecFunction(ctx, func(_ ns.NetNS) error {
-			peerLink, err := netlink.LinkByName(peer.GetIfaceName())
-			if _, notFound := err.(netlink.LinkNotFoundError); notFound {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			desiredByPeerIndex[peerLink.Attrs().Index] = desired.GetIfaceName()
-			return nil
-		})
+		index, found, err := linkIndexByName(ctx, peer.GetNode(), peer.GetIfaceName())
 		if err != nil {
 			return fmt.Errorf("failed to inspect peer for %q: %w", desired.GetIfaceName(), err)
+		}
+		if found {
+			desiredByPeerIndex[index] = desired.GetIfaceName()
+			continue
+		}
+
+		peerNodeName := peer.GetNode().GetShortName()
+		pendingByPeer[peerNodeName] = append(pendingByPeer[peerNodeName], pendingPeerRename{
+			desiredName: desired.GetIfaceName(),
+			peerName:    peer.GetIfaceName(),
+		})
+		peerNodes[peerNodeName] = peer.GetNode()
+	}
+
+	for peerNodeName, pending := range pendingByPeer {
+		mapped, err := resolveParkedPeerIndexes(
+			ctx,
+			peerNodes[peerNodeName],
+			pending,
+			desiredByPeerIndex,
+		)
+		if err != nil {
+			return err
+		}
+		for index, name := range mapped {
+			desiredByPeerIndex[index] = name
 		}
 	}
 
@@ -170,6 +202,209 @@ func (p *ParkingNode) renamePairedEndpoints(ctx context.Context, dst Node) error
 		}
 		return nil
 	})
+}
+
+func otherRuntimeEndpoint(desired Endpoint) (Endpoint, bool) {
+	if desired == nil || desired.GetLink() == nil {
+		return nil, false
+	}
+	linkEndpoints := RuntimeEndpoints(desired.GetLink())
+	if len(linkEndpoints) != 2 {
+		return nil, false
+	}
+	if linkEndpoints[0] == desired {
+		return linkEndpoints[1], true
+	}
+	if linkEndpoints[1] == desired {
+		return linkEndpoints[0], true
+	}
+	return nil, false
+}
+
+func linkIndexByName(ctx context.Context, node Node, name string) (int, bool, error) {
+	var index int
+	found := false
+	err := node.ExecFunction(ctx, func(_ ns.NetNS) error {
+		peerLink, err := netlink.LinkByName(name)
+		if _, notFound := err.(netlink.LinkNotFoundError); notFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		index = peerLink.Attrs().Index
+		found = true
+		return nil
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	return index, found, nil
+}
+
+func parkingNodeFor(node Node) (*ParkingNode, bool) {
+	namer, ok := node.(containerNamer)
+	if !ok {
+		return nil, false
+	}
+	containerName := namer.GetContainerName()
+	if containerName == "" {
+		return nil, false
+	}
+	parkPath, err := clabutils.GetNamedNetNS(clabutils.ParkingNetnsName(containerName))
+	if err != nil {
+		return nil, false
+	}
+	return NewParkingNode(containerName, parkPath), true
+}
+
+func resolveParkedPeerIndexes(
+	ctx context.Context,
+	peerNode Node,
+	pending []pendingPeerRename,
+	usedIndexes map[int]string,
+) (map[int]string, error) {
+	candidates, err := parkedPeerCandidates(ctx, peerNode, usedIndexes)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to inspect parked peers on %q: %w",
+			peerNode.GetShortName(),
+			err,
+		)
+	}
+	return mapParkedPeerIndexes(pending, candidates), nil
+}
+
+func parkedPeerCandidates(
+	ctx context.Context,
+	peerNode Node,
+	usedIndexes map[int]string,
+) ([]indexedIface, error) {
+	var candidates []indexedIface
+	seen := map[int]struct{}{}
+
+	appendOwned := func(node Node, ownerName string) error {
+		ifaces, err := DiscoverOwnedInterfacesFor(ctx, node, ownerName, nil)
+		if err != nil {
+			return err
+		}
+		for _, iface := range ifaces {
+			if iface.Type != "veth" || iface.Index == 0 {
+				continue
+			}
+			if _, used := usedIndexes[iface.Index]; used {
+				continue
+			}
+			if _, exists := seen[iface.Index]; exists {
+				continue
+			}
+			candidates = append(candidates, indexedIface{
+				name:  iface.Name,
+				index: iface.Index,
+			})
+			seen[iface.Index] = struct{}{}
+		}
+		return nil
+	}
+
+	if err := appendOwned(peerNode, peerNode.GetShortName()); err != nil {
+		return nil, err
+	}
+	if parkNode, ok := parkingNodeFor(peerNode); ok {
+		if err := appendOwned(parkNode, peerNode.GetShortName()); err != nil {
+			return nil, err
+		}
+	}
+
+	return candidates, nil
+}
+
+func mapParkedPeerIndexes(pending []pendingPeerRename, candidates []indexedIface) map[int]string {
+	result := map[int]string{}
+	used := map[int]struct{}{}
+	matched := make([]bool, len(pending))
+
+	tryMatch := func(name string, i int) bool {
+		port, ok := ifacePortIndex(name)
+		if !ok {
+			return false
+		}
+		cand, ok := uniqueIfaceByPort(candidates, used, port)
+		if !ok {
+			return false
+		}
+		result[cand.index] = pending[i].desiredName
+		used[cand.index] = struct{}{}
+		matched[i] = true
+		return true
+	}
+
+	for i, item := range pending {
+		if tryMatch(item.peerName, i) {
+			continue
+		}
+		tryMatch(item.desiredName, i)
+	}
+
+	var leftoverPending []int
+	for i, ok := range matched {
+		if !ok {
+			leftoverPending = append(leftoverPending, i)
+		}
+	}
+	var leftoverCands []indexedIface
+	for _, cand := range candidates {
+		if _, ok := used[cand.index]; ok {
+			continue
+		}
+		leftoverCands = append(leftoverCands, cand)
+	}
+	if len(leftoverPending) == 1 && len(leftoverCands) == 1 {
+		result[leftoverCands[0].index] = pending[leftoverPending[0]].desiredName
+	}
+
+	return result
+}
+
+func uniqueIfaceByPort(candidates []indexedIface, used map[int]struct{}, port int) (indexedIface, bool) {
+	found := indexedIface{}
+	count := 0
+	for _, cand := range candidates {
+		if _, ok := used[cand.index]; ok {
+			continue
+		}
+		candPort, ok := ifacePortIndex(cand.name)
+		if !ok || candPort != port {
+			continue
+		}
+		found = cand
+		count++
+		if count > 1 {
+			return indexedIface{}, false
+		}
+	}
+	if count != 1 {
+		return indexedIface{}, false
+	}
+	return found, true
+}
+
+// ifacePortIndex returns the trailing decimal run of a Linux iface name
+// (e1-3, et3, eth3).
+func ifacePortIndex(name string) (int, bool) {
+	end := len(name)
+	start := end
+	for start > 0 && name[start-1] >= '0' && name[start-1] <= '9' {
+		start--
+	}
+	if start == end {
+		return 0, false
+	}
+	port, err := strconv.Atoi(name[start:])
+	if err != nil {
+		return 0, false
+	}
+	return port, true
 }
 
 func (p *ParkingNode) DiscoverOwnedEndpoints(ctx context.Context, original Node) error {

--- a/links/parking_node_test.go
+++ b/links/parking_node_test.go
@@ -1,0 +1,95 @@
+package links
+
+import (
+	"testing"
+)
+
+func TestIfacePortIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name string
+		port int
+		ok   bool
+	}{
+		"srl":        {name: "e1-3", port: 3, ok: true},
+		"eos":        {name: "et3", port: 3, ok: true},
+		"frr":        {name: "eth3", port: 3, ok: true},
+		"breakout":   {name: "e1-2-3", port: 3, ok: true},
+		"two-digits": {name: "eth12", port: 12, ok: true},
+		"no-digits":  {name: "lo", ok: false},
+		"eth":        {name: "eth", ok: false},
+		"empty":      {name: "", ok: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			port, ok := ifacePortIndex(tc.name)
+			if ok != tc.ok || port != tc.port {
+				t.Fatalf("ifacePortIndex(%q) = (%d, %v), want (%d, %v)", tc.name, port, ok, tc.port, tc.ok)
+			}
+		})
+	}
+}
+
+func TestMapParkedPeerIndexesRenamesBothParkedEndsByPort(t *testing.T) {
+	t.Parallel()
+
+	// SRL → EOS group swap: both ends still named e1-3 in parking netns.
+	got := mapParkedPeerIndexes(
+		[]pendingPeerRename{{desiredName: "et3", peerName: "et3"}},
+		[]indexedIface{{name: "e1-3", index: 42}},
+	)
+	if got[42] != "et3" {
+		t.Fatalf("mapParkedPeerIndexes() = %v, want peer ifindex 42 → et3", got)
+	}
+}
+
+func TestMapParkedPeerIndexesPairsMultipleLinksByTrailingPort(t *testing.T) {
+	t.Parallel()
+
+	got := mapParkedPeerIndexes(
+		[]pendingPeerRename{
+			{desiredName: "eth1", peerName: "eth1"},
+			{desiredName: "eth3", peerName: "eth3"},
+		},
+		[]indexedIface{
+			{name: "e1-3", index: 30},
+			{name: "e1-1", index: 10},
+		},
+	)
+	if got[10] != "eth1" || got[30] != "eth3" {
+		t.Fatalf("mapParkedPeerIndexes() = %v, want 10→eth1 30→eth3", got)
+	}
+}
+
+func TestMapParkedPeerIndexesPairsUniqueLeftoverWithoutPort(t *testing.T) {
+	t.Parallel()
+
+	got := mapParkedPeerIndexes(
+		[]pendingPeerRename{{desiredName: "eth3", peerName: "eth3"}},
+		[]indexedIface{{name: "veth-parked", index: 7}},
+	)
+	if got[7] != "eth3" {
+		t.Fatalf("mapParkedPeerIndexes() = %v, want unique leftover 7 → eth3", got)
+	}
+}
+
+func TestMapParkedPeerIndexesSkipsAmbiguousPorts(t *testing.T) {
+	t.Parallel()
+
+	got := mapParkedPeerIndexes(
+		[]pendingPeerRename{
+			{desiredName: "eth1", peerName: "eth1"},
+			{desiredName: "eth2", peerName: "eth2"},
+		},
+		[]indexedIface{
+			{name: "e1-1", index: 11},
+			{name: "foo1", index: 12},
+		},
+	)
+	if len(got) != 0 {
+		t.Fatalf("mapParkedPeerIndexes() = %v, want no mapping for ambiguous port 1", got)
+	}
+}

--- a/nodes/srl/interface_config_test.go
+++ b/nodes/srl/interface_config_test.go
@@ -1,0 +1,50 @@
+package srl
+
+import (
+	"testing"
+
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clablinks "github.com/srl-labs/containerlab/links"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+)
+
+func TestPopulateInterfaceConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		mtu           int
+		runtimeOnly   bool
+		wantMTU       int
+		wantMgmtIPMTU int
+	}{
+		{name: "restored endpoints without topology links", runtimeOnly: true, wantMgmtIPMTU: 1500},
+		{name: "default link MTU", mtu: clabconstants.DefaultLinkMTU, wantMgmtIPMTU: 1500},
+		{name: "explicit link MTU", mtu: 9000, wantMTU: 9000, wantMgmtIPMTU: 8986},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &srl{DefaultNode: clabnodes.DefaultNode{}}
+			for _, name := range []string{"mgmt0", "e1-1", "e1-2-1"} {
+				if tc.runtimeOnly {
+					n.Endpoints = append(n.Endpoints, clablinks.NewRuntimeEndpoint(n, name))
+					continue
+				}
+				link := clablinks.NewLinkVEth()
+				link.MTU = tc.mtu
+				n.Endpoints = append(n.Endpoints, clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n, name, link)))
+			}
+			data := srlTemplateData{IFaces: map[string]tplIFace{}, MgmtIPMTU: 1500}
+			n.populateInterfaceConfig(&data)
+			if data.MgmtMTU != tc.wantMTU || data.MgmtIPMTU != tc.wantMgmtIPMTU {
+				t.Fatalf("management MTUs = %d/%d, want %d/%d", data.MgmtMTU, data.MgmtIPMTU, tc.wantMTU, tc.wantMgmtIPMTU)
+			}
+			if len(data.IFaces) != 2 {
+				t.Fatalf("data interfaces = %d, want 2", len(data.IFaces))
+			}
+			for name, wantFullName := range map[string]string{"e1-1": "ethernet-1/1", "e1-2-1": "ethernet-1/2/1"} {
+				iface := data.IFaces[name]
+				if iface.FullName != wantFullName || iface.Mtu != tc.wantMTU {
+					t.Errorf("interface %s = %+v, want name %s and MTU %d", name, iface, wantFullName, tc.wantMTU)
+				}
+			}
+		})
+	}
+}

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -723,48 +723,7 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	// so that the two MTUs match.
 	tplData.MgmtIPMTU = n.Runtime.Mgmt().MTU
 
-	// prepare the endpoints
-	const ethernetSplitParts = 3
-
-	const ethernetMTUOverhead = 14
-
-	for _, e := range n.Endpoints {
-		ifName := e.GetIfaceName()
-		if ifName == mgmt0InterfaceName {
-			if m := e.GetLink().GetMTU(); m != clabconstants.DefaultLinkMTU {
-				tplData.MgmtMTU = m
-				tplData.MgmtIPMTU = m - ethernetMTUOverhead
-			}
-
-			continue
-		}
-
-		ifNameParts := strings.SplitN(strings.TrimLeft(ifName, "e"), "-", ethernetSplitParts)
-
-		iface := tplIFace{}
-
-		iface.BaseName = fmt.Sprintf("ethernet-%s/%s", ifNameParts[0], ifNameParts[1])
-		if len(ifNameParts) == ethernetSplitParts {
-			iface.FullName = fmt.Sprintf("%s/%s", iface.BaseName, ifNameParts[2])
-			iface.HasBreakout = true
-		} else {
-			iface.FullName = iface.BaseName
-		}
-
-		if m := e.GetLink().GetMTU(); m != clabconstants.DefaultLinkMTU {
-			iface.Mtu = m
-		}
-
-		if a := e.GetIPv4Addr(); a.IsValid() {
-			iface.IPv4 = a.String()
-		}
-
-		if a := e.GetIPv6Addr(); a.IsValid() {
-			iface.IPv6 = a.String()
-		}
-
-		tplData.IFaces[ifName] = iface
-	}
+	n.populateInterfaceConfig(&tplData)
 
 	buf := new(bytes.Buffer)
 
@@ -808,6 +767,57 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	)
 
 	return nil
+}
+
+// populateInterfaceConfig adds endpoint settings to the default configuration.
+func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) {
+	const ethernetSplitParts = 3
+
+	const ethernetMTUOverhead = 14
+
+	for _, e := range n.Endpoints {
+		// Restored runtime endpoints may have no topology link or configured MTU.
+		mtu := clabconstants.DefaultLinkMTU
+		if link := e.GetLink(); link != nil {
+			mtu = link.GetMTU()
+		}
+
+		ifName := e.GetIfaceName()
+		if ifName == mgmt0InterfaceName {
+			if mtu != clabconstants.DefaultLinkMTU {
+				tplData.MgmtMTU = mtu
+				tplData.MgmtIPMTU = mtu - ethernetMTUOverhead
+			}
+
+			continue
+		}
+
+		ifNameParts := strings.SplitN(strings.TrimLeft(ifName, "e"), "-", ethernetSplitParts)
+
+		iface := tplIFace{}
+
+		iface.BaseName = fmt.Sprintf("ethernet-%s/%s", ifNameParts[0], ifNameParts[1])
+		if len(ifNameParts) == ethernetSplitParts {
+			iface.FullName = fmt.Sprintf("%s/%s", iface.BaseName, ifNameParts[2])
+			iface.HasBreakout = true
+		} else {
+			iface.FullName = iface.BaseName
+		}
+
+		if mtu != clabconstants.DefaultLinkMTU {
+			iface.Mtu = mtu
+		}
+
+		if a := e.GetIPv4Addr(); a.IsValid() {
+			iface.IPv4 = a.String()
+		}
+
+		if a := e.GetIPv6Addr(); a.IsValid() {
+			iface.IPv6 = a.String()
+		}
+
+		tplData.IFaces[ifName] = iface
+	}
 }
 
 // addOverlayCLIConfig adds CLI formatted config that is read out of a file provided via


### PR DESCRIPTION
## Summary

Add `destroy --keep-links` support for filtered node replacement and preserve dataplane veths across subsequent `apply` operations, including swaps where the replacement node uses different interface names.

## Motivation

Replacing one node previously recreated its dataplane veth pairs. This removed the surviving peer interfaces and discarded kernel-only state such as IP addresses, neighbor state, and other runtime configuration.

For example, swapping a DUT from Nokia SR Linux to Arista cEOS changes interface names from `e1-1`/`e1-2` to `et1`/`et2`. The identity of a preserved connection is the veth pair—not the old interface name. Recreating that pair breaks peers such as BIRD unless their link initialization is rerun, defeating the purpose of keeping links.

## Workflow
```
destroy --keep-links --node-filter dut
  └─ validate options
  └─ load requested topology
  └─ ParkEndpoints(dut)
       └─ discover owned DUT endpoints
       └─ move each endpoint into clab-park-dut
  └─ remove DUT container
  └─ leave peer endpoints untouched

containerlab apply
  └─ build reconciliation plan
       └─ detect missing DUT + parking namespace
       └─ classify DUT as added + parked
       └─ discover parked and live endpoints
       └─ match links by veth Index/PeerIndex
       └─ suppress stale endpoint removal
       └─ decide whether links need deployment
  └─ create replacement DUT container
  └─ RestoreEndpoints(dut)
       └─ match parked endpoint through surviving peer
       └─ rename endpoint to desired interface name
       └─ update ownership altname
       └─ move endpoint into replacement container
       └─ set link mode default and bring interface up
  └─ deploy only genuinely missing links
  └─ run node post-deploy
```

## Improvements

- Add `--keep-links` to filtered `destroy`.
- Move selected node endpoints into a deterministic parking network namespace before removing the container.
- Preserve the peer side of each veth, including kernel addresses and runtime state.
- Discover parked endpoints during apply even when the original container no longer exists.
- Match renamed endpoints by veth `Index`/`PeerIndex` identity rather than requiring an exact interface-name match.
- Rename parked endpoints to the replacement topology’s desired interface names before restoring them.
- Update ownership altnames after an interface rename.
- Prevent parked endpoints from being treated as stale solely because their desired names changed.
- Handle stale runtime entries where Docker reports the original container as `NotFound`.
- Use the explicitly requested topology during filtered destroy when an immutable topology label references a deleted temporary apply file.
- Restore interfaces using the default Linux link mode before bringing them up, clearing dormant mode left by network operating systems such as cEOS.

## Expected behavior

A sequence such as:

```text
SR Linux DUT → cEOS DUT → FRR DUT
```

preserves the original dataplane veth pairs throughout. Apply may log interface renames, but it does not log new link creation for the kept adjacencies.

Peer interfaces retain addresses that exist only in the kernel, so peer link-initialization does not need to run again.

## Testing

Added coverage for:

- CLI and destroy-option handling.
- Parking links during filtered destroy.
- Matching parked endpoints across interface renames.
- Avoiding unnecessary link deployment when a parked endpoint remains paired with the live peer.
- Stale runtime entries with a valid parking namespace.
- Explicit topology fallback during filtered destroy.
- Restoring interfaces in default link mode.

Validated with:

```bash
go test ./core ./links
```

https://github.com/user-attachments/assets/16869204-506a-4046-a1e4-4a529884125a

