### PR TITLE
flake: fix deprecation warning from pkgs.system in nixosModule

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
             enable = lib.mkEnableOption "containerlab";
             package = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.system}.containerlab;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.containerlab;
               description = "The containerlab package to install.";
             };
           };


### PR DESCRIPTION
## Problem

Evaluating a NixOS configuration that uses the flake's `nixosModules.default` emits a deprecation warning on current nixpkgs:

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

Reproduced in isolation with the flake at `b765ef87a7b0453ac2fe372c89306fcc87fc0947`:

```nix
(import (clab.inputs.nixpkgs + "/nixos/lib/eval-config.nix")) {
  system = "x86_64-linux";
  modules = [ clab.nixosModules.default { programs.containerlab.enable = true; } ];
}
```

## Cause

`pkgs.system` was deprecated in nixpkgs in favor of `pkgs.stdenv.hostPlatform.system`. The `programs.containerlab.package` default references the deprecated attribute:

```nix
default = self.packages.${pkgs.system}.containerlab;
```

## Fix

One-line change to use the non-deprecated accessor. Verified before/after: the warning is gone and the module evaluates to the same package.