### PR TITLE
Bring back automerge for --wide

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -352,7 +352,6 @@ func printContainerInspectTable(contDetails []clabtypes.ContainerDetails, o *Opt
 		Header: text.Colors{text.Bold},
 	}
 
-	// For --wide, avoid AutoMerge and multi-line cells
 	headerBase := tableWriter.Row{"Name", "Kind/Image", "State", "IPv4/6 Address"}
 	if o.Inspect.Wide {
 		headerBase = slices.Insert(headerBase, 0, "Owner")
@@ -362,31 +361,33 @@ func printContainerInspectTable(contDetails []clabtypes.ContainerDetails, o *Opt
 
 	var colConfigs []tableWriter.ColumnConfig
 
+	// Lab-level columns (Topology, Lab Name, Owner) AutoMerge across nodes of the same lab.
 	if o.Destroy.All {
 		header = append(tableWriter.Row{"Topology", "Lab Name"}, headerBase...)
-		if !o.Inspect.Wide {
-			colConfigs = append(
-				colConfigs,
-				tableWriter.ColumnConfig{
-					Number:    1,
-					AutoMerge: true, VAlign: text.VAlignMiddle,
-				},
-				tableWriter.ColumnConfig{
-					Number:    2, //nolint: mnd
-					AutoMerge: true, VAlign: text.VAlignMiddle,
-				},
-			)
-		}
-		// If wide, do not set AutoMerge for any columns
-	} else {
-		header = headerBase
-
-		if !o.Inspect.Wide {
-			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+		colConfigs = append(
+			colConfigs,
+			tableWriter.ColumnConfig{
 				Number:    1,
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			},
+			tableWriter.ColumnConfig{
+				Number:    2, //nolint: mnd
+				AutoMerge: true, VAlign: text.VAlignMiddle,
+			},
+		)
+		if o.Inspect.Wide {
+			colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+				Number:    3, //nolint: mnd
 				AutoMerge: true, VAlign: text.VAlignMiddle,
 			})
 		}
+	} else {
+		header = headerBase
+
+		colConfigs = append(colConfigs, tableWriter.ColumnConfig{
+			Number:    1,
+			AutoMerge: true, VAlign: text.VAlignMiddle,
+		})
 	}
 
 	table.AppendHeader(header)

--- a/tests/01-smoke/01-basic-flow.robot
+++ b/tests/01-smoke/01-basic-flow.robot
@@ -411,6 +411,16 @@ Ensure "inspect all" outputs IP addresses
     ${ipv6} =    String.Strip String    ${data}[6]
     Run Keyword    Match IPv6 Address    ${ipv6}
 
+Ensure "inspect all wide" merges lab columns
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} inspect --all --wide
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    Owner
+    # topology path is merged across the three nodes of this lab
+    ${topo-count} =    Get Count    ${output}    ${lab-file}
+    Should Be Equal As Integers    ${topo-count}    1
+
 Verify "inspect interfaces" contains the expected output
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${CLAB_BIN} --runtime ${runtime} inspect interfaces -t ${CURDIR}/${lab-file}


### PR DESCRIPTION
Bring back automerge when using the `--wide / -w` flag, keep the single line logic.

Before:
```
╭───────────────────────────────────────────────┬──────────┬─────────┬─────────────────────┬──────────────────────────────────────────────────────────┬──────────┬──────────────────────────────────╮
│                   Topology                    │ Lab Name │  Owner  │        Name         │                        Kind/Image                        │  State   │          IPv4/6 Address          │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/srl-dci-evpn/dci.yml               │ dci      │ toweber │ client10            │ linux ghcr.io/srl-labs/network-multitool:latest          │ running  │ 10.58.1.201 2001:db8:58:1::201   │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/srl-dci-evpn/dci.yml               │ dci      │ toweber │ client20            │ linux ghcr.io/srl-labs/network-multitool:latest          │ running  │ 10.58.1.202 2001:db8:58:1::202   │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/srl-dci-evpn/dci.yml               │ dci      │ toweber │ dcgw10              │ nokia_srsim nokia_srsim:26.3.R2                          │ running  │ 10.58.1.231 2001:db8:58:1::231   │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/eda-telemetry-lab/eda-st.clab.yaml │ eda-st   │ toweber │ clab-eda-st-leaf1   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.11 2001:db8:58:2::11     │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/eda-telemetry-lab/eda-st.clab.yaml │ eda-st   │ toweber │ clab-eda-st-leaf2   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.12 2001:db8:58:2::12     │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/eda-telemetry-lab/eda-st.clab.yaml │ eda-st   │ toweber │ clab-eda-st-leaf3   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.13 2001:db8:58:2::13     │
╰───────────────────────────────────────────────┴──────────┴─────────┴─────────────────────┴──────────────────────────────────────────────────────────┴──────────┴──────────────────────────────────╯
```


After:
```
╭───────────────────────────────────────────────┬──────────┬─────────┬─────────────────────┬──────────────────────────────────────────────────────────┬──────────┬──────────────────────────────────╮
│                   Topology                    │ Lab Name │  Owner  │        Name         │                        Kind/Image                        │  State   │          IPv4/6 Address          │
├───────────────────────────────────────────────┼──────────┼─────────┼─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/srl-dci-evpn/dci.yml               │ dci      │ toweber │ client10            │ linux ghcr.io/srl-labs/network-multitool:latest          │ running  │ 10.58.1.201 2001:db8:58:1::201   │
│                                               │          │         ├─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│                                               │          │         │ client20            │ linux ghcr.io/srl-labs/network-multitool:latest          │ running  │ 10.58.1.202 2001:db8:58:1::202   │
│                                               │          │         ├─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│                                               │          │         │ dcgw10              │ nokia_srsim nokia_srsim:26.3.R2                          │ running  │ 10.58.1.231 2001:db8:58:1::231   │
├───────────────────────────────────────────────┼──────────┤         ├─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│ /root/clab/eda-telemetry-lab/eda-st.clab.yaml │ eda-st   │         │ clab-eda-st-leaf1   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.11 2001:db8:58:2::11     │
│                                               │          │         ├─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│                                               │          │         │ clab-eda-st-leaf2   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.12 2001:db8:58:2::12     │
│                                               │          │         ├─────────────────────┼──────────────────────────────────────────────────────────┼──────────┼──────────────────────────────────┤
│                                               │          │         │ clab-eda-st-leaf3   │ nokia_srlinux ghcr.io/nokia/srlinux:25.3.2               │ running  │ 10.58.2.13 2001:db8:58:2::13     │
╰───────────────────────────────────────────────┴──────────┴─────────┴─────────────────────┴──────────────────────────────────────────────────────────┴──────────┴──────────────────────────────────╯
```