### PR TITLE
fix(apply): plan peers that lose an interface to a recreated node

### DIFF
--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	clabconstants "github.com/srl-labs/containerlab/constants"
 	clablinks "github.com/srl-labs/containerlab/links"
 	clabmocksmocknodes "github.com/srl-labs/containerlab/mocks/mocknodes"
@@ -444,7 +446,7 @@ func TestPlanRecreatedNodeLinksDeploysAllTouchingLinks(t *testing.T) {
 	plan.plannedLinkSet = map[int]struct{}{1: {}}
 	plan.addedLinks = []clablinks.Link{link2}
 
-	c.planRecreatedNodeLinks(plan)
+	c.planRecreatedNodeLinks(context.Background(), plan)
 
 	if got, want := len(plan.addedLinks), 2; got != want {
 		t.Fatalf("planned links = %d, want %d", got, want)
@@ -458,6 +460,145 @@ func TestPlanRecreatedNodeLinksDeploysAllTouchingLinks(t *testing.T) {
 	result := applyResultFromPlan(plan)
 	if got, want := len(result.AddedLinks), 2; got != want {
 		t.Fatalf("reported added links = %d, want %d", got, want)
+	}
+}
+
+// applyTestLink builds a veth link between two fake link nodes, taken from nodes
+// by name so that both ends of a chain share the same node object.
+func applyTestLink(
+	nodes map[string]*applyFakeLinkNode,
+	aName, aIface, bName, bIface string,
+) clablinks.Link {
+	link := clablinks.NewLinkVEth()
+	link.Endpoints = []clablinks.Endpoint{
+		clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(nodes[aName], aIface, link)),
+		clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(nodes[bName], bIface, link)),
+	}
+
+	return link
+}
+
+func TestPlanRecreatedNodeLinksPlansPeersOfRebuiltLinks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// link-apply-mode of every node that is not the seed of the recreation.
+		peerModes map[string]clabnodes.LinkApplyMode
+		// nodes this apply creates; they come up with the rebuilt link in place.
+		addedNodes    []string
+		links         [][4]string
+		wantRecreated []string
+		wantRestarted []string
+		// links that get rebuilt: only those touching a recreated node.
+		wantLinks int
+	}{
+		{
+			name: "recreate peer is recreated, live peer is left alone",
+			peerModes: map[string]clabnodes.LinkApplyMode{
+				"n2": clabnodes.LinkApplyModeRecreate,
+				"n3": clabnodes.LinkApplyModeLive,
+			},
+			links: [][4]string{
+				{"n1", "eth1", "n2", "eth1"},
+				{"n1", "eth2", "n3", "eth1"},
+			},
+			wantRecreated: []string{"n1", "n2"},
+			wantLinks:     2,
+		},
+		{
+			name: "restart peer is restarted and does not pull in its own peers",
+			peerModes: map[string]clabnodes.LinkApplyMode{
+				"n2": clabnodes.LinkApplyModeRestart,
+				"n3": clabnodes.LinkApplyModeRecreate,
+			},
+			links: [][4]string{
+				{"n1", "eth1", "n2", "eth1"},
+				{"n2", "eth2", "n3", "eth1"},
+			},
+			wantRecreated: []string{"n1"},
+			wantRestarted: []string{"n2"},
+			wantLinks:     1,
+		},
+		{
+			name: "recreated peer pulls in a node that is not a peer of the seed",
+			peerModes: map[string]clabnodes.LinkApplyMode{
+				"n2": clabnodes.LinkApplyModeRecreate,
+				"n3": clabnodes.LinkApplyModeRecreate,
+			},
+			links: [][4]string{
+				{"n1", "eth1", "n2", "eth1"},
+				{"n2", "eth2", "n3", "eth1"},
+			},
+			wantRecreated: []string{"n1", "n2", "n3"},
+			wantLinks:     2,
+		},
+		{
+			name: "node created by this apply is left alone",
+			peerModes: map[string]clabnodes.LinkApplyMode{
+				"n2": clabnodes.LinkApplyModeRecreate,
+			},
+			addedNodes: []string{"n2"},
+			links: [][4]string{
+				{"n1", "eth1", "n2", "eth1"},
+			},
+			wantRecreated: []string{"n1"},
+			wantLinks:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			linkNodes := map[string]*applyFakeLinkNode{}
+			for _, l := range tt.links {
+				for _, name := range []string{l[0], l[2]} {
+					if _, exists := linkNodes[name]; !exists {
+						linkNodes[name] = &applyFakeLinkNode{name: name}
+					}
+				}
+			}
+
+			c := &CLab{
+				Links: map[int]clablinks.Link{},
+				Nodes: map[string]clabnodes.Node{},
+			}
+			for i, l := range tt.links {
+				c.Links[i] = applyTestLink(linkNodes, l[0], l[1], l[2], l[3])
+			}
+			for name, mode := range tt.peerModes {
+				node := clabmocksmocknodes.NewMockNode(ctrl)
+				node.EXPECT().Config().Return(&clabtypes.NodeConfig{}).AnyTimes()
+				node.EXPECT().LinkApplyMode(gomock.Any()).Return(mode).AnyTimes()
+				c.Nodes[name] = node
+			}
+
+			plan := newApplyPlan(nil, nil)
+			// n1 is the node the topology change recreates.
+			plan.recreatedNodeSet = map[string]struct{}{"n1": {}}
+			for _, name := range tt.addedNodes {
+				plan.addedNodeSet[name] = struct{}{}
+			}
+
+			c.planRecreatedNodeLinks(context.Background(), plan)
+
+			if diff := cmp.Diff(tt.wantRecreated, sortedStringSet(plan.recreatedNodeSet),
+				cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("recreated nodes mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.wantRestarted, sortedStringSet(plan.linkRestartNodeSet),
+				cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("restarted nodes mismatch (-want +got):\n%s", diff)
+			}
+
+			if got, want := len(plan.addedLinks), tt.wantLinks; got != want {
+				t.Errorf("planned links = %d, want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -181,7 +181,7 @@ func (c *CLab) planApply(
 		}
 	}
 
-	c.planRecreatedNodeLinks(plan)
+	c.planRecreatedNodeLinks(ctx, plan)
 	for nodeName := range plan.recreatedNodeSet {
 		delete(plan.restartNodeSet, nodeName)
 		delete(plan.linkRestartNodeSet, nodeName)
@@ -245,26 +245,76 @@ func (c *CLab) planStoppedNodes(ctx context.Context, plan *applyPlan) {
 	}
 }
 
-func (c *CLab) planRecreatedNodeLinks(plan *applyPlan) {
+// planRecreatedNodeLinks plans the rebuild of every link that touches a recreated
+// node, and gives the peer on the other end its own lifecycle action.
+//
+// A recreated node tears down all of its veths, so a peer that stays up gets a new
+// interface and silently loses the dataplane state it had for the old one. That
+// hurts VM kinds: vrnetlab writes its tc ethN to tapN redirect once per tap, at VM
+// boot, so the link comes back up on every visible layer and carries nothing.
+//
+// Peers therefore follow the same link-apply-mode policy as the nodes whose links
+// changed, and a recreated peer tears down its own links in turn, so the plan is
+// grown until it stops changing.
+func (c *CLab) planRecreatedNodeLinks(ctx context.Context, plan *applyPlan) {
 	if plan == nil || len(plan.recreatedNodeSet) == 0 {
 		return
 	}
 
-	rebuildSet := make(map[string]struct{}, len(plan.recreatedNodeSet))
-	for nodeName := range plan.recreatedNodeSet {
-		if _, parked := plan.parkedNodeSet[nodeName]; parked {
-			continue
-		}
-		rebuildSet[nodeName] = struct{}{}
-	}
+	plannedPeers := map[string]struct{}{}
 
-	for _, linkIdx := range sortedLinkIndexes(c.Links) {
-		link := c.Links[linkIdx]
-		if !linkTouchesNodeSet(link, rebuildSet) {
-			continue
+	for {
+		rebuildSet := make(map[string]struct{}, len(plan.recreatedNodeSet))
+		for nodeName := range plan.recreatedNodeSet {
+			if _, parked := plan.parkedNodeSet[nodeName]; parked {
+				continue
+			}
+			rebuildSet[nodeName] = struct{}{}
 		}
 
-		plan.addDeployApplyLink(linkIdx, link)
+		peers := map[string]struct{}{}
+
+		for _, linkIdx := range sortedLinkIndexes(c.Links) {
+			link := c.Links[linkIdx]
+			if !linkTouchesNodeSet(link, rebuildSet) {
+				continue
+			}
+
+			plan.addDeployApplyLink(linkIdx, link)
+
+			for _, ep := range clablinks.RuntimeEndpoints(link) {
+				nodeName := ep.GetNode().GetShortName()
+				if _, rebuilt := rebuildSet[nodeName]; rebuilt {
+					continue
+				}
+				if _, done := plannedPeers[nodeName]; done {
+					continue
+				}
+				// a node that is being created by this apply comes up with the
+				// rebuilt link already in place.
+				if _, added := plan.addedNodeSet[nodeName]; added {
+					continue
+				}
+				peers[nodeName] = struct{}{}
+			}
+		}
+
+		if len(peers) == 0 {
+			return
+		}
+
+		recreatedBefore := len(plan.recreatedNodeSet)
+
+		for _, nodeName := range sortedStringSet(peers) {
+			plannedPeers[nodeName] = struct{}{}
+			c.planAffectedApplyNode(ctx, plan, nodeName, "peer node recreated")
+		}
+
+		// only a newly recreated peer tears down further links, so there is
+		// nothing left to discover once the recreated set stops growing.
+		if len(plan.recreatedNodeSet) == recreatedBefore {
+			return
+		}
 	}
 }
 

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -83,6 +83,12 @@ The currently declared modes per kind:
 | images built with Boxen | `live`     | Detected via the `org.opencontainers.image.vendor=Boxen` label |
 | all other kinds         | `recreate` | Conservative default for kinds not yet validated               |
 
+#### Peers of a recreated node
+
+Recreating a node tears down every link it owns, including the end that lives in a node the topology change did not touch. Rebuilding the link hands that peer a brand new interface, and any dataplane state the peer set up for the old interface when it started is lost with it. VM-backed kinds are the ones this hurts: vrnetlab bridges each `ethN` to the VM's `tapN` with tc rules that are installed once, at container start.
+
+Those peers are therefore run through the same policy: a `live` peer keeps its in-place handling, a `restart` or `recreate` peer gets its own lifecycle action, logged with the reason `peer node recreated`. Since recreating a peer tears down that peer's links in turn, the effect can travel further than the link you edited. In a lab built only of VM kinds, adding a single link can recreate a large part of the topology. Set `link-apply-mode: live` on the nodes whose NOS handles hot-plugged interfaces to keep the blast radius small.
+
 #### Overriding the mode
 
 If you know that a node's NOS handles hot-plugged interfaces (or at least survives a plain


### PR DESCRIPTION
Fixes #3379

### Problem

A recreated node tears down every veth it owns, including the end that lives in a node the topology change did not touch. `planRecreatedNodeLinks` rebuilds those links but never runs the peer through `planAffectedApplyNode`, so the peer keeps running with a brand new interface and no lifecycle action of its own.

For VM-backed kinds that is a silent dataplane loss. vrnetlab bridges each `ethN` to the VM's `tapN` with a tc ingress qdisc and a `mirred` redirect, written by `/etc/tc-tap-ifup` one time per tap when the VM boots. The `ethN` side loses both with the old interface, and the `tapN` side keeps a filter pointing at an ifindex that no longer exists. The link stays `UP,LOWER_UP` on both sides, the NOS never sees its port go down, and nothing crosses. Nothing in the deploy output names the peer.

The issue has the full reproduction with packet counters: 119 packets in, 119 to the VM before the deploy, 119 in and 0 to the VM after.

### Change

Run the peers of a rebuilt link through the same `link-apply-mode` policy that already governs the nodes whose links changed:

- a `live` peer keeps its in-place handling, exactly as today
- a `restart` or `recreate` peer gets its lifecycle action, logged with the reason `peer node recreated`

Recreating a peer tears down that peer's own links in turn, so the plan is grown until the recreated set stops changing. `planRecreatedNodeLinks` takes a `context.Context` for that reason.

Nodes this apply is creating are skipped: they come up with the rebuilt link already in place.

### Blast radius

This makes the cost of `recreate` visible. In a lab built only of VM kinds, adding a single link can now recreate a large part of the topology instead of leaving dead links behind. That is the honest consequence of the mode, and a silent dataplane loss is worse than a visible reboot. Users can keep the blast radius small with `link-apply-mode: live` on the nodes whose NOS handles hot-plugged interfaces. `docs/cmd/deploy.md` gains a section that says this.

### Verified on a live lab

Three `nokia_sros` vrnetlab nodes. Links `r1-r2` and `r1-r3` deployed, then a third link `r2-r3` added, which recreates `r2` and `r3` and rebuilds both of `r1`'s interfaces.

`--dry-run`, same lab, same topology file:

```
v0.78.2                                  this branch
─────────────────────────────────        ──────────────────────────────────────
│ recreated nodes │ r2 (added link) │    │ recreated nodes │ r1 (peer node recreated) │
│ recreated nodes │ r3 (added link) │    │ recreated nodes │ r2 (added link)          │
│ added links │ r2:eth2 -- r3:eth2 │     │ recreated nodes │ r3 (added link)          │
│ added links │ r1:eth1 -- r2:eth1 │     │ added links │ r2:eth2 -- r3:eth2           │
│ added links │ r1:eth2 -- r3:eth1 │     │ added links │ r1:eth1 -- r2:eth1           │
                                         │ added links │ r1:eth2 -- r3:eth1           │
```

After the real deploy with this branch, every `ethN` and every `tapN` on all three nodes carries both directions of the redirect, and a 119-packet datapath test into `r1`, the node that 0.78.2 leaves broken, gives:

```
r1 eth1 rx_packets : +119   packets that arrived on the container interface
r1 tap1 tx_packets : +119   packets that reached the VM
```

On 0.78.2 the same test on the equivalent peer gives `+119 / +0`.

### Tests

`TestPlanRecreatedNodeLinksPlansPeersOfRebuiltLinks`, table-driven, four cases:

| Case | Expected |
|------|----------|
| `recreate` peer and `live` peer on the same recreated node | only the `recreate` peer is recreated |
| `restart` peer with a peer of its own | the peer is restarted and does not pull in its own peers |
| chain of `recreate` peers | the propagation reaches a node that is not a peer of the seed |
| peer created by this apply | left alone |

`golangci-lint run ./core/...` reports 0 issues. `go test -race` passes on `core`, `nodes`, `links` and `types`.

---

### Note on how this was produced

This change, its unit tests and the reproduction in #3379 were written and run with Claude AI, under my review.

The reproduction and the verification are not simulated. They were executed on real `vrnetlab/nokia_sros` nodes: the deploy logs, the `tc filter` output and the packet counters quoted above are actual command output from that lab.
