### PR TITLE
apply: support network-mode: container: nodes

### DIFF
--- a/core/apply.go
+++ b/core/apply.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	clablinks "github.com/srl-labs/containerlab/links"
 )
@@ -123,10 +122,6 @@ func (c *CLab) apply(
 		}
 
 		return result, nil
-	}
-
-	if err := c.checkUnsupportedApplyNodes(); err != nil {
-		return nil, err
 	}
 
 	if err := c.setMgmtBridgeFromRuntime(currentNodes); err != nil {
@@ -258,21 +253,6 @@ func (c *CLab) checkApplyTopologyDefinition(ctx context.Context) error {
 	}
 
 	return c.verifyDuplicateAddresses()
-}
-
-func (c *CLab) checkUnsupportedApplyNodes() error {
-	for _, nodeName := range sortedNodeNames(c.Nodes) {
-		cfg := c.Nodes[nodeName].Config()
-		if cfg != nil && strings.HasPrefix(cfg.NetworkMode, "container:") {
-			return fmt.Errorf(
-				"apply does not support nodes with %q; use redeploy or "+
-					"deploy --reconfigure",
-				cfg.NetworkMode,
-			)
-		}
-	}
-
-	return nil
 }
 
 func (c *CLab) prepareApply(

--- a/core/apply.go
+++ b/core/apply.go
@@ -186,15 +186,11 @@ func (c *CLab) apply(
 		return nil, err
 	}
 
-	if err := c.DeployNodes(ctx, deployNodeNames, options.maxWorkers); err != nil {
+	if err := c.deployApplyNodes(ctx, plan, options.maxWorkers); err != nil {
 		return nil, err
 	}
 
 	if err := c.restoreRecreatedNodes(ctx, plan); err != nil {
-		return nil, err
-	}
-
-	if err := c.startStoppedNodes(ctx, plan); err != nil {
 		return nil, err
 	}
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -809,6 +809,178 @@ func TestResolveNodeConfigFromTopologyRuntimeOptions(t *testing.T) {
 	}
 }
 
+func TestNetworkModeContainerTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		networkMode string
+		want        string
+	}{
+		{networkMode: "", want: ""},
+		{networkMode: "host", want: ""},
+		{networkMode: "none", want: ""},
+		{networkMode: "container:worker1", want: "worker1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.networkMode, func(t *testing.T) {
+			t.Parallel()
+			if got := networkModeContainerTarget(tt.networkMode); got != tt.want {
+				t.Fatalf(
+					"networkModeContainerTarget(%q) = %q, want %q",
+					tt.networkMode,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestPlanNetworkModeCascadeForcesRecreate(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{ShortName: "target"}).AnyTimes()
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{
+			"target":  target,
+			"sidecar": sidecar,
+		},
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.recreatedNodeSet["target"] = struct{}{}
+	plan.restartNodeSet["sidecar"] = struct{}{}
+
+	c.planNetworkModeCascade(plan)
+
+	if _, recreated := plan.recreatedNodeSet["sidecar"]; !recreated {
+		t.Fatal("expected sidecar sharing the recreated node's netns to be recreated too")
+	}
+	if _, restarting := plan.restartNodeSet["sidecar"]; restarting {
+		t.Fatal("expected sidecar to be removed from restartNodeSet once forced to recreate")
+	}
+	if _, hasReason := plan.nodeChangeReasons["sidecar"]; !hasReason {
+		t.Fatal("expected a change reason to be recorded for the cascaded recreate")
+	}
+}
+
+func TestPlanNetworkModeCascadeIsTransitive(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	mid := clabmocksmocknodes.NewMockNode(ctrl)
+	leaf := clabmocksmocknodes.NewMockNode(ctrl)
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{ShortName: "target"}).AnyTimes()
+	mid.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "mid",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+	leaf.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "leaf",
+		NetworkMode: "container:mid",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{
+			"target": target,
+			"mid":    mid,
+			"leaf":   leaf,
+		},
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.recreatedNodeSet["target"] = struct{}{}
+
+	c.planNetworkModeCascade(plan)
+
+	if _, recreated := plan.recreatedNodeSet["leaf"]; !recreated {
+		t.Fatal("expected recreate to cascade transitively through a chain of shared namespaces")
+	}
+}
+
+func TestPlanNetworkModeCascadeIgnoresAddedNodes(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{ShortName: "target"}).AnyTimes()
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{
+			"target":  target,
+			"sidecar": sidecar,
+		},
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.recreatedNodeSet["target"] = struct{}{}
+	plan.addedNodeSet["sidecar"] = struct{}{}
+
+	c.planNetworkModeCascade(plan)
+
+	if _, recreated := plan.recreatedNodeSet["sidecar"]; recreated {
+		t.Fatal("a newly added sidecar should deploy fresh, not be marked recreated")
+	}
+}
+
+func TestCheckApplyNetworkModeTargetsRejectsDeletedTarget(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:worker1",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{"sidecar": sidecar},
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.deletedNodeSet["worker1"] = struct{}{}
+
+	err := c.checkApplyNetworkModeTargets(plan)
+	if err == nil {
+		t.Fatal("expected error when a network-mode target is deleted but the dependent stays")
+	}
+	if !strings.Contains(err.Error(), "sidecar") || !strings.Contains(err.Error(), "worker1") {
+		t.Fatalf("error = %v, want it to name both nodes", err)
+	}
+}
+
+func TestCheckApplyNetworkModeTargetsAllowsUnrelatedDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:worker1",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{"sidecar": sidecar},
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.deletedNodeSet["unrelated"] = struct{}{}
+
+	if err := c.checkApplyNetworkModeTargets(plan); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPlanNodeReconciliationRejectsExternalRecreate(t *testing.T) {
 	t.Parallel()
 

--- a/core/apply_test.go
+++ b/core/apply_test.go
@@ -960,6 +960,18 @@ func TestCheckApplyNetworkModeTargetsRejectsDeletedTarget(t *testing.T) {
 	}
 }
 
+func TestCheckApplyNetworkModeTargetsNilPlan(t *testing.T) {
+	t.Parallel()
+	if err := (&CLab{}).checkApplyNetworkModeTargets(nil); err != nil {
+		t.Fatalf("unexpected error for nil plan: %v", err)
+	}
+}
+
+func TestPlanNetworkModeCascadeNilPlan(t *testing.T) {
+	t.Parallel()
+	(&CLab{}).planNetworkModeCascade(nil) // must not panic
+}
+
 func TestCheckApplyNetworkModeTargetsAllowsUnrelatedDeletion(t *testing.T) {
 	t.Parallel()
 

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -518,10 +518,28 @@ func (c *CLab) DeployNodes(
 		}()
 	}
 
+	// Feed each node from its own goroutine so that waiting for a
+	// network-mode: container:<target> target to be running never consumes
+	// a worker slot. Blocking inside the worker loop above would deadlock
+	// whenever a dependent node is dequeued before its target, since the
+	// same (limited) pool of workers is what would need to be free to
+	// create that target.
+	var feedWg sync.WaitGroup
 	for _, nodeName := range nodeNames {
-		input <- nodeName
+		feedWg.Add(1)
+		go func(nodeName string) {
+			defer feedWg.Done()
+			if err := c.waitForApplyNetworkModeTarget(ctx, nodeName); err != nil {
+				errCh <- err
+				return
+			}
+			input <- nodeName
+		}(nodeName)
 	}
-	close(input)
+	go func() {
+		feedWg.Wait()
+		close(input)
+	}()
 
 	var errs []error
 	for range nodeNames {
@@ -535,6 +553,36 @@ func (c *CLab) DeployNodes(
 	}
 
 	return nil
+}
+
+// waitForApplyNetworkModeTarget waits until a node's network-mode:
+// container:<target> target is running, so apply's incremental deploy never
+// races a newly created or recreated target against its dependent. The
+// target may be a node in this same apply call (added or recreated
+// alongside the dependent) or, like fresh deploy, an external container not
+// managed by this topology.
+func (c *CLab) waitForApplyNetworkModeTarget(ctx context.Context, nodeName string) error {
+	node, exists := c.Nodes[nodeName]
+	if !exists {
+		return nil
+	}
+
+	target := networkModeContainerTarget(node.Config().NetworkMode)
+	if target == "" {
+		return nil
+	}
+
+	targetNode, internal := c.Nodes[target]
+	if !internal {
+		return c.waitForExternalNodeDependencies(ctx, nodeName)
+	}
+
+	runtime := c.globalRuntime()
+	if runtime == nil {
+		return fmt.Errorf("container runtime is not initialized")
+	}
+
+	return clabruntime.WaitForContainerRunning(ctx, runtime, targetNode.Config().LongName, nodeName)
 }
 
 func (c *CLab) deployNode(ctx context.Context, node clabnodes.Node) error {

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -499,7 +499,9 @@ func (c *CLab) DeployNodes(
 // deployApplyNodes schedules starts and creates together: a new sidecar can
 // depend on a stopped target, and a stopped node can depend on a new target.
 func (c *CLab) deployApplyNodes(ctx context.Context, plan *applyPlan, maxWorkers uint) error {
-	nodeNames := sortedStringSet(unionStringSets(plan.addedNodeSet, plan.recreatedNodeSet, plan.startNodeSet))
+	nodeNames := sortedStringSet(
+		unionStringSets(plan.addedNodeSet, plan.recreatedNodeSet, plan.startNodeSet),
+	)
 	return c.deployNodes(ctx, nodeNames, maxWorkers, plan.startNodeSet)
 }
 
@@ -516,14 +518,21 @@ func (c *CLab) deployNodes(
 	if maxWorkers == 0 || int(maxWorkers) > len(nodeNames) {
 		maxWorkers = uint(len(nodeNames))
 	}
-	for _, nodeName := range nodeNames {
-		if _, exists := c.Nodes[nodeName]; !exists {
-			return fmt.Errorf("node %q not found", nodeName)
-		}
+	if _, err := c.networkModeNodeOrder(nodeNames); err != nil {
+		return err
 	}
 
 	input := make(chan string)
 	errCh := make(chan error, len(nodeNames))
+	completed := make(map[string]*nodeDeployCompletion, len(nodeNames))
+	for _, name := range nodeNames {
+		completed[name] = &nodeDeployCompletion{done: make(chan struct{})}
+	}
+	finish := func(name string, err error) {
+		completed[name].err = err
+		close(completed[name].done)
+		errCh <- err
+	}
 
 	for range maxWorkers {
 		go func() {
@@ -534,31 +543,31 @@ func (c *CLab) deployNodes(
 					if err != nil {
 						err = fmt.Errorf("failed starting node %q: %w", nodeName, err)
 					}
-					errCh <- err
+					finish(nodeName, err)
 					continue
 				}
 				log.Info("Creating node", "node", nodeName)
-				errCh <- c.deployNode(ctx, c.Nodes[nodeName])
+				finish(nodeName, c.deployNode(ctx, c.Nodes[nodeName]))
 			}
 		}()
 	}
 
-	// Feed each node from its own goroutine so that waiting for a
-	// network-mode: container:<target> target to be running never consumes
-	// a worker slot. Blocking inside the worker loop above would deadlock
-	// whenever a dependent node is dequeued before its target, since the
-	// same (limited) pool of workers is what would need to be free to
-	// create that target.
+	// Wait outside the worker pool. Targets in this operation signal completion
+	// directly, avoiding runtime polling and propagating failures to dependents.
 	var feedWg sync.WaitGroup
 	for _, nodeName := range nodeNames {
 		feedWg.Add(1)
 		go func(nodeName string) {
 			defer feedWg.Done()
-			if err := c.waitForApplyNetworkModeTarget(ctx, nodeName); err != nil {
-				errCh <- err
+			if err := c.waitForNodeDeployTarget(ctx, nodeName, completed); err != nil {
+				finish(nodeName, err)
 				return
 			}
-			input <- nodeName
+			select {
+			case input <- nodeName:
+			case <-ctx.Done():
+				finish(nodeName, ctx.Err())
+			}
 		}(nodeName)
 	}
 	go func() {
@@ -578,6 +587,40 @@ func (c *CLab) deployNodes(
 	}
 
 	return nil
+}
+
+type nodeDeployCompletion struct {
+	done chan struct{}
+	// Closing done publishes err to dependent goroutines.
+	err error
+}
+
+func (c *CLab) waitForNodeDeployTarget(
+	ctx context.Context,
+	name string,
+	completed map[string]*nodeDeployCompletion,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	target := networkModeContainerTarget(c.Nodes[name].Config().NetworkMode)
+	if completion, selected := completed[target]; selected {
+		select {
+		case <-completion.done:
+			if completion.err != nil {
+				return fmt.Errorf(
+					"node %q depends on failed node %q: %w",
+					name,
+					target,
+					completion.err,
+				)
+			}
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return c.waitForApplyNetworkModeTarget(ctx, name)
 }
 
 // waitForApplyNetworkModeTarget waits until a node's network-mode:

--- a/core/deploy.go
+++ b/core/deploy.go
@@ -493,6 +493,22 @@ func (c *CLab) DeployNodes(
 	nodeNames []string,
 	maxWorkers uint,
 ) error {
+	return c.deployNodes(ctx, nodeNames, maxWorkers, nil)
+}
+
+// deployApplyNodes schedules starts and creates together: a new sidecar can
+// depend on a stopped target, and a stopped node can depend on a new target.
+func (c *CLab) deployApplyNodes(ctx context.Context, plan *applyPlan, maxWorkers uint) error {
+	nodeNames := sortedStringSet(unionStringSets(plan.addedNodeSet, plan.recreatedNodeSet, plan.startNodeSet))
+	return c.deployNodes(ctx, nodeNames, maxWorkers, plan.startNodeSet)
+}
+
+func (c *CLab) deployNodes(
+	ctx context.Context,
+	nodeNames []string,
+	maxWorkers uint,
+	startNodeSet map[string]struct{},
+) error {
 	if len(nodeNames) == 0 {
 		return nil
 	}
@@ -512,6 +528,15 @@ func (c *CLab) DeployNodes(
 	for range maxWorkers {
 		go func() {
 			for nodeName := range input {
+				if _, start := startNodeSet[nodeName]; start {
+					log.Info("Starting stopped node", "node", nodeName)
+					err := c.Nodes[nodeName].Start(ctx)
+					if err != nil {
+						err = fmt.Errorf("failed starting node %q: %w", nodeName, err)
+					}
+					errCh <- err
+					continue
+				}
 				log.Info("Creating node", "node", nodeName)
 				errCh <- c.deployNode(ctx, c.Nodes[nodeName])
 			}

--- a/core/deploy_test.go
+++ b/core/deploy_test.go
@@ -12,10 +12,18 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	clabcert "github.com/srl-labs/containerlab/cert"
+	clabmocksmocknodes "github.com/srl-labs/containerlab/mocks/mocknodes"
+	clabmocksmockruntime "github.com/srl-labs/containerlab/mocks/mockruntime"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+	clabruntimedocker "github.com/srl-labs/containerlab/runtime/docker"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	"go.uber.org/mock/gomock"
 )
 
 func TestWaitForNodeDeployErrorPrecedence(t *testing.T) {
@@ -92,6 +100,153 @@ func TestCheckReconcileDeployOptionsAllowsTopologyManagementNetwork(t *testing.T
 
 	if err := c.checkReconcileDeployOptions(&DeployOptions{}); err != nil {
 		t.Fatalf("topology management settings must not be treated as overrides: %v", err)
+	}
+}
+
+func TestWaitForApplyNetworkModeTargetNoTarget(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	node := clabmocksmocknodes.NewMockNode(ctrl)
+	node.EXPECT().Config().Return(&clabtypes.NodeConfig{ShortName: "n1"}).AnyTimes()
+
+	c := &CLab{Nodes: map[string]clabnodes.Node{"n1": node}}
+
+	if err := c.waitForApplyNetworkModeTarget(context.Background(), "n1"); err != nil {
+		t.Fatalf("unexpected error for node without a network-mode target: %v", err)
+	}
+}
+
+func TestWaitForApplyNetworkModeTargetInternalTargetAlreadyRunning(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName: "target",
+		LongName:  "clab-lab-target",
+	}).AnyTimes()
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+	mockRuntime.EXPECT().GetContainerStatus(gomock.Any(), "clab-lab-target").
+		Return(clabruntime.Running)
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: mockRuntime,
+		},
+		globalRuntimeName: clabruntimedocker.RuntimeName,
+	}
+
+	if err := c.waitForApplyNetworkModeTarget(context.Background(), "sidecar"); err != nil {
+		t.Fatalf("unexpected error waiting for an already-running target: %v", err)
+	}
+}
+
+func TestWaitForApplyNetworkModeTargetExternalTargetDelegates(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:not-in-topology",
+	}).AnyTimes()
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+	mockRuntime.EXPECT().GetContainerStatus(gomock.Any(), "not-in-topology").
+		Return(clabruntime.Running)
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{"sidecar": sidecar},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: mockRuntime,
+		},
+		globalRuntimeName: clabruntimedocker.RuntimeName,
+	}
+
+	if err := c.waitForApplyNetworkModeTarget(context.Background(), "sidecar"); err != nil {
+		t.Fatalf(
+			"expected external target not managed by this topology to be waited on like fresh "+
+				"deploy does, got: %v",
+			err,
+		)
+	}
+}
+
+// TestDeployNodesWaitsForNetworkModeTargetWithSingleWorker locks in the fix
+// for a real deadlock: with a single worker and the dependent node queued
+// before its network-mode target, waiting for the target inside the
+// worker's own loop would block the only worker able to create that
+// target. The wait must happen outside the worker pool.
+func TestDeployNodesWaitsForNetworkModeTargetWithSingleWorker(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+
+	var targetDeployed atomic.Bool
+
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName: "target",
+		LongName:  "clab-lab-target",
+	}).AnyTimes()
+	target.EXPECT().GetShortName().Return("target").AnyTimes()
+	target.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).Return(nil)
+	target.EXPECT().Deploy(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *clabnodes.DeployParams) error {
+			targetDeployed.Store(true)
+			return nil
+		},
+	)
+	target.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+	sidecar.EXPECT().GetShortName().Return("sidecar").AnyTimes()
+	sidecar.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *clabnodes.PreDeployParams) error {
+			if !targetDeployed.Load() {
+				t.Error("sidecar was deployed before its network-mode target")
+			}
+			return nil
+		},
+	)
+	sidecar.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
+	sidecar.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+
+	mockRuntime.EXPECT().GetContainerStatus(gomock.Any(), "clab-lab-target").DoAndReturn(
+		func(context.Context, string) clabruntime.ContainerStatus {
+			if targetDeployed.Load() {
+				return clabruntime.Running
+			}
+			return clabruntime.NotFound
+		},
+	).AnyTimes()
+
+	c := &CLab{
+		Config: &Config{Name: "lab"},
+		Nodes:  map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: mockRuntime,
+		},
+		globalRuntimeName: clabruntimedocker.RuntimeName,
+	}
+
+	// The dependent is listed before its target on purpose, with exactly
+	// one worker, so a naive in-worker wait would deadlock here.
+	err := c.DeployNodes(context.Background(), []string{"sidecar", "target"}, 1)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/core/deploy_test.go
+++ b/core/deploy_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,6 +256,72 @@ func TestDeployNodesEmptyNodeNames(t *testing.T) {
 
 	if err := (&CLab{}).DeployNodes(context.Background(), nil, 0); err != nil {
 		t.Fatalf("expected nil for empty node list, got: %v", err)
+	}
+}
+
+func TestDeployApplyNodesStartsNamespaceTarget(t *testing.T) {
+	t.Parallel()
+	for _, startSidecar := range []bool{false, true} {
+		t.Run(fmt.Sprintf("start-sidecar=%v", startSidecar), func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			target := clabmocksmocknodes.NewMockNode(ctrl)
+			sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+			runtime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+			var running atomic.Bool
+			target.EXPECT().Config().Return(&clabtypes.NodeConfig{LongName: "clab-lab-target"}).AnyTimes()
+			target.EXPECT().Start(gomock.Any()).DoAndReturn(func(context.Context) error {
+				running.Store(true)
+				return nil
+			})
+			sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{NetworkMode: "container:target"}).AnyTimes()
+			if startSidecar {
+				sidecar.EXPECT().Start(gomock.Any()).DoAndReturn(func(context.Context) error {
+					if !running.Load() {
+						t.Error("sidecar started before its target")
+					}
+					return nil
+				})
+			} else {
+				sidecar.EXPECT().GetShortName().Return("sidecar")
+				sidecar.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(context.Context, *clabnodes.PreDeployParams) error {
+						if !running.Load() {
+							t.Error("sidecar created before its target started")
+						}
+						return nil
+					},
+				)
+				sidecar.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
+				sidecar.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+			}
+			runtime.EXPECT().GetContainerStatus(gomock.Any(), "clab-lab-target").DoAndReturn(
+				func(context.Context, string) clabruntime.ContainerStatus {
+					if running.Load() {
+						return clabruntime.Running
+					}
+					return clabruntime.Stopped
+				},
+			).AnyTimes()
+			c := &CLab{
+				Config:            &Config{Name: "lab"},
+				Nodes:             map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
+				Runtimes:          map[string]clabruntime.ContainerRuntime{clabruntimedocker.RuntimeName: runtime},
+				globalRuntimeName: clabruntimedocker.RuntimeName,
+			}
+			plan := newApplyPlan(nil, nil)
+			plan.startNodeSet["target"] = struct{}{}
+			if startSidecar {
+				plan.startNodeSet["sidecar"] = struct{}{}
+			} else {
+				plan.addedNodeSet["sidecar"] = struct{}{}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := c.deployApplyNodes(ctx, plan, 1); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/core/deploy_test.go
+++ b/core/deploy_test.go
@@ -250,6 +250,88 @@ func TestDeployNodesWaitsForNetworkModeTargetWithSingleWorker(t *testing.T) {
 	}
 }
 
+func TestDeployNodesEmptyNodeNames(t *testing.T) {
+	t.Parallel()
+
+	if err := (&CLab{}).DeployNodes(context.Background(), nil, 0); err != nil {
+		t.Fatalf("expected nil for empty node list, got: %v", err)
+	}
+}
+
+func TestDeployNodesUnknownNode(t *testing.T) {
+	t.Parallel()
+
+	c := &CLab{Nodes: map[string]clabnodes.Node{}}
+	err := c.DeployNodes(context.Background(), []string{"ghost"}, 1)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestDeployNodesReturnsErrorWhenWaitFails(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	mockRuntime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
+
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:external-target",
+	}).AnyTimes()
+
+	c := &CLab{
+		Nodes: map[string]clabnodes.Node{"sidecar": sidecar},
+		Runtimes: map[string]clabruntime.ContainerRuntime{
+			clabruntimedocker.RuntimeName: mockRuntime,
+		},
+		globalRuntimeName: clabruntimedocker.RuntimeName,
+	}
+
+	// Pre-cancel the context so WaitForContainerRunning returns immediately with an error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.DeployNodes(ctx, []string{"sidecar"}, 1)
+	if err == nil {
+		t.Fatal("expected error when context is canceled while waiting for network-mode target")
+	}
+}
+
+func TestWaitForApplyNetworkModeTargetUnknownNode(t *testing.T) {
+	t.Parallel()
+
+	c := &CLab{Nodes: map[string]clabnodes.Node{}}
+	if err := c.waitForApplyNetworkModeTarget(context.Background(), "nonexistent"); err != nil {
+		t.Fatalf("expected nil for node not in c.Nodes, got: %v", err)
+	}
+}
+
+func TestWaitForApplyNetworkModeTargetNilRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName: "target",
+		LongName:  "clab-lab-target",
+	}).AnyTimes()
+	sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+		ShortName:   "sidecar",
+		NetworkMode: "container:target",
+	}).AnyTimes()
+
+	// No runtimes configured → globalRuntime() returns nil.
+	c := &CLab{Nodes: map[string]clabnodes.Node{"target": target, "sidecar": sidecar}}
+
+	err := c.waitForApplyNetworkModeTarget(context.Background(), "sidecar")
+	if err == nil || !strings.Contains(err.Error(), "container runtime is not initialized") {
+		t.Fatalf("expected runtime-not-initialized error, got: %v", err)
+	}
+}
+
 func TestCertificateAuthoritySetupUsesEnvironmentCAWithoutSettings(t *testing.T) {
 	tempDir := t.TempDir()
 	topoFile := filepath.Join(tempDir, "topology.clab.yml")

--- a/core/deploy_test.go
+++ b/core/deploy_test.go
@@ -225,15 +225,6 @@ func TestDeployNodesWaitsForNetworkModeTargetWithSingleWorker(t *testing.T) {
 	sidecar.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
 	sidecar.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
 
-	mockRuntime.EXPECT().GetContainerStatus(gomock.Any(), "clab-lab-target").DoAndReturn(
-		func(context.Context, string) clabruntime.ContainerStatus {
-			if targetDeployed.Load() {
-				return clabruntime.Running
-			}
-			return clabruntime.NotFound
-		},
-	).AnyTimes()
-
 	c := &CLab{
 		Config: &Config{Name: "lab"},
 		Nodes:  map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
@@ -245,7 +236,9 @@ func TestDeployNodesWaitsForNetworkModeTargetWithSingleWorker(t *testing.T) {
 
 	// The dependent is listed before its target on purpose, with exactly
 	// one worker, so a naive in-worker wait would deadlock here.
-	err := c.DeployNodes(context.Background(), []string{"sidecar", "target"}, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := c.DeployNodes(ctx, []string{"sidecar", "target"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,6 +252,76 @@ func TestDeployNodesEmptyNodeNames(t *testing.T) {
 	}
 }
 
+func TestDeployNodesPropagatesTargetFailure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	target := clabmocksmocknodes.NewMockNode(ctrl)
+	sidecar := clabmocksmocknodes.NewMockNode(ctrl)
+	target.EXPECT().Config().Return(&clabtypes.NodeConfig{}).AnyTimes()
+	target.EXPECT().GetShortName().Return("target")
+	failure := errors.New("target pre-deploy failed")
+	target.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).Return(failure)
+	sidecar.EXPECT().
+		Config().
+		Return(&clabtypes.NodeConfig{NetworkMode: "container:target"}).
+		AnyTimes()
+	c := &CLab{
+		Config: &Config{Name: "lab"},
+		Nodes:  map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := c.DeployNodes(ctx, []string{"sidecar", "target"}, 1)
+	if !errors.Is(err, failure) || errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want the target failure without waiting for a timeout", err)
+	}
+	if !strings.Contains(err.Error(), `node "sidecar" depends on failed node "target"`) {
+		t.Fatalf("error must identify the blocked dependent: %v", err)
+	}
+}
+
+func TestDeployNodesUnblocksNamespaceChainWithoutPolling(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	c := &CLab{Config: &Config{Name: "lab"}, Nodes: map[string]clabnodes.Node{}}
+	var calls []any
+	for _, name := range []string{"target", "sidecar", "leaf"} {
+		node := clabmocksmocknodes.NewMockNode(ctrl)
+		cfg := &clabtypes.NodeConfig{ShortName: name}
+		switch name {
+		case "sidecar":
+			cfg.NetworkMode = "container:target"
+		case "leaf":
+			cfg.NetworkMode = "container:sidecar"
+		}
+		node.EXPECT().Config().Return(cfg).AnyTimes()
+		node.EXPECT().GetShortName().Return(name)
+		calls = append(calls, node.EXPECT().PreDeploy(gomock.Any(), gomock.Any()).Return(nil))
+		node.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
+		node.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
+		c.Nodes[name] = node
+	}
+	gomock.InOrder(calls...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	// No runtime is configured: internal task dependencies must use completion
+	// signals, even with a chain submitted in reverse order and only one worker.
+	if err := c.DeployNodes(ctx, []string{"leaf", "sidecar", "target"}, 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeployNodesRejectsNamespaceCycleBeforeDeployment(t *testing.T) {
+	t.Parallel()
+	c := &CLab{Nodes: map[string]clabnodes.Node{
+		"a": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:b"}},
+		"b": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:a"}},
+	}}
+	if err := c.DeployNodes(context.Background(), []string{"a", "b"}, 1); err == nil {
+		t.Fatal("expected cyclic dependency error")
+	}
+}
+
 func TestDeployApplyNodesStartsNamespaceTarget(t *testing.T) {
 	t.Parallel()
 	for _, startSidecar := range []bool{false, true} {
@@ -269,12 +332,16 @@ func TestDeployApplyNodesStartsNamespaceTarget(t *testing.T) {
 			sidecar := clabmocksmocknodes.NewMockNode(ctrl)
 			runtime := clabmocksmockruntime.NewMockContainerRuntime(ctrl)
 			var running atomic.Bool
-			target.EXPECT().Config().Return(&clabtypes.NodeConfig{LongName: "clab-lab-target"}).AnyTimes()
+			target.EXPECT().Config().Return(&clabtypes.NodeConfig{
+				LongName: "clab-lab-target",
+			}).AnyTimes()
 			target.EXPECT().Start(gomock.Any()).DoAndReturn(func(context.Context) error {
 				running.Store(true)
 				return nil
 			})
-			sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{NetworkMode: "container:target"}).AnyTimes()
+			sidecar.EXPECT().Config().Return(&clabtypes.NodeConfig{
+				NetworkMode: "container:target",
+			}).AnyTimes()
 			if startSidecar {
 				sidecar.EXPECT().Start(gomock.Any()).DoAndReturn(func(context.Context) error {
 					if !running.Load() {
@@ -295,18 +362,13 @@ func TestDeployApplyNodesStartsNamespaceTarget(t *testing.T) {
 				sidecar.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
 				sidecar.EXPECT().UpdateConfigWithRuntimeInfo(gomock.Any()).Return(nil)
 			}
-			runtime.EXPECT().GetContainerStatus(gomock.Any(), "clab-lab-target").DoAndReturn(
-				func(context.Context, string) clabruntime.ContainerStatus {
-					if running.Load() {
-						return clabruntime.Running
-					}
-					return clabruntime.Stopped
-				},
-			).AnyTimes()
+
 			c := &CLab{
-				Config:            &Config{Name: "lab"},
-				Nodes:             map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
-				Runtimes:          map[string]clabruntime.ContainerRuntime{clabruntimedocker.RuntimeName: runtime},
+				Config: &Config{Name: "lab"},
+				Nodes:  map[string]clabnodes.Node{"target": target, "sidecar": sidecar},
+				Runtimes: map[string]clabruntime.ContainerRuntime{
+					clabruntimedocker.RuntimeName: runtime,
+				},
 				globalRuntimeName: clabruntimedocker.RuntimeName,
 			}
 			plan := newApplyPlan(nil, nil)

--- a/core/lifecycle.go
+++ b/core/lifecycle.go
@@ -88,7 +88,10 @@ func (c *CLab) restartApplyNodes(
 	ctx context.Context,
 	nodeSet map[string]struct{},
 ) error {
-	nodeNames := sortedStringSet(nodeSet)
+	nodeNames, err := c.networkModeNodeOrder(sortedStringSet(nodeSet))
+	if err != nil {
+		return err
+	}
 
 	for _, nodeName := range nodeNames {
 		node := c.Nodes[nodeName]

--- a/core/lifecycle.go
+++ b/core/lifecycle.go
@@ -69,21 +69,6 @@ func (c *CLab) restoreRecreatedNodes(ctx context.Context, plan *applyPlan) error
 	return nil
 }
 
-func (c *CLab) startStoppedNodes(ctx context.Context, plan *applyPlan) error {
-	for _, nodeName := range sortedStringSet(plan.startNodeSet) {
-		node, exists := c.Nodes[nodeName]
-		if !exists {
-			continue
-		}
-		log.Info("Starting stopped node", "node", nodeName)
-		if err := node.Start(ctx); err != nil {
-			return fmt.Errorf("failed starting node %q: %w", nodeName, err)
-		}
-	}
-
-	return nil
-}
-
 func (c *CLab) restartApplyNodes(
 	ctx context.Context,
 	nodeSet map[string]struct{},

--- a/core/network_mode.go
+++ b/core/network_mode.go
@@ -45,11 +45,15 @@ func (c *CLab) planNetworkModeRestarts(plan *applyPlan) error {
 		}
 		target := networkModeContainerTarget(c.Nodes[name].Config().NetworkMode)
 		_, earlyRestart := plan.restartNodeSet[target]
+		_, starting := plan.startNodeSet[target]
 		_, lateRestart := plan.linkRestartNodeSet[target]
-		if !earlyRestart && !lateRestart {
+		if !earlyRestart && !starting && !lateRestart {
 			continue
 		}
 		if !lateRestart {
+			if _, starting := plan.startNodeSet[name]; starting {
+				continue
+			}
 			if _, added := plan.addedNodeSet[name]; added {
 				continue
 			}

--- a/core/network_mode.go
+++ b/core/network_mode.go
@@ -1,0 +1,68 @@
+package core
+
+import "fmt"
+
+// networkModeNodeOrder orders selected nodes before their namespace dependents.
+// References outside the selection are handled by the caller.
+func (c *CLab) networkModeNodeOrder(nodeNames []string) ([]string, error) {
+	selected := make(map[string]struct{}, len(nodeNames))
+	for _, name := range nodeNames {
+		if _, exists := c.Nodes[name]; !exists {
+			return nil, fmt.Errorf("node %q not found", name)
+		}
+		selected[name] = struct{}{}
+	}
+	dependents := make(map[string][]string)
+	order := make([]string, 0, len(nodeNames))
+	for _, name := range nodeNames {
+		target := networkModeContainerTarget(c.Nodes[name].Config().NetworkMode)
+		if _, internal := selected[target]; internal {
+			dependents[target] = append(dependents[target], name)
+		} else {
+			order = append(order, name)
+		}
+	}
+	for i := 0; i < len(order); i++ {
+		order = append(order, dependents[order[i]]...)
+	}
+	if len(order) != len(nodeNames) {
+		return nil, fmt.Errorf("cyclic network-mode container dependencies")
+	}
+	return order, nil
+}
+
+// planNetworkModeRestarts rebinds dependents after their target's namespace
+// changes. Link restarts happen after deployment, so even a freshly deployed
+// dependent must restart after a target that is restarted for a link change.
+func (c *CLab) planNetworkModeRestarts(plan *applyPlan) error {
+	order, err := c.networkModeNodeOrder(sortedNodeNames(c.Nodes))
+	if err != nil {
+		return err
+	}
+	for _, name := range order {
+		if _, restarting := plan.linkRestartNodeSet[name]; restarting {
+			continue
+		}
+		target := networkModeContainerTarget(c.Nodes[name].Config().NetworkMode)
+		_, earlyRestart := plan.restartNodeSet[target]
+		_, lateRestart := plan.linkRestartNodeSet[target]
+		if !earlyRestart && !lateRestart {
+			continue
+		}
+		if !lateRestart {
+			if _, added := plan.addedNodeSet[name]; added {
+				continue
+			}
+			if _, recreated := plan.recreatedNodeSet[name]; recreated {
+				continue
+			}
+		}
+		plan.linkRestartNodeSet[name] = struct{}{}
+		reason := fmt.Sprintf("network-mode target %q restarted", target)
+		if previous := plan.nodeChangeReasons[name]; previous != "" {
+			reason = previous + "; " + reason
+		}
+		plan.nodeChangeReasons[name] = reason
+	}
+	return nil
+}

--- a/core/network_mode.go
+++ b/core/network_mode.go
@@ -10,6 +10,9 @@ func (c *CLab) networkModeNodeOrder(nodeNames []string) ([]string, error) {
 		if _, exists := c.Nodes[name]; !exists {
 			return nil, fmt.Errorf("node %q not found", name)
 		}
+		if _, duplicate := selected[name]; duplicate {
+			return nil, fmt.Errorf("node %q selected more than once", name)
+		}
 		selected[name] = struct{}{}
 	}
 	dependents := make(map[string][]string)

--- a/core/network_mode_test.go
+++ b/core/network_mode_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	clablinks "github.com/srl-labs/containerlab/links"
@@ -11,6 +12,95 @@ import (
 	clabtypes "github.com/srl-labs/containerlab/types"
 	"go.uber.org/mock/gomock"
 )
+
+type networkModeTestNode struct {
+	clabnodes.Node
+	cfg *clabtypes.NodeConfig
+}
+
+func (n *networkModeTestNode) Config() *clabtypes.NodeConfig { return n.cfg }
+
+func TestPlanApplyCascadesLinkRestart(t *testing.T) {
+	t.Parallel()
+	c, current := newNetworkModePlanTestLab(t, clabruntime.Running, clabnodes.LinkApplyModeRestart)
+	plan, err := c.planApply(context.Background(), current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sortedStringSet(plan.linkRestartNodeSet); !slices.Equal(got, []string{"leaf", "sidecar", "target"}) {
+		t.Fatalf("restarted nodes = %v, want target and both dependents", got)
+	}
+	if len(plan.recreatedNodeSet) != 0 {
+		t.Fatalf("restart must preserve container identities: %v", plan.recreatedNodeSet)
+	}
+}
+
+func TestPlanNetworkModeRestartsForNewDependents(t *testing.T) {
+	t.Parallel()
+	for _, late := range []bool{false, true} {
+		for _, recreated := range []bool{false, true} {
+			c := &CLab{Nodes: map[string]clabnodes.Node{
+				"target":  &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
+				"sidecar": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"}},
+			}}
+			plan := newApplyPlan(nil, nil)
+			if late {
+				plan.linkRestartNodeSet["target"] = struct{}{}
+			} else {
+				plan.restartNodeSet["target"] = struct{}{}
+			}
+			if recreated {
+				plan.recreatedNodeSet["sidecar"] = struct{}{}
+			} else {
+				plan.addedNodeSet["sidecar"] = struct{}{}
+			}
+			if err := c.planNetworkModeRestarts(plan); err != nil {
+				t.Fatal(err)
+			}
+			if _, restart := plan.linkRestartNodeSet["sidecar"]; restart != late {
+				t.Fatalf("late=%v recreated=%v: sidecar restart=%v", late, recreated, restart)
+			}
+		}
+	}
+}
+
+func TestRestartApplyNodesOrdersNamespaceDependencies(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	c := &CLab{Nodes: map[string]clabnodes.Node{}}
+	nodeSet := map[string]struct{}{}
+	var calls []any
+	for _, name := range []string{"target", "sidecar", "leaf"} {
+		node := clabmocksmocknodes.NewMockNode(ctrl)
+		cfg := &clabtypes.NodeConfig{ShortName: name}
+		switch name {
+		case "sidecar":
+			cfg.NetworkMode = "container:target"
+		case "leaf":
+			cfg.NetworkMode = "container:sidecar"
+		}
+		node.EXPECT().Config().Return(cfg).AnyTimes()
+		calls = append(calls, node.EXPECT().Stop(gomock.Any()).Return(nil), node.EXPECT().Start(gomock.Any()).Return(nil))
+		node.EXPECT().GetContainerStatus(gomock.Any()).Return(clabruntime.Running)
+		c.Nodes[name] = node
+		nodeSet[name] = struct{}{}
+	}
+	gomock.InOrder(calls...)
+	if err := c.restartApplyNodes(context.Background(), nodeSet); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNetworkModeNodeOrderRejectsCycles(t *testing.T) {
+	t.Parallel()
+	c := &CLab{Nodes: map[string]clabnodes.Node{
+		"a": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:b"}},
+		"b": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:a"}},
+	}}
+	if _, err := c.networkModeNodeOrder([]string{"a", "b"}); err == nil {
+		t.Fatal("expected cyclic dependency error")
+	}
+}
 
 func TestPlanApplyCascadesLinkRecreate(t *testing.T) {
 	t.Parallel()

--- a/core/network_mode_test.go
+++ b/core/network_mode_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	clablinks "github.com/srl-labs/containerlab/links"
+	clabmocksmocknodes "github.com/srl-labs/containerlab/mocks/mocknodes"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPlanApplyCascadesLinkRecreate(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []clabruntime.ContainerStatus{clabruntime.Running, clabruntime.Stopped} {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			c, current := newNetworkModePlanTestLab(t, status, clabnodes.LinkApplyModeRecreate)
+			plan, err := c.planApply(context.Background(), current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"target", "sidecar", "leaf"} {
+				if _, ok := plan.recreatedNodeSet[name]; !ok {
+					t.Errorf("node %q must be recreated after the target's link change", name)
+				}
+				if _, ok := plan.startNodeSet[name]; ok {
+					t.Errorf("recreated node %q must not also be started", name)
+				}
+				wantParked := name == "target" || status == clabruntime.Running
+				if _, parked := plan.parkedNodeSet[name]; parked != wantParked {
+					t.Errorf("node %q parked = %v, want %v", name, parked, wantParked)
+				}
+			}
+		})
+	}
+}
+
+// newNetworkModePlanTestLab models a new link on a running target and a chain
+// of existing namespace-sharing dependents. Interface discovery is mocked so
+// the complete planner can run without creating real network namespaces.
+func newNetworkModePlanTestLab(
+	t *testing.T,
+	dependentStatus clabruntime.ContainerStatus,
+	mode clabnodes.LinkApplyMode,
+) (*CLab, map[string]*runtimeNodeGroup) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	paths := &clabtypes.TopoPaths{}
+	if err := paths.SetLabDir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	c := &CLab{
+		Config:    &Config{Topology: clabtypes.NewTopology()},
+		TopoPaths: paths,
+		Nodes:     map[string]clabnodes.Node{},
+		Links:     map[int]clablinks.Link{},
+	}
+	current := map[string]*runtimeNodeGroup{}
+	for name, target := range map[string]string{"target": "", "sidecar": "target", "leaf": "sidecar"} {
+		cfg := &clabtypes.NodeConfig{ShortName: name, LongName: "clab-netmode-test-" + name}
+		status := clabruntime.Running
+		if target != "" {
+			cfg.NetworkMode = "container:" + target
+			status = dependentStatus
+		}
+		node := clabmocksmocknodes.NewMockNode(ctrl)
+		node.EXPECT().Config().Return(cfg).AnyTimes()
+		node.EXPECT().GetShortName().Return(name).AnyTimes()
+		node.EXPECT().GetContainerStatus(gomock.Any()).Return(status).AnyTimes()
+		node.EXPECT().ExecFunction(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		node.EXPECT().ComputeDiff(gomock.Any(), gomock.Any()).Return(&clabtypes.TopologyDiff{})
+		node.EXPECT().GetReconcilePlan(gomock.Any(), gomock.Any()).Return(&clabnodes.ReconcileResult{}, nil)
+		if name == "target" {
+			node.EXPECT().LinkApplyMode(gomock.Any()).Return(mode)
+		}
+		c.Nodes[name] = node
+		c.Config.Topology.Nodes[name] = &clabtypes.NodeDefinition{Kind: "linux"}
+		current[name] = &runtimeNodeGroup{}
+	}
+	link := &applyFakeLink{linkType: clablinks.LinkTypeDummy}
+	link.endpoints = []clablinks.Endpoint{
+		clablinks.NewEndpointDummy(clablinks.NewEndpointGeneric(c.Nodes["target"], "eth1", link)),
+	}
+	c.Links[0] = link
+	return c, current
+}

--- a/core/network_mode_test.go
+++ b/core/network_mode_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"testing"
 
@@ -20,6 +21,58 @@ type networkModeTestNode struct {
 
 func (n *networkModeTestNode) Config() *clabtypes.NodeConfig { return n.cfg }
 
+func TestPlanNetworkModeCascadeScalesWithChainLength(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	c := &CLab{Nodes: map[string]clabnodes.Node{}}
+	const count = 256
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("n%04d", i)
+		cfg := &clabtypes.NodeConfig{ShortName: name}
+		if i < count-1 {
+			cfg.NetworkMode = fmt.Sprintf("container:n%04d", i+1)
+		}
+		node := clabmocksmocknodes.NewMockNode(ctrl)
+		// Bound configuration reads rather than wall time so this regression
+		// detects repeated whole-chain scans without depending on CPU speed.
+		node.EXPECT().Config().Return(cfg).MaxTimes(2)
+		c.Nodes[name] = node
+	}
+	plan := newApplyPlan(nil, nil)
+	plan.recreatedNodeSet[fmt.Sprintf("n%04d", count-1)] = struct{}{}
+	c.planNetworkModeCascade(plan)
+	if len(plan.recreatedNodeSet) != count {
+		t.Fatalf("recreated %d nodes, want %d", len(plan.recreatedNodeSet), count)
+	}
+}
+
+func BenchmarkPlanNetworkModeCascade(b *testing.B) {
+	for _, count := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			c := &CLab{Nodes: make(map[string]clabnodes.Node, count)}
+			for i := 0; i < count; i++ {
+				name := fmt.Sprintf("n%05d", i)
+				cfg := &clabtypes.NodeConfig{ShortName: name}
+				if i < count-1 {
+					cfg.NetworkMode = fmt.Sprintf("container:n%05d", i+1)
+				}
+				c.Nodes[name] = &networkModeTestNode{cfg: cfg}
+			}
+			root := fmt.Sprintf("n%05d", count-1)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				plan := newApplyPlan(nil, nil)
+				plan.recreatedNodeSet[root] = struct{}{}
+				c.planNetworkModeCascade(plan)
+				if len(plan.recreatedNodeSet) != count {
+					b.Fatal("incomplete cascade")
+				}
+			}
+		})
+	}
+}
+
 func TestPlanApplyCascadesLinkRestart(t *testing.T) {
 	t.Parallel()
 	c, current := newNetworkModePlanTestLab(t, clabruntime.Running, clabnodes.LinkApplyModeRestart)
@@ -27,7 +80,9 @@ func TestPlanApplyCascadesLinkRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := sortedStringSet(plan.linkRestartNodeSet); !slices.Equal(got, []string{"leaf", "sidecar", "target"}) {
+	if got := sortedStringSet(plan.linkRestartNodeSet); !slices.Equal(got, []string{
+		"leaf", "sidecar", "target",
+	}) {
 		t.Fatalf("restarted nodes = %v, want target and both dependents", got)
 	}
 	if len(plan.recreatedNodeSet) != 0 {
@@ -40,8 +95,10 @@ func TestPlanNetworkModeRestartsForNewDependents(t *testing.T) {
 	for _, late := range []bool{false, true} {
 		for _, recreated := range []bool{false, true} {
 			c := &CLab{Nodes: map[string]clabnodes.Node{
-				"target":  &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
-				"sidecar": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"}},
+				"target": &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
+				"sidecar": &networkModeTestNode{
+					cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"},
+				},
 			}}
 			plan := newApplyPlan(nil, nil)
 			if late {
@@ -80,7 +137,8 @@ func TestRestartApplyNodesOrdersNamespaceDependencies(t *testing.T) {
 			cfg.NetworkMode = "container:sidecar"
 		}
 		node.EXPECT().Config().Return(cfg).AnyTimes()
-		calls = append(calls, node.EXPECT().Stop(gomock.Any()).Return(nil), node.EXPECT().Start(gomock.Any()).Return(nil))
+		calls = append(calls, node.EXPECT().Stop(gomock.Any()).Return(nil),
+			node.EXPECT().Start(gomock.Any()).Return(nil))
 		node.EXPECT().GetContainerStatus(gomock.Any()).Return(clabruntime.Running)
 		c.Nodes[name] = node
 		nodeSet[name] = struct{}{}
@@ -106,8 +164,10 @@ func TestPlanNetworkModeRestartsForStoppedTarget(t *testing.T) {
 	t.Parallel()
 	for _, sidecarStopped := range []bool{false, true} {
 		c := &CLab{Nodes: map[string]clabnodes.Node{
-			"target":  &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
-			"sidecar": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"}},
+			"target": &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
+			"sidecar": &networkModeTestNode{
+				cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"},
+			},
 		}}
 		plan := newApplyPlan(nil, nil)
 		plan.startNodeSet["target"] = struct{}{}
@@ -118,7 +178,11 @@ func TestPlanNetworkModeRestartsForStoppedTarget(t *testing.T) {
 			t.Fatal(err)
 		}
 		if _, restart := plan.linkRestartNodeSet["sidecar"]; restart == sidecarStopped {
-			t.Fatalf("sidecar stopped=%v: restart=%v; only running dependents need restarting", sidecarStopped, restart)
+			t.Fatalf(
+				"sidecar stopped=%v: restart=%v; only running dependents need restarting",
+				sidecarStopped,
+				restart,
+			)
 		}
 	}
 }
@@ -184,7 +248,9 @@ func newNetworkModePlanTestLab(
 		node.EXPECT().GetContainerStatus(gomock.Any()).Return(status).AnyTimes()
 		node.EXPECT().ExecFunction(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		node.EXPECT().ComputeDiff(gomock.Any(), gomock.Any()).Return(&clabtypes.TopologyDiff{})
-		node.EXPECT().GetReconcilePlan(gomock.Any(), gomock.Any()).Return(&clabnodes.ReconcileResult{}, nil)
+		node.EXPECT().
+			GetReconcilePlan(gomock.Any(), gomock.Any()).
+			Return(&clabnodes.ReconcileResult{}, nil)
 		if name == "target" {
 			node.EXPECT().LinkApplyMode(gomock.Any()).Return(mode)
 		}

--- a/core/network_mode_test.go
+++ b/core/network_mode_test.go
@@ -102,6 +102,27 @@ func TestNetworkModeNodeOrderRejectsCycles(t *testing.T) {
 	}
 }
 
+func TestPlanNetworkModeRestartsForStoppedTarget(t *testing.T) {
+	t.Parallel()
+	for _, sidecarStopped := range []bool{false, true} {
+		c := &CLab{Nodes: map[string]clabnodes.Node{
+			"target":  &networkModeTestNode{cfg: &clabtypes.NodeConfig{}},
+			"sidecar": &networkModeTestNode{cfg: &clabtypes.NodeConfig{NetworkMode: "container:target"}},
+		}}
+		plan := newApplyPlan(nil, nil)
+		plan.startNodeSet["target"] = struct{}{}
+		if sidecarStopped {
+			plan.startNodeSet["sidecar"] = struct{}{}
+		}
+		if err := c.planNetworkModeRestarts(plan); err != nil {
+			t.Fatal(err)
+		}
+		if _, restart := plan.linkRestartNodeSet["sidecar"]; restart == sidecarStopped {
+			t.Fatalf("sidecar stopped=%v: restart=%v; only running dependents need restarting", sidecarStopped, restart)
+		}
+	}
+}
+
 func TestPlanApplyCascadesLinkRecreate(t *testing.T) {
 	t.Parallel()
 

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -105,6 +105,93 @@ func (p *applyPlan) isNonContainerNode(nodeName string) bool {
 	return p.isExternallyManaged(nodeName) || p.isRootNamespaceNode(nodeName)
 }
 
+// networkModeContainerTarget returns the referenced node name for a
+// "network-mode: container:<name>" config, or "" if networkMode does not
+// share another container's network namespace.
+func networkModeContainerTarget(networkMode string) string {
+	netModeArr := strings.SplitN(networkMode, ":", 2) //nolint: mnd
+	if netModeArr[0] != "container" || len(netModeArr) != 2 {
+		return ""
+	}
+
+	return netModeArr[1]
+}
+
+// checkApplyNetworkModeTargets rejects apply when a node's network-mode:
+// container:<target> target is being removed from the topology while the
+// dependent node stays desired. Deleting the target would leave the
+// dependent silently attached to a defunct network namespace.
+func (c *CLab) checkApplyNetworkModeTargets(plan *applyPlan) error {
+	if plan == nil {
+		return nil
+	}
+
+	for _, nodeName := range sortedNodeNames(c.Nodes) {
+		networkMode := c.Nodes[nodeName].Config().NetworkMode
+		target := networkModeContainerTarget(networkMode)
+		if target == "" {
+			continue
+		}
+		if _, deleted := plan.deletedNodeSet[target]; deleted {
+			return fmt.Errorf(
+				"node %q has network-mode %q, but %q is being removed from the topology; "+
+					"remove or retarget %q as well",
+				nodeName,
+				networkMode,
+				target,
+				nodeName,
+			)
+		}
+	}
+
+	return nil
+}
+
+// planNetworkModeCascade forces recreation of nodes whose network-mode:
+// container:<target> target is itself being recreated. Docker binds
+// NetworkMode to the target container's ID at creation time, so a plain
+// restart of the dependent cannot rebind it to the target's new container;
+// only recreating the dependent does. Runs to a fixed point so chains of
+// shared-namespace nodes all get picked up.
+func (c *CLab) planNetworkModeCascade(plan *applyPlan) {
+	if plan == nil {
+		return
+	}
+
+	for {
+		changed := false
+
+		for _, nodeName := range sortedNodeNames(c.Nodes) {
+			if _, recreated := plan.recreatedNodeSet[nodeName]; recreated {
+				continue
+			}
+			if _, added := plan.addedNodeSet[nodeName]; added {
+				continue
+			}
+
+			target := networkModeContainerTarget(c.Nodes[nodeName].Config().NetworkMode)
+			if target == "" {
+				continue
+			}
+			if _, targetRecreated := plan.recreatedNodeSet[target]; !targetRecreated {
+				continue
+			}
+
+			plan.recreatedNodeSet[nodeName] = struct{}{}
+			delete(plan.restartNodeSet, nodeName)
+			delete(plan.linkRestartNodeSet, nodeName)
+			plan.nodeChangeReasons[nodeName] = fmt.Sprintf(
+				"network-mode target %q recreated", target,
+			)
+			changed = true
+		}
+
+		if !changed {
+			return
+		}
+	}
+}
+
 func (c *CLab) planApply(
 	ctx context.Context,
 	currentNodes map[string]*runtimeNodeGroup,
@@ -137,9 +224,15 @@ func (c *CLab) planApply(
 		}
 	}
 
+	if err := c.checkApplyNetworkModeTargets(plan); err != nil {
+		return nil, err
+	}
+
 	if err := c.planNodeReconciliation(ctx, plan); err != nil {
 		return nil, err
 	}
+
+	c.planNetworkModeCascade(plan)
 
 	c.planParkedNodes(ctx, plan)
 	c.planStoppedNodes(ctx, plan)

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -109,12 +109,10 @@ func (p *applyPlan) isNonContainerNode(nodeName string) bool {
 // "network-mode: container:<name>" config, or "" if networkMode does not
 // share another container's network namespace.
 func networkModeContainerTarget(networkMode string) string {
-	netModeArr := strings.SplitN(networkMode, ":", 2) //nolint: mnd
-	if netModeArr[0] != "container" || len(netModeArr) != 2 {
-		return ""
+	if target, shared := strings.CutPrefix(networkMode, "container:"); shared {
+		return target
 	}
-
-	return netModeArr[1]
+	return ""
 }
 
 // checkApplyNetworkModeTargets rejects apply when a node's network-mode:
@@ -151,29 +149,30 @@ func (c *CLab) checkApplyNetworkModeTargets(plan *applyPlan) error {
 // container:<target> target is itself being recreated. Docker binds
 // NetworkMode to the target container's ID at creation time, so a plain
 // restart of the dependent cannot rebind it to the target's new container;
-// only recreating the dependent does. Runs to a fixed point so chains of
-// shared-namespace nodes all get picked up.
+// only recreating the dependent does. A reverse dependency graph visits each
+// node and dependency at most once, including long namespace-sharing chains.
 func (c *CLab) planNetworkModeCascade(plan *applyPlan) {
-	if plan == nil {
+	if plan == nil || len(plan.recreatedNodeSet) == 0 {
 		return
 	}
 
-	for {
-		changed := false
-
-		for _, nodeName := range sortedNodeNames(c.Nodes) {
+	dependents := make(map[string][]string)
+	for name, node := range c.Nodes {
+		if target := networkModeContainerTarget(node.Config().NetworkMode); target != "" {
+			dependents[target] = append(dependents[target], name)
+		}
+	}
+	queue := make([]string, 0, len(c.Nodes))
+	for name := range plan.recreatedNodeSet {
+		queue = append(queue, name)
+	}
+	for i := 0; i < len(queue); i++ {
+		target := queue[i]
+		for _, nodeName := range dependents[target] {
 			if _, recreated := plan.recreatedNodeSet[nodeName]; recreated {
 				continue
 			}
 			if _, added := plan.addedNodeSet[nodeName]; added {
-				continue
-			}
-
-			target := networkModeContainerTarget(c.Nodes[nodeName].Config().NetworkMode)
-			if target == "" {
-				continue
-			}
-			if _, targetRecreated := plan.recreatedNodeSet[target]; !targetRecreated {
 				continue
 			}
 
@@ -183,11 +182,7 @@ func (c *CLab) planNetworkModeCascade(plan *applyPlan) {
 			plan.nodeChangeReasons[nodeName] = fmt.Sprintf(
 				"network-mode target %q recreated", target,
 			)
-			changed = true
-		}
-
-		if !changed {
-			return
+			queue = append(queue, nodeName)
 		}
 	}
 }

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -232,8 +232,6 @@ func (c *CLab) planApply(
 		return nil, err
 	}
 
-	c.planNetworkModeCascade(plan)
-
 	c.planParkedNodes(ctx, plan)
 	c.planStoppedNodes(ctx, plan)
 
@@ -274,10 +272,15 @@ func (c *CLab) planApply(
 		}
 	}
 
+	// Link reconciliation can request additional recreations. Propagate namespace
+	// dependencies only after those decisions, then park every affected live node.
+	c.planNetworkModeCascade(plan)
+	c.planParkedNodes(ctx, plan)
 	c.planRecreatedNodeLinks(plan)
 	for nodeName := range plan.recreatedNodeSet {
 		delete(plan.restartNodeSet, nodeName)
 		delete(plan.linkRestartNodeSet, nodeName)
+		delete(plan.startNodeSet, nodeName)
 	}
 
 	return plan, nil
@@ -298,6 +301,9 @@ func (c *CLab) planParkedNodes(ctx context.Context, plan *applyPlan) {
 	}
 
 	for nodeName := range plan.recreatedNodeSet {
+		if _, parked := plan.parkedNodeSet[nodeName]; parked {
+			continue
+		}
 		node, exists := c.Nodes[nodeName]
 		if !exists {
 			continue

--- a/core/topology_reconcile.go
+++ b/core/topology_reconcile.go
@@ -282,6 +282,9 @@ func (c *CLab) planApply(
 		delete(plan.linkRestartNodeSet, nodeName)
 		delete(plan.startNodeSet, nodeName)
 	}
+	if err := c.planNetworkModeRestarts(plan); err != nil {
+		return nil, err
+	}
 
 	return plan, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -214,6 +214,13 @@ func WaitForContainerRunning(
 	r ContainerRuntime,
 	contName, nodeName string,
 ) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("node %q waiting for external container %q: %w", nodeName, contName, err)
+	}
+	if r.GetContainerStatus(ctx, contName) == Running {
+		return nil
+	}
+
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -8,17 +8,18 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
 func TestWaitForContainerRunningHonorsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 	done := make(chan error, 1)
 
 	go func() {
 		done <- WaitForContainerRunning(ctx, nil, "external", "node")
 	}()
-	cancel()
 
 	select {
 	case err := <-done:
@@ -28,6 +29,44 @@ func TestWaitForContainerRunningHonorsContextCancellation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("WaitForContainerRunning did not return after context cancellation")
 	}
+}
+
+type statusTestRuntime struct {
+	ContainerRuntime
+	status ContainerStatus
+}
+
+func (r *statusTestRuntime) GetContainerStatus(context.Context, string) ContainerStatus {
+	return r.status
+}
+
+func TestWaitForContainerRunningChecksImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		if err := WaitForContainerRunning(context.Background(), &statusTestRuntime{
+			status: Running,
+		}, "target", "sidecar"); err != nil {
+			t.Fatal(err)
+		}
+		if elapsed := time.Since(start); elapsed != 0 {
+			t.Fatalf("running target incurred a polling delay of %s", elapsed)
+		}
+	})
+}
+
+func TestWaitForContainerRunningCancelsDuringWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			done <- WaitForContainerRunning(ctx, &statusTestRuntime{status: Stopped}, "target", "sidecar")
+		}()
+		synctest.Wait()
+		cancel()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context cancellation", err)
+		}
+	})
 }
 
 func TestContainerHasJoinableNetns(t *testing.T) {

--- a/tests/01-smoke/31-apply-network-mode.clab.yml
+++ b/tests/01-smoke/31-apply-network-mode.clab.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../schemas/clab.schema.json
+# Copyright 2020 Nokia
+# Licensed under the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: apply-netmode
+
+topology:
+  nodes:
+    w1:
+      kind: linux
+      image: alpine:3
+      cmd: tail -f /dev/null
+{{- if .driftW1 }}
+      env:
+        RECONCILE_MARKER: updated
+{{- end }}
+{{- if .addSidecar1 }}
+    w1-sc:
+      kind: linux
+      image: alpine:3
+      cmd: tail -f /dev/null
+      network-mode: container:w1
+{{- end }}
+{{- if and .addTogether (not .removeW2) }}
+    w2:
+      kind: linux
+      image: alpine:3
+      cmd: tail -f /dev/null
+{{- end }}
+{{- if .addTogether }}
+    w2-sc:
+      kind: linux
+      image: alpine:3
+      cmd: tail -f /dev/null
+      network-mode: container:w2
+{{- end }}

--- a/tests/01-smoke/31-apply-network-mode.clab.yml
+++ b/tests/01-smoke/31-apply-network-mode.clab.yml
@@ -11,6 +11,9 @@ topology:
       kind: linux
       image: alpine:3
       cmd: tail -f /dev/null
+{{- if .linkApplyMode }}
+      link-apply-mode: {{ .linkApplyMode }}
+{{- end }}
 {{- if .driftW1 }}
       env:
         RECONCILE_MARKER: updated
@@ -34,4 +37,8 @@ topology:
       image: alpine:3
       cmd: tail -f /dev/null
       network-mode: container:w2
+{{- end }}
+{{- if .addLink }}
+  links:
+    - endpoints: [w1:eth1, w2:eth1]
 {{- end }}

--- a/tests/01-smoke/31-apply-network-mode.robot
+++ b/tests/01-smoke/31-apply-network-mode.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Process
+Resource            ../common.robot
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+
+*** Variables ***
+${lab-name}                 apply-netmode
+${runtime}                  docker
+${topo}                     31-apply-network-mode.clab.yml
+${initial-vars}             31-apply-network-mode.vars.initial.yml
+${add-sidecar1-vars}        31-apply-network-mode.vars.add-sidecar1.yml
+${drift-w1-vars}            31-apply-network-mode.vars.drift-w1.yml
+${add-together-vars}        31-apply-network-mode.vars.add-together.yml
+${remove-w2-vars}           31-apply-network-mode.vars.remove-w2.yml
+${runtime-cli-exec-cmd}     docker exec
+
+
+*** Test Cases ***
+Apply initial lab with a single node
+    ${rc}    ${output} =    Apply Topology    ${initial-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Node Should Be Running    w1
+
+Apply adds a network-mode sidecar to an already-running target
+    ${rc}    ${output} =    Apply Topology    ${add-sidecar1-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    added nodes
+    Should Contain    ${output}    w1-sc
+    Node Should Be Running    w1-sc
+    Nodes Should Share Network Namespace    w1    w1-sc
+
+Apply cascades sidecar recreation when its network-mode target is recreated
+    ${w1_before} =    Node Runtime Identity    w1
+    ${w1sc_before} =    Node Runtime Identity    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${drift-w1-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    recreated nodes
+    Should Contain    ${output}    w1
+    Should Contain    ${output}    w1-sc
+    Should Contain    ${output}    network-mode target
+    ${w1_after} =    Node Runtime Identity    w1
+    ${w1sc_after} =    Node Runtime Identity    w1-sc
+    Should Not Be Equal As Strings    ${w1_after}    ${w1_before}
+    Should Not Be Equal As Strings    ${w1sc_after}    ${w1sc_before}
+    Nodes Should Share Network Namespace    w1    w1-sc
+
+Apply adds a network-mode target and its sidecar together
+    ${rc}    ${output} =    Apply Topology    ${add-together-vars}    --max-workers 1
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    added nodes
+    Should Contain    ${output}    w2
+    Should Contain    ${output}    w2-sc
+    Node Should Be Running    w2
+    Node Should Be Running    w2-sc
+    Nodes Should Share Network Namespace    w2    w2-sc
+
+Apply rejects removing a network-mode target while its sidecar remains
+    ${rc}    ${output} =    Apply Topology    ${remove-w2-vars}
+    Should Not Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    w2-sc
+    Should Contain    ${output}    w2
+    Should Contain    ${output}    being removed from the topology
+    Node Should Be Running    w2
+    Node Should Be Running    w2-sc
+
+
+*** Keywords ***
+Setup
+    Run Clab Command    destroy --name ${lab-name} --cleanup
+
+Teardown
+    Run Clab Command    destroy --name ${lab-name} --cleanup
+
+Run Clab Command
+    [Arguments]    ${args}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${CLAB_BIN} --runtime ${runtime} ${args} 2>&1
+    Log    ${output}
+    RETURN    ${rc}    ${output}
+
+Apply Topology
+    [Arguments]    ${vars_file}    ${extra_args}=${EMPTY}
+    ${rc}    ${output} =    Run Clab Command
+    ...    apply -t ${CURDIR}/${topo} --vars ${CURDIR}/${vars_file} ${extra_args}
+    RETURN    ${rc}    ${output}
+
+Node Should Be Running
+    [Arguments]    ${node}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} inspect -f '{{.State.Status}}' clab-${lab-name}-${node}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Match Regexp    ${output}    (?im)^running\\s*$
+
+Node Runtime Identity
+    [Arguments]    ${node}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} inspect -f '{{.State.Pid}} {{.State.StartedAt}}' clab-${lab-name}-${node}
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    RETURN    ${output}
+
+Nodes Should Share Network Namespace
+    [Arguments]    ${node_a}    ${node_b}
+    ${rc}    ${netns_a} =    Run And Return Rc And Output
+    ...    ${runtime-cli-exec-cmd} clab-${lab-name}-${node_a} readlink /proc/self/ns/net
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${netns_b} =    Run And Return Rc And Output
+    ...    ${runtime-cli-exec-cmd} clab-${lab-name}-${node_b} readlink /proc/self/ns/net
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Strings    ${netns_a}    ${netns_b}

--- a/tests/01-smoke/31-apply-network-mode.robot
+++ b/tests/01-smoke/31-apply-network-mode.robot
@@ -27,12 +27,43 @@ Apply initial lab with a single node
     Should Be Equal As Integers    ${rc}    0
     Node Should Be Running    w1
 
+Apply adds a network-mode sidecar to a stopped target
+    [Timeout]    30 seconds
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} stop -t 1 clab-${lab-name}-w1
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${output} =    Apply Topology    ${add-sidecar1-vars}    --max-workers 1
+    Should Be Equal As Integers    ${rc}    0
+    Node Should Be Running    w1
+    Node Should Be Running    w1-sc
+    Nodes Should Share Network Namespace    w1    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${initial-vars}
+    Should Be Equal As Integers    ${rc}    0
+
 Apply adds a network-mode sidecar to an already-running target
     ${rc}    ${output} =    Apply Topology    ${add-sidecar1-vars}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    added nodes
     Should Contain    ${output}    w1-sc
     Node Should Be Running    w1-sc
+    Nodes Should Share Network Namespace    w1    w1-sc
+
+Apply rejoins a running sidecar when starting its stopped target
+    [Timeout]    30 seconds
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} stop -t 1 clab-${lab-name}-w1
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${output} =    Apply Topology    ${add-sidecar1-vars}    --max-workers 1
+    Should Be Equal As Integers    ${rc}    0
+    Nodes Should Share Network Namespace    w1    w1-sc
+
+Apply starts a stopped target and sidecar in dependency order
+    [Timeout]    30 seconds
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} stop -t 1 clab-${lab-name}-w1-sc clab-${lab-name}-w1
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${output} =    Apply Topology    ${add-sidecar1-vars}    --max-workers 1
+    Should Be Equal As Integers    ${rc}    0
     Nodes Should Share Network Namespace    w1    w1-sc
 
 Apply cascades sidecar recreation when its network-mode target is recreated

--- a/tests/01-smoke/31-apply-network-mode.robot
+++ b/tests/01-smoke/31-apply-network-mode.robot
@@ -17,6 +17,7 @@ ${drift-w1-vars}            31-apply-network-mode.vars.drift-w1.yml
 ${add-together-vars}        31-apply-network-mode.vars.add-together.yml
 ${remove-w2-vars}           31-apply-network-mode.vars.remove-w2.yml
 ${link-recreate-vars}       31-apply-network-mode.vars.link-recreate.yml
+${link-restart-vars}        31-apply-network-mode.vars.link-restart.yml
 ${runtime-cli-exec-cmd}     docker exec
 
 
@@ -71,6 +72,20 @@ Apply cascades sidecar recreation for a link change
     ${sidecar_after} =    Node Runtime Identity    w1-sc
     Should Not Be Equal As Strings    ${w1_after}    ${w1_before}
     Should Not Be Equal As Strings    ${sidecar_after}    ${sidecar_before}
+    Nodes Should Share Network Namespace    w1    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${add-together-vars}
+    Should Be Equal As Integers    ${rc}    0
+
+Apply restarts namespace dependents after a link-triggered target restart
+    ${w1_before} =    Node Container ID    w1
+    ${sidecar_before} =    Node Container ID    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${link-restart-vars}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    network-mode target
+    ${w1_after} =    Node Container ID    w1
+    ${sidecar_after} =    Node Container ID    w1-sc
+    Should Be Equal As Strings    ${w1_before}    ${w1_after}
+    Should Be Equal As Strings    ${sidecar_before}    ${sidecar_after}
     Nodes Should Share Network Namespace    w1    w1-sc
     ${rc}    ${output} =    Apply Topology    ${add-together-vars}
     Should Be Equal As Integers    ${rc}    0
@@ -131,6 +146,13 @@ Node Runtime Identity
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    ${runtime} inspect -f '{{.State.Pid}} {{.State.StartedAt}}' clab-${lab-name}-${node}
     Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    RETURN    ${output}
+
+Node Container ID
+    [Arguments]    ${node}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    ${runtime} inspect -f '{{.Id}}' clab-${lab-name}-${node}
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${output}
 

--- a/tests/01-smoke/31-apply-network-mode.robot
+++ b/tests/01-smoke/31-apply-network-mode.robot
@@ -16,6 +16,7 @@ ${add-sidecar1-vars}        31-apply-network-mode.vars.add-sidecar1.yml
 ${drift-w1-vars}            31-apply-network-mode.vars.drift-w1.yml
 ${add-together-vars}        31-apply-network-mode.vars.add-together.yml
 ${remove-w2-vars}           31-apply-network-mode.vars.remove-w2.yml
+${link-recreate-vars}       31-apply-network-mode.vars.link-recreate.yml
 ${runtime-cli-exec-cmd}     docker exec
 
 
@@ -57,6 +58,22 @@ Apply adds a network-mode target and its sidecar together
     Node Should Be Running    w2
     Node Should Be Running    w2-sc
     Nodes Should Share Network Namespace    w2    w2-sc
+
+Apply cascades sidecar recreation for a link change
+    ${w1_before} =    Node Runtime Identity    w1
+    ${sidecar_before} =    Node Runtime Identity    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${link-recreate-vars}    --dry-run
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    network-mode target
+    ${rc}    ${output} =    Apply Topology    ${link-recreate-vars}
+    Should Be Equal As Integers    ${rc}    0
+    ${w1_after} =    Node Runtime Identity    w1
+    ${sidecar_after} =    Node Runtime Identity    w1-sc
+    Should Not Be Equal As Strings    ${w1_after}    ${w1_before}
+    Should Not Be Equal As Strings    ${sidecar_after}    ${sidecar_before}
+    Nodes Should Share Network Namespace    w1    w1-sc
+    ${rc}    ${output} =    Apply Topology    ${add-together-vars}
+    Should Be Equal As Integers    ${rc}    0
 
 Apply rejects removing a network-mode target while its sidecar remains
     ${rc}    ${output} =    Apply Topology    ${remove-w2-vars}

--- a/tests/01-smoke/31-apply-network-mode.robot
+++ b/tests/01-smoke/31-apply-network-mode.robot
@@ -67,13 +67,26 @@ Apply rejects removing a network-mode target while its sidecar remains
     Node Should Be Running    w2
     Node Should Be Running    w2-sc
 
+Cleanup removes all incrementally added nodes
+    Cleanup Lab
+
 
 *** Keywords ***
 Setup
-    Run Clab Command    destroy --name ${lab-name} --cleanup
+    Cleanup Lab
 
 Teardown
-    Run Clab Command    destroy --name ${lab-name} --cleanup
+    Cleanup Lab
+
+Cleanup Lab
+    # Render every node, including nodes added with vars after the initial deployment.
+    ${rc}    ${output} =    Run Clab Command
+    ...    destroy -t ${CURDIR}/${topo} --vars ${CURDIR}/${add-together-vars} --cleanup
+    Should Be Equal As Integers    ${rc}    0
+    ${rc}    ${containers} =    Run And Return Rc And Output
+    ...    ${runtime} ps -aq --filter label=containerlab=${lab-name}
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Empty    ${containers}
 
 Run Clab Command
     [Arguments]    ${args}

--- a/tests/01-smoke/31-apply-network-mode.vars.add-sidecar1.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.add-sidecar1.yml
@@ -1,0 +1,4 @@
+driftW1: false
+addSidecar1: true
+addTogether: false
+removeW2: false

--- a/tests/01-smoke/31-apply-network-mode.vars.add-together.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.add-together.yml
@@ -1,0 +1,4 @@
+driftW1: true
+addSidecar1: true
+addTogether: true
+removeW2: false

--- a/tests/01-smoke/31-apply-network-mode.vars.drift-w1.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.drift-w1.yml
@@ -1,0 +1,4 @@
+driftW1: true
+addSidecar1: true
+addTogether: false
+removeW2: false

--- a/tests/01-smoke/31-apply-network-mode.vars.initial.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.initial.yml
@@ -1,0 +1,4 @@
+driftW1: false
+addSidecar1: false
+addTogether: false
+removeW2: false

--- a/tests/01-smoke/31-apply-network-mode.vars.link-recreate.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.link-recreate.yml
@@ -1,0 +1,6 @@
+driftW1: true
+addSidecar1: true
+addTogether: true
+removeW2: false
+addLink: true
+linkApplyMode: recreate

--- a/tests/01-smoke/31-apply-network-mode.vars.link-restart.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.link-restart.yml
@@ -1,0 +1,6 @@
+driftW1: true
+addSidecar1: true
+addTogether: true
+removeW2: false
+addLink: true
+linkApplyMode: restart

--- a/tests/01-smoke/31-apply-network-mode.vars.remove-w2.yml
+++ b/tests/01-smoke/31-apply-network-mode.vars.remove-w2.yml
@@ -1,0 +1,4 @@
+driftW1: true
+addSidecar1: true
+addTogether: true
+removeW2: true


### PR DESCRIPTION
## What
`apply` previously blanket-rejected any node with `network-mode: container:<target>` via `checkUnsupportedApplyNodes()`. That check was added defensively in an unrelated bridge PR and turns out to be unnecessary for the common case of a sidecar container with no clab-managed links sharing a target's netns (e.g. `network-mode: container:worker1`).

## Changes
- Delete `checkUnsupportedApplyNodes()` and its call site.
- `DeployNodes` now waits for a node's `network-mode: container:` target to be running from a per-node goroutine decoupled from the worker pool, so a dependent node queued ahead of its target (added/recreated in the same `apply`) can't deadlock a constrained worker pool (e.g. `--max-workers 1`). Mirrors fresh deploy's existing `waitForExternalNodeDependencies` for targets not managed by this topology.
- `planApply` now forces a node into `recreatedNodeSet` (via a fixed-point pass, so chains cascade) whenever its `network-mode: container:` target is itself recreated — Docker binds `NetworkMode` to the target's container ID at creation time, so a plain restart of the dependent can't rebind it after the target gets a new container ID.
- `planApply` rejects an apply that deletes a `network-mode: container:` target while its dependent node stays desired, naming both nodes in the error, to avoid silently leaving the dependent attached to a defunct network namespace.

## Testing
- New unit tests in `core/apply_test.go` / `core/deploy_test.go` cover the cascade (including a transitive A→B→C chain and excluding newly-added nodes), the deleted-target rejection, and the `DeployNodes` ordering fix (including a regression test that reproduces the deadlock against a deliberately-reverted naive implementation).
- New Robot Framework smoke suite `tests/01-smoke/31-apply-network-mode.robot` exercises against real Docker containers:
  1. adding a no-link sidecar to an already-running target
  2. target recreation cascading a sidecar recreate
  3. adding a target + its sidecar together in one `apply --max-workers 1` call
  4. `apply` rejecting removal of a target while its sidecar remains desired
- `make build`, `go vet`, `go test -race ./...`, and the existing `tests/01-smoke/29-apply.robot` suite all pass with no regressions.