### PR TITLE
sonic-vs: mark the wire interfaces ARP-off and IPv6-off so only the port answers

### DIFF
--- a/docs/manual/kinds/sonic-vs.md
+++ b/docs/manual/kinds/sonic-vs.md
@@ -67,6 +67,10 @@ sonic-vs container uses the following mapping for its linux interfaces:
 
 When containerlab launches sonic-vs node, it will assign IPv4/6 address to the `eth0` interface. Data interface `eth1` mapped to `Ethernet0` port and needs to be configured with IP addressing manually. See Lab examples for exact configurations.
 
+/// note
+The `ethN` data interfaces are only the wire behind the SONiC ports (`eth1` behind `Ethernet0`, `eth2` behind `Ethernet4`, and so on); SONiC configures the port, while the `ethN` interface carries its frames. Containerlab therefore marks every `ethN` data interface ARP-off and IPv6-off once the links exist, so that only the port answers on the link and a neighbour cannot cache the wire's MAC.
+///
+
 ## Lab examples
 
 The following labs feature sonic-vs node:

--- a/nodes/sonic/sonic.go
+++ b/nodes/sonic/sonic.go
@@ -20,6 +20,13 @@ const (
 	generateable     = true
 	generateIfFormat = "eth%d"
 
+	// mgmtIfName is the management interface of a sonic-vs node. It is created
+	// by the runtime rather than by a link, so it is not an endpoint of the node
+	// today - but a node with `network-mode: none` may declare one, and the
+	// management interface is not a wire behind a SONiC port, so it is filtered
+	// out explicitly.
+	mgmtIfName = "eth0"
+
 	scrapliPlatformName = "sonic"
 )
 
@@ -66,8 +73,98 @@ func (s *sonic) PreDeploy(_ context.Context, params *clabnodes.PreDeployParams) 
 	return nil
 }
 
+// wireInterfaceCmds returns the commands that quiet the kernel on the
+// containerlab-created wire interfaces of a sonic-vs node. The management
+// interface is skipped: it is not a wire behind a SONiC port.
+func wireInterfaceCmds(ifNames []string) []string {
+	cmds := make([]string, 0, len(ifNames)*2)
+
+	for _, ifName := range ifNames {
+		if ifName == mgmtIfName {
+			continue
+		}
+
+		cmds = append(cmds,
+			fmt.Sprintf("ip link set arp off dev %s", ifName),
+			fmt.Sprintf("sysctl -w net.ipv6.conf.%s.disable_ipv6=1", ifName),
+		)
+	}
+
+	return cmds
+}
+
+// quietWireInterfaces marks the wire interfaces of the node ARP-off and
+// IPv6-off.
+//
+// A sonic-vs node has two kernel interfaces per link: the veth containerlab
+// creates (ethN, the wire) and the tap syncd derives from it (eth1 becomes
+// Ethernet0, eth2 becomes Ethernet4, and so on - the port SONiC configures).
+// Left alone, the kernel answers ARP for the port's address on the wire with
+// the wire's MAC and brings up an IPv6 link-local there, so a neighbour can
+// cache the wrong MAC and learn a device that isn't the port. Quieting the wire
+// leaves only the port answering. This is what SONiC's own vs harness does
+// (sonic-swss, tests/conftest.py, VirtualServer).
+//
+// The commands are idempotent, so this may run more than once for a node - it
+// runs at post-deploy time and again for links added to a running node. A
+// failure is logged and does not fail the deploy.
+func (s *sonic) quietWireInterfaces(ctx context.Context) error {
+	ifNames := make([]string, 0, len(s.Endpoints))
+
+	for _, e := range s.Endpoints {
+		ifNames = append(ifNames, e.GetIfaceName())
+	}
+
+	for _, cmdStr := range wireInterfaceCmds(ifNames) {
+		cmd, err := clabexec.NewExecCmdFromString(cmdStr)
+		if err != nil {
+			log.Warn("failed to quiet sonic-vs wire interface",
+				"node", s.Cfg.ShortName, "cmd", cmdStr, "error", err)
+
+			continue
+		}
+
+		execResult, err := s.RunExec(ctx, cmd)
+		if err != nil || (execResult != nil && execResult.GetReturnCode() != 0) {
+			if err == nil {
+				err = fmt.Errorf("returned %d: %s",
+					execResult.GetReturnCode(), execResult.GetStdErrString())
+			}
+
+			log.Warn("failed to quiet sonic-vs wire interface",
+				"node", s.Cfg.ShortName, "cmd", cmdStr, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// PostDeployEndpoints runs sonic-vs endpoint fixups after dataplane links
+// exist. It also covers links added to an already running node.
+func (s *sonic) PostDeployEndpoints(ctx context.Context) error {
+	return s.quietWireInterfaces(ctx)
+}
+
+// Start starts a stopped sonic-vs node and re-applies the wire fixups. Stopping
+// a node parks its endpoints in a separate network namespace and starting it
+// moves them back; a netdev that crosses a namespace has its IPv6 configuration
+// rebuilt, so disable_ipv6 falls back to 0 and a link-local address reappears
+// on the wire.
+func (s *sonic) Start(ctx context.Context) error {
+	if err := s.DefaultNode.Start(ctx); err != nil {
+		return err
+	}
+
+	return s.PostDeployEndpoints(ctx)
+}
+
 func (s *sonic) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams) error {
 	log.Debugf("Running postdeploy actions for sonic-vs '%s' node", s.Cfg.ShortName)
+
+	// quiet the wires before the SONiC agents start.
+	if err := s.quietWireInterfaces(ctx); err != nil {
+		return err
+	}
 
 	cmd, _ := clabexec.NewExecCmdFromString("supervisord")
 	err := s.RunExecNotWait(ctx, cmd)

--- a/nodes/sonic/sonic_test.go
+++ b/nodes/sonic/sonic_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package sonic
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWireInterfaceCmds(t *testing.T) {
+	tests := map[string]struct {
+		ifNames []string
+		want    []string
+	}{
+		"no interfaces": {
+			ifNames: nil,
+			want:    []string{},
+		},
+		"skips the management interface": {
+			ifNames: []string{"eth0", "eth1"},
+			want: []string{
+				"ip link set arp off dev eth1",
+				"sysctl -w net.ipv6.conf.eth1.disable_ipv6=1",
+			},
+		},
+		"two interfaces": {
+			ifNames: []string{"eth1", "eth2"},
+			want: []string{
+				"ip link set arp off dev eth1",
+				"sysctl -w net.ipv6.conf.eth1.disable_ipv6=1",
+				"ip link set arp off dev eth2",
+				"sysctl -w net.ipv6.conf.eth2.disable_ipv6=1",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := wireInterfaceCmds(tc.ifNames)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("wireInterfaceCmds() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION

A `sonic-vs` node ends up with two kernel interfaces per link: the veth containerlab creates
(`ethN`) and the tap `syncd` derives from it - `eth1` becomes `Ethernet0`, `eth2` becomes
`Ethernet4`, and so on. SONiC configures the port; the `ethN` interface is only the wire that
carries the port's frames.

Left alone, the kernel treats that wire as an ordinary interface. It answers ARP for the port's
address with the wire's MAC, and it brings up an IPv6 link-local address there. A neighbour can
therefore cache the wrong MAC for the port, and can discover a device on the link that isn't the
port at all. Both interfaces see the same ARP request, so which reply the neighbour keeps is a
race - the entry is unreliable rather than reliably wrong, which makes it easy to miss.

SONiC's own virtual-switch test harness turns ARP off on these interfaces for the same reason:
[`sonic-swss/tests/conftest.py#L245-L246`](https://github.com/sonic-net/sonic-swss/blob/8b183d0cf1c1ebe3f1309099141676adbf9c63bf/tests/conftest.py#L245-L246),
class `VirtualServer` - *"disable arp, so no neigh on physical interfaces"*.

This change does the same for every data endpoint of the node (`eth0`, the management interface,
is skipped), running inside the container:

```
ip link set arp off dev <ifname>
sysctl -w net.ipv6.conf.<ifname>.disable_ipv6=1
```

A failure is logged as a warning and the deploy continues - this is a hardening fixup, not
something a lab should die on. `PostDeploy` applies it before the SONiC agents start, and
`PostDeployEndpoints` applies it again for links added to an already running node -
`clab tools veth create -t <topo>`, and `clab apply` where the node is not recreated
(`link-apply-mode: live` or `restart`), which is the path `deployLinks` uses. `Start` re-applies it
after `clab stop`/`clab start`, because moving a netdev between network namespaces resets its IPv6
sysctls. The commands are idempotent, so running them more than once is harmless.

Scope: this affects only the `sonic-vs` kind. `dell_sonic`, `plvision_sonic` and `sonic-vm` are
VM-based kinds and do not have this container/tap duality. The one way an existing user could
notice a difference: a lab that addresses the `ethN` interface directly instead of the
`Ethernet` port would lose IPv4 and IPv6 on that interface. The documented workflow for this kind
configures the port (`config interface ip add Ethernet0 ...`), which is unaffected.

The kind documentation gains a short note explaining the `ethN`/`Ethernet` relationship, and
there is a unit test for the command list.

Verified on a two-node `sonic-vs` lab (`s1:eth1 <-> s2:eth1`, `Ethernet0` addressed
`10.1.1.1/30` + `2001:db8::1/64` and `10.1.1.2/30` + `2001:db8::2/64`):

- **IPv4:** `eth1` shows `NOARP`; `ping -c3 10.1.1.2` is 0% loss and `ip neigh show 10.1.1.2`
  resolves to s2's `Ethernet0` MAC, not s2's `eth1` MAC.
- **IPv6:** `net.ipv6.conf.eth1.disable_ipv6 = 1` and `ip -6 addr show eth1` is empty, while
  `Ethernet0` keeps its own link-local; `ping6 -c3 2001:db8::2` is 0% loss and
  `ip -6 neigh show 2001:db8::2` resolves to s2's `Ethernet0` MAC.
- **Later-added link:** `clab tools veth create -t <topo> -a s1:eth2 -b s2:eth2` on the running
  lab leaves `eth2` with `NOARP` and `disable_ipv6=1` on both nodes.
- **Stop/start:** without the `Start` override, `clab stop` + `clab start` leaves `eth1` at
  `net.ipv6.conf.eth1.disable_ipv6 = 0` with a fresh `fe80::` address (NOARP survives); with it,
  `eth1` comes back `disable_ipv6 = 1`, `NOARP`, and `ip -6 addr show eth1` empty.
- `eth0` is untouched throughout: no `NOARP`, IPv6 still enabled.
- **Control on stock 0.78.2:** the same test resolves `10.1.1.2` to s2's `eth1` (wire) MAC on 2 of
  3 flush-and-ping rounds and to the port MAC on 1 of 3 - the race, observed.


