### PR TITLE
fix: canonical image name for registries addressed by host and port

### DIFF
--- a/utils/containers.go
+++ b/utils/containers.go
@@ -15,6 +15,7 @@ func GetCanonicalImageName(imageName string) string {
 	//    foo/bar == docker.io/foo/bar:latest
 	//    foo.bar/baz == foo.bar/bar:latest
 	//    localhost/foo:bar == localhost/foo:bar
+	//    myregistry:5000/foo == myregistry:5000/foo:latest
 	// docker.elastic.co/elasticsearch/elasticsearch ==
 	// docker.elastic.co/elasticsearch/elasticsearch:latest
 	canonicalImageName := imageName
@@ -31,6 +32,9 @@ func GetCanonicalImageName(imageName string) string {
 		switch {
 		case strings.Contains(nameSplit[0], "."):
 			canonicalImageName = imageName
+		case strings.Contains(nameSplit[0], ":"):
+			// case of myregistry:5000/foo - a registry addressed by host and port
+			canonicalImageName = imageName
 		case strings.Contains(nameSplit[0], "localhost"):
 			// case of localhost/foo:bar - podman prefixes local images with "localhost"
 			canonicalImageName = imageName
@@ -38,8 +42,12 @@ func GetCanonicalImageName(imageName string) string {
 			canonicalImageName = "docker.io/" + imageName
 		}
 	}
-	// append latest tag if no tag was provided
-	if !strings.Contains(canonicalImageName, ":") {
+
+	// append latest tag if no tag was provided.
+	// only the last path element can carry a tag, a colon before it belongs
+	// to the registry port.
+	lastElement := canonicalImageName[strings.LastIndex(canonicalImageName, "/")+1:]
+	if !strings.Contains(lastElement, ":") {
 		canonicalImageName += ":latest"
 	}
 

--- a/utils/containers_test.go
+++ b/utils/containers_test.go
@@ -35,6 +35,22 @@ func TestGetCanonicalImageName(t *testing.T) {
 			got:  "custom.io/linux/alpine",
 			want: "custom.io/linux/alpine:latest",
 		},
+		"registry with a port and no tag": {
+			got:  "myregistry:5000/alpine",
+			want: "myregistry:5000/alpine:latest",
+		},
+		"registry with a port and a tag": {
+			got:  "myregistry:5000/alpine:v1",
+			want: "myregistry:5000/alpine:v1",
+		},
+		"dotted registry with a port and no tag": {
+			got:  "registry.local:5000/linux/alpine",
+			want: "registry.local:5000/linux/alpine:latest",
+		},
+		"localhost registry with a port and no tag": {
+			got:  "localhost:5000/alpine",
+			want: "localhost:5000/alpine:latest",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
`GetCanonicalImageName` in `utils/containers.go` reads a registry port as a tag separator, so an image hosted on a registry addressed as `host:port` comes back mangled.

Two checks go wrong. The switch that decides whether the first path element is a registry accepts it only when it contains a dot or the substring `localhost`, so `myregistry:5000/alpine` misses both, falls to the default branch and comes out as `docker.io/myregistry:5000/alpine`. Separately, the implicit-tag check searches the whole reference for a colon, so the port supplies one and `registry.local:5000/foo/bar` is returned with no tag at all.

Both strings are then used as real references. `DockerRuntime.PullImage` feeds the result to `ImageInspectWithRaw` and `ImagePull`, and hands the same string to `GetDockerAuth`, which parses it with `reference.ParseNormalizedNamed` in `runtime/docker/auth.go`. That parser rejects `docker.io/myregistry:5000/alpine` because `5000/alpine` is not a valid tag, so the credential lookup logs an error and returns nothing before the pull itself fails. `PodmanRuntime.PullImage` passes the same string to `images.Exists` and `images.Pull`.

The fix adds a colon to the registry test in that switch, and narrows the tag test to the last path element, since only the last element can carry a tag. Every output now agrees with `reference.ParseNormalizedNamed` followed by `reference.TagNameOnly`, the pair the repo already depends on.

Four table cases were added to `TestGetCanonicalImageName`. I ran `utils/containers.go` and `utils/containers_test.go` as a standalone package, since the rest of `utils` needs Linux netlink and I am on macOS. Against the file as it stands on `main` the four new cases fail: `myregistry:5000/alpine` gives `docker.io/myregistry:5000/alpine`, `myregistry:5000/alpine:v1` gives `docker.io/myregistry:5000/alpine:v1`, and `registry.local:5000/linux/alpine` and `localhost:5000/alpine` both come back untagged. With the change all ten cases pass, and the six that were already there are unchanged in both runs.

`GOOS=linux go build ./...`, `GOOS=linux go test -c ./utils/`, `gofmt -l utils/`, `golangci-lint fmt --diff ./utils/...` and `golangci-lint run ./utils/...` are all clean.

One nearby case is left alone on purpose: `foo/bar/baz` keeps its current output of `foo/bar/baz:latest`, where `reference.ParseNormalizedNamed` would give `docker.io/foo/bar/baz:latest`. That is a separate call about multi-segment Docker Hub paths and it is not what this fixes.
