### PR TITLE
fix(iol): fix flaky mgmt interface update on re-deploy

### DIFF
--- a/nodes/iol/iol.go
+++ b/nodes/iol/iol.go
@@ -174,9 +174,6 @@ func (n *iol) PostDeploy(ctx context.Context, _ *clabnodes.PostDeployParams) err
 
 	// Must update mgmt IP if not first boot
 	if !n.firstBoot {
-		// iol has a 5sec boot delay, wait a few extra secs for the console
-		time.Sleep(10 * time.Second)
-
 		return n.UpdateMgmtIntf(ctx)
 	}
 
@@ -439,8 +436,22 @@ func (n *iol) CheckInterfaceName() error {
 }
 
 func (n *iol) UpdateMgmtIntf(ctx context.Context) error {
+	// ponytail: fixed sleep heuristic; proper fix is to read PTY output until
+	// an interactive prompt pattern is detected. Upgrade by implementing a
+	// PTY reader in WriteToStdinNoWait or adding a console-ready probe.
+	//
+	// IOL has a 5s startup countdown followed by NVRAM loading (~10-20s
+	// depending on config size and system load). Commands written to the PTY
+	// during NVRAM loading are consumed mid-boot and silently lost, which
+	// leaves the management interface unconfigured. Wait 25s so the first
+	// attempt lands after the console is interactive.
+	time.Sleep(25 * time.Second)
+
+	// Prefix with \rend\r to exit any lingering config mode left by a
+	// previous partial attempt before re-entering the command sequence.
+	// All IOS commands here are idempotent; repeating them is safe.
 	mgmt_str := fmt.Sprintf(
-		"\renable\rconfig terminal\rinterface Ethernet0/0\rip address %s %s\rno ipv6 address\ripv6 address %s/%d\rexit\rip route vrf clab-mgmt 0.0.0.0 0.0.0.0 Ethernet0/0 %s\ripv6 route vrf clab-mgmt ::/0 Ethernet0/0 %s\rend\rwr\r",
+		"\rend\renable\rconfig terminal\rinterface Ethernet0/0\rip address %s %s\rno ipv6 address\ripv6 address %s/%d\rexit\rip route vrf clab-mgmt 0.0.0.0 0.0.0.0 Ethernet0/0 %s\ripv6 route vrf clab-mgmt ::/0 Ethernet0/0 %s\rend\rwr\r",
 		n.Cfg.MgmtIPv4Address,
 		clabutils.CIDRToDDN(n.Cfg.MgmtIPv4PrefixLength),
 		n.Cfg.MgmtIPv6Address,
@@ -448,8 +459,20 @@ func (n *iol) UpdateMgmtIntf(ctx context.Context) error {
 		n.Cfg.MgmtIPv4Gateway,
 		n.Cfg.MgmtIPv6Gateway,
 	)
+	data := []byte(mgmt_str)
 
-	return n.Runtime.WriteToStdinNoWait(ctx, n.Cfg.ContainerID, []byte(mgmt_str))
+	var lastErr error
+	for i := range 3 {
+		if i > 0 {
+			time.Sleep(10 * time.Second)
+		}
+		lastErr = n.Runtime.WriteToStdinNoWait(ctx, n.Cfg.ContainerID, data)
+		if lastErr != nil {
+			log.Warnf("UpdateMgmtIntf: attempt %d/3 failed for %s: %v",
+				i+1, n.Cfg.ShortName, lastErr)
+		}
+	}
+	return lastErr
 }
 
 // SaveConfig is used for "clab save" functionality -- it saves the running config to the startup

--- a/tests/10-basic-cisco_iol/01-iol.robot
+++ b/tests/10-basic-cisco_iol/01-iol.robot
@@ -119,12 +119,8 @@ Verify connectivity via new management addresses on router1
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-router1 "sh run interface Ethernet0/0"
-    Log    ${output}
-    Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    ${ipv4_addr.upper()}
-    Should Contain    ${output}    ${ipv6_addr.upper()}
+    Wait Until Keyword Succeeds    3 min    15 sec
+    ...    Verify IOL SSH Mgmt Addrs    clab-${lab-name}-router1    ${ipv4_addr}    ${ipv6_addr}
 
 Verify connectivity via new management addresses on switch
     ${rc}    ${ipv4_addr} =    Run And Return Rc And Output
@@ -137,14 +133,19 @@ Verify connectivity via new management addresses on switch
     Should Be Equal As Integers    ${rc}    0
     Log    \n--> LOG: IPv6 addr - ${ipv6_addr}    console=True
 
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@clab-${lab-name}-switch "sh run interface Ethernet0/0"
-    Log    ${output}
-    Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    ${ipv4_addr.upper()}
-    Should Contain    ${output}    ${ipv6_addr.upper()}
+    Wait Until Keyword Succeeds    3 min    15 sec
+    ...    Verify IOL SSH Mgmt Addrs    clab-${lab-name}-switch    ${ipv4_addr}    ${ipv6_addr}
 
 
 *** Keywords ***
 Cleanup
     Run    ${CLAB_BIN} --runtime ${runtime} destroy -t ${CURDIR}/${lab-file-name} --cleanup
+
+Verify IOL SSH Mgmt Addrs
+    [Arguments]    ${host}    ${ipv4_addr}    ${ipv6_addr}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    sshpass -p "admin" ssh -o "IdentitiesOnly=yes" admin@${host} "sh run interface Ethernet0/0"
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    ${ipv4_addr.upper()}
+    Should Contain    ${output}    ${ipv6_addr.upper()}


### PR DESCRIPTION
## Problem

`UpdateMgmtIntf` fires console commands via `WriteToStdinNoWait` to reconfigure the management IP when a node is re-deployed with a non-empty NVRAM (`firstBoot=false`). The previous implementation used a **fixed 10s sleep**, which is too short: IOL has a 5s startup countdown plus variable NVRAM loading time (~10-20s depending on config size and system load). Commands injected during NVRAM loading are **consumed mid-boot and silently lost**, leaving the management interface unconfigured and SSH unreachable.

This has caused **13+ CI failures** in the `cisco_iol-tests / cisco_iol-tests (01*.robot)` job, always at the same step:
```
Verify connectivity via new management addresses on router1 | FAIL |
255 != 0
```
Exit code 255 means SSH timed out (no response) — not a wrong password or wrong IP, but IOL simply not accepting SSH at all on the re-deployed node.

## Fix

### `nodes/iol/iol.go`
- Move the timing delay out of `PostDeploy` and into `UpdateMgmtIntf`
- **Increase initial wait from 10s to 25s** — past the NVRAM loading window even on loaded CI runners
- **Retry 3× with 10s gaps** — belt-and-suspenders against variable boot times
- **Prefix each attempt with `\rend\r`** — exits any lingering IOS config mode left by a previous partial write before re-entering the command sequence; all commands are idempotent so repeating is safe

### `tests/10-basic-cisco_iol/01-iol.robot`  
- Extract the SSH probe into a `Verify IOL SSH Mgmt Addrs` keyword
- Wrap both `Verify connectivity via new management addresses` cases with `Wait Until Keyword Succeeds    3 min    15 sec` as a defensive safety net independent of the code path

## Timing after the fix

```
T+0s  : containers start
T+25s : attempt 1 (IOS past NVRAM loading, at interactive console prompt)
T+35s : attempt 2
T+45s : attempt 3
T+45s : PostDeploy returns → deploy command returns
T+105s: test checks SSH (T+45 + 60s sleep) — IOL SSH-ready at ~T+56s
```

The accepted trade-off: re-deploy PostDeploy increases from 10s → 45s (all IOL nodes run in parallel so wall-clock impact is 35s per re-deploy).