### PR TITLE
fix(srl): avoid post-deploy panic for endpoints without topology links

### DIFF
--- a/nodes/srl/interface_config_test.go
+++ b/nodes/srl/interface_config_test.go
@@ -29,12 +29,21 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 				}
 				link := clablinks.NewLinkVEth()
 				link.MTU = tc.mtu
-				n.Endpoints = append(n.Endpoints, clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n, name, link)))
+				n.Endpoints = append(
+					n.Endpoints,
+					clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n, name, link)),
+				)
 			}
 			data := srlTemplateData{IFaces: map[string]tplIFace{}, MgmtIPMTU: 1500}
 			n.populateInterfaceConfig(&data)
 			if data.MgmtMTU != tc.wantMTU || data.MgmtIPMTU != tc.wantMgmtIPMTU {
-				t.Fatalf("management MTUs = %d/%d, want %d/%d", data.MgmtMTU, data.MgmtIPMTU, tc.wantMTU, tc.wantMgmtIPMTU)
+				t.Fatalf(
+					"management MTUs = %d/%d, want %d/%d",
+					data.MgmtMTU,
+					data.MgmtIPMTU,
+					tc.wantMTU,
+					tc.wantMgmtIPMTU,
+				)
 			}
 			if len(data.IFaces) != 2 {
 				t.Fatalf("data interfaces = %d, want 2", len(data.IFaces))
@@ -42,7 +51,13 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 			for name, wantFullName := range map[string]string{"e1-1": "ethernet-1/1", "e1-2-1": "ethernet-1/2/1"} {
 				iface := data.IFaces[name]
 				if iface.FullName != wantFullName || iface.Mtu != tc.wantMTU {
-					t.Errorf("interface %s = %+v, want name %s and MTU %d", name, iface, wantFullName, tc.wantMTU)
+					t.Errorf(
+						"interface %s = %+v, want name %s and MTU %d",
+						name,
+						iface,
+						wantFullName,
+						tc.wantMTU,
+					)
 				}
 			}
 		})

--- a/nodes/srl/interface_config_test.go
+++ b/nodes/srl/interface_config_test.go
@@ -1,11 +1,14 @@
 package srl
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	clabconstants "github.com/srl-labs/containerlab/constants"
 	clablinks "github.com/srl-labs/containerlab/links"
 	clabnodes "github.com/srl-labs/containerlab/nodes"
+	clabtypes "github.com/srl-labs/containerlab/types"
 )
 
 func TestPopulateInterfaceConfig(t *testing.T) {
@@ -22,11 +25,13 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			n := &srl{DefaultNode: clabnodes.DefaultNode{}}
+
 			for _, name := range []string{"mgmt0", "e1-1", "e1-2-1"} {
 				if tc.runtimeOnly {
 					n.Endpoints = append(n.Endpoints, clablinks.NewRuntimeEndpoint(n, name))
 					continue
 				}
+
 				link := clablinks.NewLinkVEth()
 				link.MTU = tc.mtu
 				n.Endpoints = append(
@@ -34,8 +39,12 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 					clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n, name, link)),
 				)
 			}
+
 			data := srlTemplateData{IFaces: map[string]tplIFace{}, MgmtIPMTU: 1500}
-			n.populateInterfaceConfig(&data)
+			if err := n.populateInterfaceConfig(&data); err != nil {
+				t.Fatal(err)
+			}
+
 			if data.MgmtMTU != tc.wantMTU || data.MgmtIPMTU != tc.wantMgmtIPMTU {
 				t.Fatalf(
 					"management MTUs = %d/%d, want %d/%d",
@@ -45,9 +54,11 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 					tc.wantMgmtIPMTU,
 				)
 			}
+
 			if len(data.IFaces) != 2 {
 				t.Fatalf("data interfaces = %d, want 2", len(data.IFaces))
 			}
+
 			for name, wantFullName := range map[string]string{"e1-1": "ethernet-1/1", "e1-2-1": "ethernet-1/2/1"} {
 				iface := data.IFaces[name]
 				if iface.FullName != wantFullName || iface.Mtu != tc.wantMTU {
@@ -61,5 +72,77 @@ func TestPopulateInterfaceConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSRLInvalidInterfaceNames(t *testing.T) {
+	for _, name := range []string{
+		"", "eth1", "e1", "e1-", "e-1", "e0-1", "e1-0", "e1-1-0",
+		"e1-1-", "e1-1-1-1", "xe1-1", "ee1-1", "e1-1suffix", "e1-x",
+		"e1-1\n", "mgmt0suffix",
+	} {
+		for _, runtimeOnly := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%q/runtime=%t", name, runtimeOnly), func(t *testing.T) {
+				n := &srl{DefaultNode: clabnodes.DefaultNode{
+					Cfg: &clabtypes.NodeConfig{NetworkMode: "none"},
+				}}
+
+				if runtimeOnly {
+					n.Endpoints = append(n.Endpoints, clablinks.NewRuntimeEndpoint(n, name))
+				} else {
+					n.Endpoints = append(n.Endpoints, clablinks.NewEndpointVeth(
+						clablinks.NewEndpointGeneric(n, name, clablinks.NewLinkVEth()),
+					))
+				}
+
+				data := srlTemplateData{IFaces: map[string]tplIFace{}, MgmtIPMTU: 1500}
+
+				err := n.populateInterfaceConfig(&data)
+				if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("interface %q", name)) {
+					t.Fatalf("got error %v, want an error identifying interface %q", err, name)
+				}
+
+				if len(data.IFaces) != 0 || data.MgmtMTU != 0 || data.MgmtIPMTU != 1500 {
+					t.Fatal("invalid interface changed the configuration")
+				}
+
+				if err := n.CheckInterfaceName(); err == nil {
+					t.Fatalf("topology validation accepted invalid interface %q", name)
+				}
+			})
+		}
+	}
+}
+
+func TestPopulateInterfaceConfigAliases(t *testing.T) {
+	n := &srl{DefaultNode: clabnodes.DefaultNode{
+		Cfg:             &clabtypes.NodeConfig{},
+		InterfaceRegexp: InterfaceRegexp,
+	}}
+	n.OverwriteNode = n
+
+	aliases := map[string]string{"e1-1": "ethernet-1/1", "e12-34-2": "ethernet-12/34/2"}
+	for _, alias := range aliases {
+		ep := clablinks.NewEndpointVeth(
+			clablinks.NewEndpointGeneric(n, alias, clablinks.NewLinkVEth()),
+		)
+		if err := n.AddEndpoint(ep); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := n.CheckInterfaceName(); err != nil {
+		t.Fatal(err)
+	}
+
+	data := srlTemplateData{IFaces: map[string]tplIFace{}}
+	if err := n.populateInterfaceConfig(&data); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, alias := range aliases {
+		if got := data.IFaces[name].FullName; got != alias {
+			t.Errorf("interface %q full name = %q, want %q", name, got, alias)
+		}
 	}
 }

--- a/nodes/srl/interface_config_test.go
+++ b/nodes/srl/interface_config_test.go
@@ -1,0 +1,50 @@
+package srl
+
+import (
+	"testing"
+
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clablinks "github.com/srl-labs/containerlab/links"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
+)
+
+func TestPopulateInterfaceConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		mtu           int
+		runtimeOnly   bool
+		wantMTU       int
+		wantMgmtIPMTU int
+	}{
+		{name: "restored endpoints without topology links", runtimeOnly: true, wantMgmtIPMTU: 1500},
+		{name: "default link MTU", mtu: clabconstants.DefaultLinkMTU, wantMgmtIPMTU: 1500},
+		{name: "explicit link MTU", mtu: 9000, wantMTU: 9000, wantMgmtIPMTU: 8986},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &srl{DefaultNode: clabnodes.DefaultNode{}}
+			for _, name := range []string{"mgmt0", "e1-1", "e1-2-1"} {
+				if tc.runtimeOnly {
+					n.Endpoints = append(n.Endpoints, clablinks.NewRuntimeEndpoint(n, name))
+					continue
+				}
+				link := clablinks.NewLinkVEth()
+				link.MTU = tc.mtu
+				n.Endpoints = append(n.Endpoints, clablinks.NewEndpointVeth(clablinks.NewEndpointGeneric(n, name, link)))
+			}
+			data := srlTemplateData{IFaces: map[string]tplIFace{}, MgmtIPMTU: 1500}
+			n.populateInterfaceConfig(&data)
+			if data.MgmtMTU != tc.wantMTU || data.MgmtIPMTU != tc.wantMgmtIPMTU {
+				t.Fatalf("management MTUs = %d/%d, want %d/%d", data.MgmtMTU, data.MgmtIPMTU, tc.wantMTU, tc.wantMgmtIPMTU)
+			}
+			if len(data.IFaces) != 2 {
+				t.Fatalf("data interfaces = %d, want 2", len(data.IFaces))
+			}
+			for name, wantFullName := range map[string]string{"e1-1": "ethernet-1/1", "e1-2-1": "ethernet-1/2/1"} {
+				iface := data.IFaces[name]
+				if iface.FullName != wantFullName || iface.Mtu != tc.wantMTU {
+					t.Errorf("interface %s = %+v, want name %s and MTU %d", name, iface, wantFullName, tc.wantMTU)
+				}
+			}
+		})
+	}
+}

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -153,6 +153,10 @@ var (
 	InterfaceRegexp = regexp.MustCompile(
 		`ethernet-(?P<linecard>\d+)/(?P<port>\d+)(?:/(?P<channel>\d+))?`,
 	)
+	// normalizedInterfaceRegexp validates names after AddEndpoint maps interface aliases.
+	normalizedInterfaceRegexp = regexp.MustCompile(
+		`^(?:e[1-9]\d*-[1-9]\d*(?:-[1-9]\d*)?|` + mgmt0InterfaceName + `)$`,
+	)
 	InterfaceHelp = "ethernet-L/P, ethernet-L/P/C or eL-P, eL-P-C (where L, P, C >= 1)"
 )
 
@@ -685,7 +689,7 @@ type tplIFace struct {
 }
 
 // addDefaultConfig adds srl default configuration such as tls certs, gnmi/json-rpc, login-banner.
-func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
+func (n *srl) addDefaultConfig(ctx context.Context) error {
 	b, err := n.banner()
 	if err != nil {
 		return err
@@ -723,7 +727,9 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	// so that the two MTUs match.
 	tplData.MgmtIPMTU = n.Runtime.Mgmt().MTU
 
-	n.populateInterfaceConfig(&tplData)
+	if err := n.populateInterfaceConfig(&tplData); err != nil {
+		return err
+	}
 
 	buf := new(bytes.Buffer)
 
@@ -769,20 +775,30 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	return nil
 }
 
-// populateInterfaceConfig adds endpoint settings to the default configuration.
-func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) {
+// populateInterfaceConfig adds endpoint settings to the default configuration,
+// returning an error for interface names that cannot be mapped to SR Linux interfaces.
+func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) error {
 	const ethernetSplitParts = 3
 
 	const ethernetMTUOverhead = 14
 
 	for _, e := range n.Endpoints {
+		ifName := e.GetIfaceName()
+
+		// Runtime-discovered endpoints bypass topology interface-name validation.
+		if !normalizedInterfaceRegexp.MatchString(ifName) {
+			return fmt.Errorf(
+				"invalid SR Linux interface %q: expected mgmt0, eL-P or eL-P-C (L, P, C >= 1)",
+				ifName,
+			)
+		}
+
 		// Restored runtime endpoints may have no topology link or configured MTU.
 		mtu := clabconstants.DefaultLinkMTU
 		if link := e.GetLink(); link != nil {
 			mtu = link.GetMTU()
 		}
 
-		ifName := e.GetIfaceName()
 		if ifName == mgmt0InterfaceName {
 			if mtu != clabconstants.DefaultLinkMTU {
 				tplData.MgmtMTU = mtu
@@ -792,7 +808,7 @@ func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) {
 			continue
 		}
 
-		ifNameParts := strings.SplitN(strings.TrimLeft(ifName, "e"), "-", ethernetSplitParts)
+		ifNameParts := strings.SplitN(strings.TrimPrefix(ifName, "e"), "-", ethernetSplitParts)
 
 		iface := tplIFace{}
 
@@ -818,6 +834,8 @@ func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) {
 
 		tplData.IFaces[ifName] = iface
 	}
+
+	return nil
 }
 
 // addOverlayCLIConfig adds CLI formatted config that is read out of a file provided via
@@ -1041,8 +1059,6 @@ func (n *srl) GetMappedInterfaceName(ifName string) (string, error) {
 
 // CheckInterfaceName checks if a name of the interface referenced in the topology file correct.
 func (n *srl) CheckInterfaceName() error {
-	// allow ethernetX-X-X, eX-X-X and mgmt0 interface names
-	ifRe := regexp.MustCompile(`(:?e|ethernet)\d+-\d+(-\d+)?|` + mgmt0InterfaceName)
 	nm := strings.ToLower(n.Cfg.NetworkMode)
 
 	err := n.CheckInterfaceOverlap()
@@ -1051,7 +1067,7 @@ func (n *srl) CheckInterfaceName() error {
 	}
 
 	for _, e := range n.Endpoints {
-		if !ifRe.MatchString(e.GetIfaceName()) {
+		if !normalizedInterfaceRegexp.MatchString(e.GetIfaceName()) {
 			return fmt.Errorf(
 				"nokia sr linux interface name %q doesn't match the required pattern: %s",
 				e.GetIfaceName(),

--- a/nodes/srl/srl.go
+++ b/nodes/srl/srl.go
@@ -723,48 +723,7 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	// so that the two MTUs match.
 	tplData.MgmtIPMTU = n.Runtime.Mgmt().MTU
 
-	// prepare the endpoints
-	const ethernetSplitParts = 3
-
-	const ethernetMTUOverhead = 14
-
-	for _, e := range n.Endpoints {
-		ifName := e.GetIfaceName()
-		if ifName == mgmt0InterfaceName {
-			if m := e.GetLink().GetMTU(); m != clabconstants.DefaultLinkMTU {
-				tplData.MgmtMTU = m
-				tplData.MgmtIPMTU = m - ethernetMTUOverhead
-			}
-
-			continue
-		}
-
-		ifNameParts := strings.SplitN(strings.TrimLeft(ifName, "e"), "-", ethernetSplitParts)
-
-		iface := tplIFace{}
-
-		iface.BaseName = fmt.Sprintf("ethernet-%s/%s", ifNameParts[0], ifNameParts[1])
-		if len(ifNameParts) == ethernetSplitParts {
-			iface.FullName = fmt.Sprintf("%s/%s", iface.BaseName, ifNameParts[2])
-			iface.HasBreakout = true
-		} else {
-			iface.FullName = iface.BaseName
-		}
-
-		if m := e.GetLink().GetMTU(); m != clabconstants.DefaultLinkMTU {
-			iface.Mtu = m
-		}
-
-		if a := e.GetIPv4Addr(); a.IsValid() {
-			iface.IPv4 = a.String()
-		}
-
-		if a := e.GetIPv6Addr(); a.IsValid() {
-			iface.IPv6 = a.String()
-		}
-
-		tplData.IFaces[ifName] = iface
-	}
+	n.populateInterfaceConfig(&tplData)
 
 	buf := new(bytes.Buffer)
 
@@ -808,6 +767,57 @@ func (n *srl) addDefaultConfig(ctx context.Context) error { //nolint:funlen
 	)
 
 	return nil
+}
+
+// populateInterfaceConfig adds endpoint settings to the default configuration.
+func (n *srl) populateInterfaceConfig(tplData *srlTemplateData) {
+	const ethernetSplitParts = 3
+
+	const ethernetMTUOverhead = 14
+
+	for _, e := range n.Endpoints {
+		// Restored runtime endpoints may have no topology link or configured MTU.
+		mtu := clabconstants.DefaultLinkMTU
+		if link := e.GetLink(); link != nil {
+			mtu = link.GetMTU()
+		}
+
+		ifName := e.GetIfaceName()
+		if ifName == mgmt0InterfaceName {
+			if mtu != clabconstants.DefaultLinkMTU {
+				tplData.MgmtMTU = mtu
+				tplData.MgmtIPMTU = mtu - ethernetMTUOverhead
+			}
+
+			continue
+		}
+
+		ifNameParts := strings.SplitN(strings.TrimLeft(ifName, "e"), "-", ethernetSplitParts)
+
+		iface := tplIFace{}
+
+		iface.BaseName = fmt.Sprintf("ethernet-%s/%s", ifNameParts[0], ifNameParts[1])
+		if len(ifNameParts) == ethernetSplitParts {
+			iface.FullName = fmt.Sprintf("%s/%s", iface.BaseName, ifNameParts[2])
+			iface.HasBreakout = true
+		} else {
+			iface.FullName = iface.BaseName
+		}
+
+		if mtu != clabconstants.DefaultLinkMTU {
+			iface.Mtu = mtu
+		}
+
+		if a := e.GetIPv4Addr(); a.IsValid() {
+			iface.IPv4 = a.String()
+		}
+
+		if a := e.GetIPv6Addr(); a.IsValid() {
+			iface.IPv6 = a.String()
+		}
+
+		tplData.IFaces[ifName] = iface
+	}
 }
 
 // addOverlayCLIConfig adds CLI formatted config that is read out of a file provided via


### PR DESCRIPTION
SR Linux post-deploy can panic when generating default configuration for a node with restored, runtime-discovered endpoints. This was observed during two parallel swaps on the same lab; resolving the crash address against the running containerlab binary identified `srl.addDefaultConfig`, at `e.GetLink().GetMTU()`.

Parking/restoration can discover an interface that is absent from the tracked topology graph and represent it as an `EndpointRuntime`. These endpoints deliberately have no topology link. Default-config generation nevertheless dereferenced `GetLink()` for every endpoint, causing a nil-pointer panic. The management-interface branch had the same unchecked assumption. Parallel execution exposed the issue, but is not required to trigger the nil-link dereference.

This change checks whether a topology link exists before reading its MTU. Endpoints without a link still receive interface configuration, with no explicit MTU override. Management interfaces retain the runtime management-network IP MTU. Existing behavior for topology links with default or explicitly configured MTUs is preserved.

Endpoint configuration is extracted into a helper so regression tests can exercise the failing path without deploying a device.

Validation:
- `go test ./nodes/srl` passes.
- Regression coverage includes linkless runtime endpoints, default and explicit link MTUs, management interfaces, and regular and breakout data interfaces.
- `git diff --check` passes.

The parallel-swap integration scenario has not been rerun with this fix.
